### PR TITLE
fix: correct git fetch syntax for tag-based updates

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -132,8 +132,8 @@ else
     if [ -d "$INSTALL_DIR/.git" ]; then
         print_info "Updating existing clone..."
         cd "$INSTALL_DIR"
-        git fetch origin "$INSTALL_TAG"
-        git reset --hard "origin/$INSTALL_TAG"
+        git fetch origin "tag" "$INSTALL_TAG"
+        git reset --hard "$INSTALL_TAG"
     else
         rm -rf "$INSTALL_DIR"
         git clone --depth 1 --branch "$INSTALL_TAG" "$REPO_URL" "$INSTALL_DIR" || {


### PR DESCRIPTION
## Bug Fix

The installer was failing when updating to a specific tag because it was trying to fetch a branch (e.g., `origin/v0.4.0-alpha`) which doesn't exist - tags are not branches.

## Error
```
fatal: ambiguous argument 'origin/v0.4.0-alpha': unknown revision or path not in the working tree.
```

## Fix
Changed:
```bash
git fetch origin "$INSTALL_TAG"
git reset --hard "origin/$INSTALL_TAG"
```

To:
```bash
git fetch origin tag "$INSTALL_TAG"
git reset --hard "$INSTALL_TAG"
```

This correctly fetches the tag from the remote and then resets to the local tag ref.