### PR TITLE
feat: Enable automated PyPI publishing on release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,7 @@ on:
 permissions:
   contents: write
   packages: write
+  id-token: write  # Required for PyPI trusted publishing
 
 env:
   PYTHON_VERSION: '3.10'
@@ -91,19 +92,41 @@ jobs:
             ---
             See [CHANGELOG](https://github.com/jatinkrmalik/vocalinux/releases) for detailed changes.
 
-  # Optional: publish to PyPI when ready
-  # publish-pypi:
-  #   name: Publish to PyPI
-  #   needs: build-and-release
-  #   runs-on: ubuntu-latest
-  #   if: ${{ !contains(github.ref, 'alpha') && !contains(github.ref, 'beta') }}
-  #   steps:
-  #     - uses: actions/checkout@v4
-  #     - uses: actions/setup-python@v5
-  #       with:
-  #         python-version: ${{ env.PYTHON_VERSION }}
-  #     - run: pip install build twine
-  #     - run: python -m build
-  #     - uses: pypa/gh-action-pypi-publish@release/v1
-  #       with:
-  #         password: ${{ secrets.PYPI_API_TOKEN }}
+  publish-pypi:
+    name: Publish to PyPI
+    needs: build-and-release
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/project/vocalinux/
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+          cache: 'pip'
+
+      - name: Install build dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install build twine
+
+      - name: Build package
+        run: |
+          python -m build
+          echo "Built packages:"
+          ls -la dist/
+
+      - name: Verify package
+        run: |
+          twine check dist/*
+
+      - name: Publish to PyPI
+        env:
+          TWINE_USERNAME: __token__
+          TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
+        run: |
+          twine upload dist/* --skip-existing


### PR DESCRIPTION
## Summary

This PR enables automated publishing to PyPI when a new release tag is pushed.

## Changes

### Release Workflow Updates
- Added `publish-pypi` job that runs after the GitHub release is created
- Job builds the package, verifies with `twine check`, and uploads to PyPI
- Uses `PYPI_API_TOKEN` secret for authentication (already configured in repo)
- Added `id-token: write` permission for trusted publishing support

### Package Verification ✅
Tested locally:
```
$ python -m build
Successfully built vocalinux-0.2.0a0.tar.gz and vocalinux-0.2.0a0-py3-none-any.whl

$ twine check dist/*
Checking dist/vocalinux-0.2.0a0-py3-none-any.whl: PASSED
Checking dist/vocalinux-0.2.0a0.tar.gz: PASSED
```

### Package Details
- **Name:** vocalinux
- **Version:** 0.2.0a0 (alpha)
- **Size:** ~832KB wheel, ~738KB source
- **Entry point:** `vocalinux` command

## How It Works

1. Push a tag: `git tag v0.2.1-alpha && git push origin v0.2.1-alpha`
2. `build-and-release` job creates GitHub Release with artifacts
3. `publish-pypi` job uploads to PyPI
4. Users can install with: `pip install vocalinux`

## Requirements
- [x] `PYPI_API_TOKEN` secret configured in repository

## After Merge
The next release tag will automatically publish to PyPI at:
https://pypi.org/project/vocalinux/

---

Closes #47 