### PR TITLE
fix: update website version to 0.4.0-alpha

### DIFF
--- a/web/src/app/layout.tsx
+++ b/web/src/app/layout.tsx
@@ -116,7 +116,7 @@ export default function RootLayout({
       "priceCurrency": "USD"
     },
     "description": "Free, open-source voice dictation for Linux. 100% offline with Whisper AI and VOSK. Works with X11 and Wayland.",
-    "softwareVersion": "0.3.0-alpha",
+    "softwareVersion": "0.4.0-alpha",
     "author": {
       "@type": "Person",
       "name": "Jatin K Malik",

--- a/web/src/app/page.tsx
+++ b/web/src/app/page.tsx
@@ -204,7 +204,7 @@ export default function HomePage() {
             />
             <span className="font-bold text-lg sm:text-xl">Vocalinux</span>
             <span className="hidden sm:inline-block text-xs bg-gradient-to-r from-primary/20 to-green-500/20 text-primary border border-primary/30 px-2.5 py-1 rounded-full font-semibold shadow-sm shadow-primary/20">
-              v0.3.0 Alpha
+              v0.4.0 Alpha
             </span>
           </Link>
 


### PR DESCRIPTION
## Summary
- Updates website version display from `0.3.0-alpha` to `0.4.0-alpha` to match the current version in `src/vocalinux/version.py`

## Changes
- `web/src/app/page.tsx`: Updated header badge version
- `web/src/app/layout.tsx`: Updated structured data version

## Context
The website was hardcoded to show version 0.3.0-alpha, which was outdated. This PR brings it in sync with the actual package version.