### PR TITLE
Comment out language parameter in transcribe call

### DIFF
--- a/src/vocalinux/speech_recognition/recognition_manager.py
+++ b/src/vocalinux/speech_recognition/recognition_manager.py
@@ -437,7 +437,7 @@ class SpeechRecognitionManager:
             # Transcribe with Whisper (handles variable length audio automatically)
             result = self.model.transcribe(
                 audio_float,
-                language="en",
+                # language="en",
                 task="transcribe",
                 verbose=False,
                 temperature=0.0,  # Greedy decoding for consistency


### PR DESCRIPTION
Comment out the language parameter in the transcribe method. This will permit auto recognition of language and use the application to write languages other than hardcoded English

## Description

Using language="en" hardcodes transcribing in English even if the spoken part is in a different language

## Type of Change

- [x ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 📖 Documentation update
- [ ] 🧹 Code refactoring
- [ ] ✅ Test update

## Checklist

- [ x] My code follows the code style of this project (black, isort)
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests pass locally
- [ x] Pre-commit hooks pass

## Screenshots (if applicable)

<!-- Add screenshots to help explain your changes -->

## Additional Notes

The expected behaviour is that STT transcribes the speech as it is spoken, not to default to English, this is STT + translate. It took me a lot of time to find out why it behaved so strangely.