### PR TITLE
chore: merge v0.4.0-alpha release to main

### DIFF
--- a/src/vocalinux/version.py
+++ b/src/vocalinux/version.py
@@ -2,8 +2,8 @@
 Version information for Vocalinux.
 """
 
-__version__ = "0.3.0-alpha"
-__version_info__ = (0, 3, 0, "alpha")
+__version__ = "0.4.0-alpha"
+__version_info__ = (0, 4, 0, "alpha")
 __author__ = "Jatin K Malik"
 __email__ = "jatinkrmalik@gmail.com"
 __license__ = "GPL-3.0"


### PR DESCRIPTION
This PR merges the version bump for v0.4.0-alpha release back to main.

**Changes:**
- Bumps version from 0.3.0-alpha to 0.4.0-alpha

**Release:** https://github.com/jatinkrmalik/vocalinux/releases/tag/v0.4.0-alpha