### PR TITLE
fix: remove --system-site-packages to avoid Python 3.12+ conflicts

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -568,13 +568,11 @@ setup_virtual_environment() {
     fi
 
     # Create virtual environment
-    python3 -m venv "$VENV_DIR" --system-site-packages || {
-        print_error "Failed to create virtual environment"
-        print_info "Trying without --system-site-packages..."
-        python3 -m venv "$VENV_DIR" || {
-            print_error "Failed to create virtual environment. Please check your Python installation."
-            exit 1
-        }
+    # Note: We don't use --system-site-packages to avoid conflicts with system packages
+    # that may be incompatible with Python 3.12+ (e.g., old coverage versions)
+    python3 -m venv "$VENV_DIR" || {
+        print_error "Failed to create virtual environment. Please check your Python installation."
+        exit 1
     }
 
     # Activate virtual environment


### PR DESCRIPTION
## Summary
Fixes #66

The `--system-site-packages` flag causes the virtual environment to inherit
system packages, which can include versions incompatible with newer Python
versions.

## Problem
On Arch/EndeavourOS with Python 3.12, an old `coverage` package from the
system causes Whisper to fail with:

```
module 'coverage.types' has no attribute 'Tracer'
```

This happens because:
1. The installer creates a venv with `--system-site-packages`
2. The system has an old `coverage` package (from poetry or other tools)
3. When Whisper tries to initialize, it imports the incompatible system coverage

## Solution
Remove the `--system-site-packages` flag and create an isolated virtual
environment. All dependencies are installed at compatible versions within
the venv, avoiding conflicts with system packages.

The fallback logic that tried without `--system-site-packages` on failure
has been removed since the first attempt never actually fails - it just
creates a venv that inherits problematic system packages.

## Test plan
- [x] Code change reviewed
- [ ] Tested on Arch/EndeavourOS with Python 3.12 (user with issue can verify)