### PR TITLE
fix: download install.sh from main to get --tag support

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -74,7 +74,7 @@ jobs:
 
             ### Quick Install (Recommended)
             ```bash
-            curl -fsSL https://raw.githubusercontent.com/jatinkrmalik/vocalinux/${{ github.ref_name }}/install.sh | bash
+            curl -fsSL https://raw.githubusercontent.com/jatinkrmalik/vocalinux/main/install.sh | bash -s -- --tag=${{ github.ref_name }}
             ```
 
             ### From Source

--- a/README.md
+++ b/README.md
@@ -51,10 +51,10 @@
 ### One-liner Installation (Recommended)
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/jatinkrmalik/vocalinux/v0.3.0-alpha/install.sh | bash
+curl -fsSL https://raw.githubusercontent.com/jatinkrmalik/vocalinux/main/install.sh | bash -s -- --tag=v0.3.0-alpha
 ```
 
-> **Note**: Installs the latest stable release. For the most recent version, check [GitHub Releases](https://github.com/jatinkrmalik/vocalinux/releases).
+> **Note**: Installs the latest stable release (v0.3.0-alpha). For the most recent version, check [GitHub Releases](https://github.com/jatinkrmalik/vocalinux/releases).
 
 This will:
 - Clone the repository to `~/.local/share/vocalinux-install`
@@ -70,13 +70,13 @@ This will:
 
 **Whisper with CPU-only PyTorch (no NVIDIA GPU needed):**
 ```bash
-curl -fsSL https://raw.githubusercontent.com/jatinkrmalik/vocalinux/v0.3.0-alpha/install.sh | bash -s -- --whisper-cpu
+curl -fsSL https://raw.githubusercontent.com/jatinkrmalik/vocalinux/main/install.sh | bash -s -- --tag=v0.3.0-alpha --whisper-cpu
 ```
 This installs Whisper with CPU-only PyTorch (~200MB instead of ~2.3GB). Works great for systems without NVIDIA GPU.
 
 **For low-RAM systems (8GB or less) - VOSK only:**
 ```bash
-curl -fsSL https://raw.githubusercontent.com/jatinkrmalik/vocalinux/v0.3.0-alpha/install.sh | bash -s -- --no-whisper
+curl -fsSL https://raw.githubusercontent.com/jatinkrmalik/vocalinux/main/install.sh | bash -s -- --tag=v0.3.0-alpha --no-whisper
 ```
 This skips Whisper installation entirely and configures VOSK as the default engine.
 
@@ -116,7 +116,7 @@ Or launch it from your application menu!
 
 ```bash
 # If installed via curl:
-curl -fsSL https://raw.githubusercontent.com/jatinkrmalik/vocalinux/v0.3.0-alpha/uninstall.sh | bash
+curl -fsSL https://raw.githubusercontent.com/jatinkrmalik/vocalinux/main/uninstall.sh | bash
 
 # If installed from source:
 ./uninstall.sh

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -7,10 +7,10 @@ This guide provides detailed instructions for installing Vocalinux on Linux syst
 ### One-liner Installation (Recommended)
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/jatinkrmalik/vocalinux/v0.3.0-alpha/install.sh | bash
+curl -fsSL https://raw.githubusercontent.com/jatinkrmalik/vocalinux/main/install.sh | bash -s -- --tag=v0.3.0-alpha
 ```
 
-> **Note**: Installs the latest stable release. For the most recent version, check [GitHub Releases](https://github.com/jatinkrmalik/vocalinux/releases).
+> **Note**: Installs the latest stable release (v0.3.0-alpha). For the most recent version, check [GitHub Releases](https://github.com/jatinkrmalik/vocalinux/releases).
 
 That's it! The installer handles everything automatically, including Whisper AI support.
 

--- a/web/src/app/page.tsx
+++ b/web/src/app/page.tsx
@@ -39,22 +39,22 @@ import { atomOneDark } from "react-syntax-highlighter/dist/esm/styles/hljs";
 import { useInView } from "react-intersection-observer";
 
 // The one-liner install command (split into three lines for display)
-// Uses the latest stable release tag and passes it to the script
+// Downloads install.sh from main (which has --tag support) and passes the latest release tag
 const getInstallCommands = (latestRelease: string) => ({
   oneClickInstallCommand: `curl \\
-  -fsSL https://raw.githubusercontent.com/jatinkrmalik/vocalinux/${latestRelease}/install.sh \\
+  -fsSL https://raw.githubusercontent.com/jatinkrmalik/vocalinux/main/install.sh \\
   | bash -s -- --tag=${latestRelease}`,
 
   oneClickInstallWhisperCpu: `curl \\
-  -fsSL https://raw.githubusercontent.com/jatinkrmalik/vocalinux/${latestRelease}/install.sh \\
+  -fsSL https://raw.githubusercontent.com/jatinkrmalik/vocalinux/main/install.sh \\
   | bash -s -- --tag=${latestRelease} --whisper-cpu`,
 
   oneClickInstallNoWhisper: `curl \\
-  -fsSL https://raw.githubusercontent.com/jatinkrmalik/vocalinux/${latestRelease}/install.sh \\
+  -fsSL https://raw.githubusercontent.com/jatinkrmalik/vocalinux/main/install.sh \\
   | bash -s -- --tag=${latestRelease} --no-whisper`,
 
   uninstallCommand: `curl -fsSL \\
-  https://raw.githubusercontent.com/jatinkrmalik/vocalinux/${latestRelease}/uninstall.sh \\
+  https://raw.githubusercontent.com/jatinkrmalik/vocalinux/main/uninstall.sh \\
   | bash`,
 });
 


### PR DESCRIPTION
## Problem
The `v0.3.0-alpha` release was created **before** the `--tag` feature was added to `install.sh`. When users try to install using:
```bash
curl -fsSL .../vocalinux/v0.3.0-alpha/install.sh | bash -s -- --tag=v0.3.0-alpha
```
They get: `[ERROR] Unknown option: --tag=v0.3.0-alpha`

## Solution
Always download `install.sh` from `main` (which has `--tag` support) and pass the release tag as a parameter.

**Before:**
```bash
curl -fsSL .../vocalinux/\${latestRelease}/install.sh | bash -s -- --tag=\${latestRelease}
```

**After:**
```bash
curl -fsSL .../vocalinux/main/install.sh | bash -s -- --tag=\${latestRelease}
```

## Files Changed
- `web/src/app/page.tsx`: Download from main instead of `${latestRelease}`
- `README.md`: Update install commands
- `docs/INSTALL.md`: Update install command  
- `.github/workflows/release.yml`: Update release notes template