### PR TITLE
fix: install.sh now works with curl | bash

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,10 +33,16 @@
 ### One-liner Installation (Recommended)
 
 \`\`\`bash
-git clone https://github.com/jatinkrmalik/vocalinux.git && cd vocalinux && ./install.sh
+curl -fsSL https://raw.githubusercontent.com/jatinkrmalik/vocalinux/main/install.sh | bash
 \`\`\`
 
-### Or step by step:
+This will:
+- Clone the repository
+- Install all dependencies
+- Set up a virtual environment in `~/.local/share/vocalinux/venv`
+- Create a symlink at `~/.local/bin/vocalinux`
+
+### Alternative: Install from Source
 
 \`\`\`bash
 # Clone the repository
@@ -52,11 +58,15 @@ The installer handles everything: system dependencies, Python environment, speec
 ### After Installation
 
 \`\`\`bash
-# Activate the virtual environment
-source activate-vocalinux.sh
-
-# Run Vocalinux
+# If ~/.local/bin is in your PATH (recommended):
 vocalinux
+
+# Or activate the virtual environment first:
+source ~/.local/bin/activate-vocalinux.sh
+vocalinux
+
+# Or run directly:
+~/.local/share/vocalinux/venv/bin/vocalinux
 \`\`\`
 
 Or launch it from your application menu!


### PR DESCRIPTION
## Summary
Fixes the install script to work when run remotely via `curl | bash`.

## Problem
When users ran:
```bash
curl -fsSL https://raw.githubusercontent.com/jatinkrmalik/vocalinux/main/install.sh | bash
```

The script failed with:
```
ERROR: Directory '.' is not installable. Neither 'setup.py' nor 'pyproject.toml' found.
```

This happened because the script assumed it was running from within the cloned repo.

## Solution
- **Auto-detect remote execution**: Script checks if `setup.py` or `pyproject.toml` exists
- **Clone repo if needed**: Clones to `~/.local/share/vocalinux-install`
- **User-friendly venv location**: Installs venv to `~/.local/share/vocalinux/venv`
- **Easy access symlink**: Creates `~/.local/bin/vocalinux` for direct execution
- **Activation script**: Creates `~/.local/bin/activate-vocalinux.sh`

## Updated README
- New recommended installation: `curl ... | bash`
- Alternative: clone and run manually
- Updated after-installation instructions

## Testing
After merging, users can install with:
```bash
curl -fsSL https://raw.githubusercontent.com/jatinkrmalik/vocalinux/main/install.sh | bash
```