### PR TITLE
Fix: Install script now clones specific release tag instead of main

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -70,6 +70,10 @@ while [[ $# -gt 0 ]]; do
             NON_INTERACTIVE="yes"  # Skip the prompt
             shift
             ;;
+        --tag=*)
+            INSTALL_TAG="${1#*=}"
+            shift
+            ;;
         -y|--yes)
             NON_INTERACTIVE="yes"
             shift
@@ -85,6 +89,7 @@ while [[ $# -gt 0 ]]; do
             echo "  --with-whisper   Install Whisper AI support with GPU/CUDA (included by default)"
             echo "  --whisper-cpu    Install Whisper with CPU-only PyTorch (smaller download, works on low-RAM)"
             echo "  --no-whisper     VOSK-only install (skips Whisper entirely, uses VOSK as default)"
+            echo "  --tag=TAG        Install specific release tag (default: v0.3.0-alpha)"
             echo "  -y, --yes        Non-interactive mode (accept defaults)"
             echo "  --help           Show this help message"
             exit 0
@@ -106,6 +111,9 @@ print_info "Vocalinux Installer"
 print_info "=============================="
 echo ""
 
+# Default to installing from latest stable release instead of main branch
+INSTALL_TAG="${INSTALL_TAG:-v0.3.0-alpha}"
+
 # Check if running from within the vocalinux repo or remotely (via curl)
 REPO_URL="https://github.com/jatinkrmalik/vocalinux.git"
 INSTALL_DIR=""
@@ -117,18 +125,18 @@ if [ -f "setup.py" ] || [ -f "pyproject.toml" ]; then
     print_info "Running from local repository: $INSTALL_DIR"
 else
     # Running remotely (e.g., via curl | bash)
-    print_info "Cloning Vocalinux repository..."
+    print_info "Installing Vocalinux version: ${INSTALL_TAG}"
     INSTALL_DIR="$HOME/.local/share/vocalinux-install"
     mkdir -p "$INSTALL_DIR"
 
     if [ -d "$INSTALL_DIR/.git" ]; then
         print_info "Updating existing clone..."
         cd "$INSTALL_DIR"
-        git fetch origin main
-        git reset --hard origin/main
+        git fetch origin "$INSTALL_TAG"
+        git reset --hard "origin/$INSTALL_TAG"
     else
         rm -rf "$INSTALL_DIR"
-        git clone --depth 1 "$REPO_URL" "$INSTALL_DIR" || {
+        git clone --depth 1 --branch "$INSTALL_TAG" "$REPO_URL" "$INSTALL_DIR" || {
             print_error "Failed to clone Vocalinux repository"
             exit 1
         }

--- a/web/src/app/page.tsx
+++ b/web/src/app/page.tsx
@@ -39,19 +39,19 @@ import { atomOneDark } from "react-syntax-highlighter/dist/esm/styles/hljs";
 import { useInView } from "react-intersection-observer";
 
 // The one-liner install command (split into three lines for display)
-// Uses the latest stable release tag instead of main branch
+// Uses the latest stable release tag and passes it to the script
 const getInstallCommands = (latestRelease: string) => ({
   oneClickInstallCommand: `curl \\
   -fsSL https://raw.githubusercontent.com/jatinkrmalik/vocalinux/${latestRelease}/install.sh \\
-  | bash`,
+  | bash -s -- --tag=${latestRelease}`,
 
   oneClickInstallWhisperCpu: `curl \\
   -fsSL https://raw.githubusercontent.com/jatinkrmalik/vocalinux/${latestRelease}/install.sh \\
-  | bash -s -- --whisper-cpu`,
+  | bash -s -- --tag=${latestRelease} --whisper-cpu`,
 
   oneClickInstallNoWhisper: `curl \\
   -fsSL https://raw.githubusercontent.com/jatinkrmalik/vocalinux/${latestRelease}/install.sh \\
-  | bash -s -- --no-whisper`,
+  | bash -s -- --tag=${latestRelease} --no-whisper`,
 
   uninstallCommand: `curl -fsSL \\
   https://raw.githubusercontent.com/jatinkrmalik/vocalinux/${latestRelease}/uninstall.sh \\


### PR DESCRIPTION
## Critical Fix: Install script was installing from main regardless of release version

### The Problem
Even though users fetched `install.sh` from a specific release tag (e.g., v0.3.0-alpha),
the script itself would then clone the repository from `main` branch. This meant:

- Users thought they were installing a stable release
- But they actually got whatever code is currently on `main` (potentially unstable/untested)
- The release tag was effectively ignored for the actual installation

### The Solution
1. **Added `--tag` parameter** to install.sh
2. **Default to v0.3.0-alpha** (latest stable release) instead of `main`
3. **Clone the specific tag** using `git clone --branch <tag>`
4. **Website passes the tag** dynamically: `bash -s -- --tag=<version>`

### Changes
**install.sh:**
- Add `--tag=TAG` parameter
- Set `INSTALL_TAG="${INSTALL_TAG:-v0.3.0-alpha}"` as default
- Clone specific branch: `git clone --depth 1 --branch $INSTALL_TAG`
- Update existing clone to use tag: `git reset --hard origin/$INSTALL_TAG`

**web/src/app/page.tsx:**
- Pass `--tag=${latestRelease}` to all install commands

### How it works now
```bash
# Website generates this command with the actual release tag:
curl -fsSL https://raw.githubusercontent.com/jatinkrmalik/vocalinux/v0.3.0-alpha/install.sh | bash -s -- --tag=v0.3.0-alpha

# The script then clones exactly that version
git clone --depth 1 --branch v0.3.0-alpha https://github.com/jatinkrmalik/vocalinux.git
```

### Testing
To verify it works:
```bash
curl -fsSL https://raw.githubusercontent.com/jatinkrmalik/vocalinux/v0.3.0-alpha/install.sh | bash -s -- --tag=v0.3.0-alpha
```

This should clone and install exactly v0.3.0-alpha, not main.