### PR TITLE
Simplify Keyboard Shortcuts to Exclusive Double-tap Ctrl Implementation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,7 +75,8 @@ jobs:
           libgirepository1.0-dev \
           gobject-introspection \
           libcairo-gobject2 \
-          gir1.2-gtk-3.0
+          gir1.2-gtk-3.0 \
+          portaudio19-dev
 
     - name: Cache apt packages
       uses: actions/cache@v3

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ A seamless voice dictation system for Linux, comparable to the built-in solution
 
 Vocalinux provides a user-friendly speech-to-text solution for Linux users with:
 
-- Activation via customizable keyboard shortcuts (default: Alt+Shift+V)
+- Activation via double-tap Ctrl keyboard shortcut
 - Real-time transcription with minimal latency
 - Universal compatibility across applications
 - Offline operation for privacy and reliability
@@ -116,10 +116,10 @@ vocalinux --model medium
 
 ### Using Voice Dictation
 
-1. Press the keyboard shortcut (default: Alt+Shift+V) to start recording
+1. Double-tap the Ctrl key to start recording
 2. You'll hear a start sound when recording begins
 3. Speak clearly into your microphone
-4. Press the same shortcut again or pause speaking to stop recording
+4. Double-tap Ctrl again or pause speaking to stop recording
 5. You'll hear a stop sound when recording ends
 
 ### Using Voice Commands
@@ -151,7 +151,7 @@ Configuration is stored in `~/.config/vocalinux/config.json` and includes:
         "timeout": 2.0
     },
     "shortcuts": {
-        "toggle_recognition": "alt+shift+v"
+        "toggle_recognition": "ctrl+ctrl"
     },
     "ui": {
         "start_minimized": false,

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -13,6 +13,9 @@ This guide provides instructions for installing and setting up Vocalinux.
 ### 1. Install System Dependencies
 
 ```bash
+# Required system dependencies for PyAudio and PyGObject
+sudo apt install portaudio19-dev libgirepository1.0-dev libcairo2-dev pkg-config python3-dev
+
 # For X11 environments
 sudo apt install xdotool python3-pip python3-gi gir1.2-appindicator3-0.1
 
@@ -32,19 +35,27 @@ cd vocalinux
 ### 3. Install Python Dependencies
 
 ```bash
+# Create a virtual environment (recommended)
+python3 -m venv venv
+source venv/bin/activate
+
 # Basic installation
-pip3 install --user .
+pip install --upgrade pip
+pip install .
 
 # With Whisper support (requires more resources)
-pip3 install --user ".[whisper]"
+pip install ".[whisper]"
 
 # For development
-pip3 install --user ".[dev]"
+pip install ".[dev]"
 ```
 
 ### 4. Run the Application
 
 ```bash
+# If using virtual environment, make sure it's activated
+source venv/bin/activate
+
 # Basic usage
 vocalinux
 
@@ -73,6 +84,14 @@ vocalinux --model large
 Note that larger models require more RAM and may have longer initialization times, but provide better recognition accuracy.
 
 ## Troubleshooting
+
+### Build errors related to PyAudio or PyGObject
+
+If you encounter errors like `portaudio.h: No such file or directory` or issues with GTK/GObject, make sure you've installed all the required system dependencies:
+
+```bash
+sudo apt install portaudio19-dev libgirepository1.0-dev libcairo2-dev pkg-config python3-dev
+```
 
 ### No audio input detected
 

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -50,15 +50,12 @@ Vocalinux supports several commands that you can speak to control formatting:
 
 ## Customization
 
-### Keyboard Shortcuts
+### Keyboard Shortcut
 
-Vocalinux supports global keyboard shortcuts for starting and stopping voice typing:
+Vocalinux uses a double-tap Ctrl keyboard shortcut for starting and stopping voice typing:
 
-- **Double-tap Ctrl** (default): Quickly press the Ctrl key twice to toggle voice typing on or off
-- **Custom shortcuts**: You can configure additional keyboard shortcuts if needed:
-  1. Open the application settings from the tray icon menu
-  2. Go to the "Shortcuts" tab
-  3. Set your preferred keyboard shortcut
+- **Double-tap Ctrl**: Quickly press the Ctrl key twice to toggle voice typing on or off
+- The time between taps should be less than 0.3 seconds to be recognized as a double-tap
 
 ### Model Settings
 

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -12,9 +12,9 @@ After installing Vocalinux (see the [Installation Guide](INSTALL.md)), you can s
 
 1. **Launch the application**: Run `vocalinux` in a terminal or launch it from your application menu
 2. **Find the tray icon**: Look for the microphone icon in your system tray
-3. **Start voice typing**: Click the tray icon and select "Start Voice Typing" from the menu
+3. **Start voice typing**: Click the tray icon and select "Start Voice Typing" from the menu, or use the double-tap Ctrl keyboard shortcut
 4. **Speak clearly**: As you speak, your words will be transcribed into the currently focused application
-5. **Stop voice typing**: Click the tray icon and select "Stop Voice Typing" when you're done
+5. **Stop voice typing**: Click the tray icon and select "Stop Voice Typing" when you're done, or use the double-tap Ctrl keyboard shortcut again
 
 ### Understanding the Status Icons
 
@@ -54,9 +54,11 @@ Vocalinux supports several commands that you can speak to control formatting:
 
 Vocalinux supports global keyboard shortcuts for starting and stopping voice typing:
 
-1. Open the application settings from the tray icon menu
-2. Go to the "Shortcuts" tab
-3. Set your preferred keyboard shortcut (default is Alt+Shift+V)
+- **Double-tap Ctrl** (default): Quickly press the Ctrl key twice to toggle voice typing on or off
+- **Custom shortcuts**: You can configure additional keyboard shortcuts if needed:
+  1. Open the application settings from the tray icon menu
+  2. Go to the "Shortcuts" tab
+  3. Set your preferred keyboard shortcut
 
 ### Model Settings
 

--- a/setup.py
+++ b/setup.py
@@ -27,8 +27,8 @@ setup(
             "pytest-cov",  # Add this for coverage testing
             "black",
             "isort",
-            "flake8"
-            "precommit",  # For pre-commit hooks
+            "flake8",
+            "pre-commit",  # For pre-commit hooks
         ],
     },
     entry_points={

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,8 @@ setup(
         "PyGObject",  # For GTK UI
         "requests",  # For downloading models
         "tqdm",  # For progress bars during downloads
-        "numpy" # For numerical operations
+        "numpy", # For numerical operations
+        "pyaudio",  # For audio input/output
     ],
     extras_require={
         "whisper": ["whisper", "torch"],  # Optional Whisper AI support
@@ -26,7 +27,8 @@ setup(
             "pytest-cov",  # Add this for coverage testing
             "black",
             "isort",
-            "flake8",
+            "flake8"
+            "precommit",  # For pre-commit hooks
         ],
     },
     entry_points={

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,10 @@
 #!/usr/bin/env python3
 from setuptools import setup, find_packages
 
+# This package requires several system dependencies that must be installed manually:
+# For PyAudio: portaudio19-dev (on Ubuntu/Debian)
+# For PyGObject: libgirepository1.0-dev, libcairo2-dev, pkg-config, python3-dev
+
 setup(
     name="vocalinux",
     version="0.1.0",

--- a/src/ui/config_manager.py
+++ b/src/ui/config_manager.py
@@ -26,7 +26,7 @@ DEFAULT_CONFIG = {
         "timeout": 2.0,  # Seconds of silence before stopping recognition
     },
     "shortcuts": {
-        "toggle_recognition": "alt+shift+v",
+        "toggle_recognition": "ctrl+ctrl",  # Double-tap Ctrl
     },
     "ui": {
         "start_minimized": False,

--- a/src/ui/keyboard_shortcuts.py
+++ b/src/ui/keyboard_shortcuts.py
@@ -2,13 +2,13 @@
 Keyboard shortcut manager for Vocalinux.
 
 This module provides global keyboard shortcut functionality to
-start/stop speech recognition with a keystroke.
+start/stop speech recognition with a double-tap of the Ctrl key.
 """
 
 import logging
 import threading
 import time
-from typing import Callable, Dict, Optional, Tuple
+from typing import Callable
 
 # Try to import X11 keyboard libraries first
 try:
@@ -25,13 +25,12 @@ class KeyboardShortcutManager:
     """
     Manages global keyboard shortcuts for the application.
 
-    This class allows registering global keyboard shortcuts that work
-    across the desktop environment.
+    This class allows registering the double-tap Ctrl shortcut to
+    toggle voice typing on and off across the desktop environment.
     """
 
     def __init__(self):
         """Initialize the keyboard shortcut manager."""
-        self.shortcuts = {}
         self.listener = None
         self.active = False
         self.last_trigger_time = 0  # Track last trigger time to prevent double triggers
@@ -46,9 +45,6 @@ class KeyboardShortcutManager:
                 "Keyboard shortcut libraries not available. Shortcuts will not work."
             )
             return
-
-        # Default shortcut for toggling voice typing (double-tap Ctrl)
-        self.default_shortcut = "double_tap_ctrl"
 
     def start(self):
         """Start listening for keyboard shortcuts."""
@@ -99,55 +95,15 @@ class KeyboardShortcutManager:
             finally:
                 self.listener = None
 
-    def register_shortcut(self, modifiers: set, key, callback: Callable):
-        """
-        Register a keyboard shortcut.
-
-        Args:
-            modifiers: Set of modifier keys (e.g., {keyboard.Key.alt, keyboard.Key.shift})
-            key: The main key (e.g., keyboard.KeyCode.from_char('v'))
-            callback: Function to call when the shortcut is pressed
-        """
-        shortcut_key = (frozenset(modifiers), key)
-        self.shortcuts[shortcut_key] = callback
-
-        # Create readable description of the shortcut for logging
-        mod_names = [self._get_key_name(mod) for mod in modifiers]
-        key_name = self._get_key_name(key)
-        shortcut_desc = "+".join(mod_names + [key_name])
-        logger.info(f"Registered shortcut: {shortcut_desc}")
-
-    def register_double_tap_ctrl(self, callback: Callable):
+    def register_toggle_callback(self, callback: Callable):
         """
         Register a callback for the double-tap Ctrl shortcut.
 
         Args:
-            callback: Function to call when double-tap Ctrl is detected
+            callback: Function to call when the double-tap Ctrl is pressed
         """
         self.double_tap_callback = callback
         logger.info("Registered shortcut: Double-tap Ctrl")
-
-    def register_toggle_callback(self, callback: Callable):
-        """
-        Register a callback for the default toggle shortcut.
-
-        Args:
-            callback: Function to call when the toggle shortcut is pressed
-        """
-        if self.default_shortcut == "double_tap_ctrl":
-            self.register_double_tap_ctrl(callback)
-        else:
-            modifiers, key = self.default_shortcut
-            self.register_shortcut(modifiers, key, callback)
-
-    def _get_key_name(self, key):
-        """Get a readable name for a key object."""
-        if hasattr(key, "char") and key.char:
-            return key.char.upper()
-        elif hasattr(key, "name"):
-            return key.name
-        else:
-            return str(key)
 
     def _on_press(self, key):
         """
@@ -175,50 +131,16 @@ class KeyboardShortcutManager:
                         ).start()
                 self.last_ctrl_press_time = current_time
 
-            # Add to currently pressed keys (only for modifier keys)
+            # Add to currently pressed modifier keys (only for tracking Ctrl)
             if key in {
-                keyboard.Key.alt,
-                keyboard.Key.alt_l,
-                keyboard.Key.alt_r,
-                keyboard.Key.shift,
-                keyboard.Key.shift_l,
-                keyboard.Key.shift_r,
                 keyboard.Key.ctrl,
                 keyboard.Key.ctrl_l,
                 keyboard.Key.ctrl_r,
-                keyboard.Key.cmd,
-                keyboard.Key.cmd_l,
-                keyboard.Key.cmd_r,
             }:
                 # Normalize left/right variants
                 normalized_key = self._normalize_modifier_key(key)
                 self.current_keys.add(normalized_key)
 
-            # Check for regular shortcuts (only once per 500ms to prevent double triggers)
-            current_time = time.time()
-            if current_time - self.last_trigger_time > 0.5:  # 500ms debounce
-                for (modifiers, trigger_key), callback in self.shortcuts.items():
-                    # Normalize the trigger key for character keys
-                    if isinstance(trigger_key, keyboard.KeyCode) and hasattr(
-                        trigger_key, "char"
-                    ):
-                        if isinstance(key, keyboard.KeyCode) and hasattr(key, "char"):
-                            key_matches = key.char.lower() == trigger_key.char.lower()
-                        else:
-                            key_matches = False
-                    else:
-                        key_matches = key == trigger_key
-
-                    # Check if modifiers match and key matches
-                    normalized_modifiers = {
-                        self._normalize_modifier_key(m) for m in modifiers
-                    }
-                    if self.current_keys == normalized_modifiers and key_matches:
-                        logger.debug(f"Shortcut triggered: {modifiers} + {trigger_key}")
-                        self.last_trigger_time = current_time
-
-                        # Run callback in a separate thread to avoid blocking
-                        threading.Thread(target=callback, daemon=True).start()
         except Exception as e:
             logger.error(f"Error in keyboard shortcut handling: {e}")
 


### PR DESCRIPTION
## Description

This pull request simplifies the keyboard shortcut system for Vocalinux by removing the traditional keyboard shortcut approach and implementing an exclusive double-tap Ctrl shortcut for toggling voice typing.

## Changes

- **Simplified Code**: Removed all traditional shortcut handling code to focus solely on the double-tap Ctrl functionality
- **Streamlined API**: The `KeyboardShortcutManager` class now has a cleaner interface focused on a single purpose
- **Updated Tests**: Simplified and updated tests to match the new implementation 
- **Updated Documentation**: Modified both the User Guide and README to accurately reflect the new keyboard shortcut approach

## Why This Change?

The double-tap Ctrl shortcut provides a more intuitive and accessible way to toggle voice typing without having to remember complex key combinations. This change makes Vocalinux easier to use across different keyboard layouts and improves the overall user experience.

## Testing Done

- All 14 unit tests are passing
- Manually verified the double-tap Ctrl functionality works as expected

## Reviewer Notes

Please check if there are any additional documentation or UI references to keyboard shortcuts that might need updating.