### PR TITLE
fix: persist model selection per-engine when switching between VOSK and Whisper

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -670,6 +670,8 @@ install_python_package() {
     "speech_recognition": {
         "engine": "vosk",
         "model_size": "small",
+        "vosk_model_size": "small",
+        "whisper_model_size": "tiny",
         "vad_sensitivity": 3,
         "silence_timeout": 2.0
     },


### PR DESCRIPTION
## Summary
This PR fixes a bug where the app would not remember the model selection for each speech recognition engine independently. When switching from Whisper (with tiny model) to VOSK and back to Whisper, the app would incorrectly start downloading the medium model instead of remembering the tiny model that was previously configured.

## Problem
The root cause was that the config stored only a single `model_size` field for both engines. When switching engines:
1. User starts with Whisper using "tiny" model (default from install)
2. User switches to VOSK, which saves `model_size: "small"`
3. User switches back to Whisper - the saved "small" isn't a downloaded Whisper model, so the code would fall back to downloading a different model (often "medium" based on system recommendations)

## Solution
Implemented per-engine model size tracking:

### Config Manager Changes
- Added `vosk_model_size` and `whisper_model_size` fields to store model selection independently
- Added `get_model_size_for_engine(engine)` method to retrieve the saved model for a specific engine
- Added `set_model_size_for_engine(engine, model_size)` method to save per-engine model sizes
- Added automatic migration for existing configs without the new fields
- Fixed shallow copy issue that could cause test state pollution

### Settings Dialog Changes
- Updated `_get_current_settings()` to load the per-engine model size
- Updated `_populate_model_options()` to use the engine-specific saved model when switching engines

### Install Script Changes
- Updated default config to include the new `vosk_model_size` and `whisper_model_size` fields

## Testing
- Added unit tests for the new per-engine model size functionality
- Added migration test to verify old configs are properly upgraded
- All existing tests pass

## Backward Compatibility
- Existing configs without `vosk_model_size`/`whisper_model_size` are automatically migrated
- The generic `model_size` field is still maintained for backward compatibility