### PR TITLE
fix: escape commit message in Detect Changes workflow step

### DIFF
--- a/.github/workflows/unified-pipeline.yml
+++ b/.github/workflows/unified-pipeline.yml
@@ -41,10 +41,11 @@ jobs:
         id: deploy_check
         run: |
           # Deploy if web files changed OR python files changed (for version updates)
+          COMMIT_MESSAGE="${{ github.event.head_commit.message }}"
           if [[ "${{ steps.filter.outputs.web }}" == "true" ]] || \
              [[ "${{ steps.filter.outputs.python }}" == "true" ]] || \
              [[ "${{ github.event_name }}" == "workflow_dispatch" ]] || \
-             [[ "${{ github.event.head_commit.message }}" == *"[web]"* ]]; then
+             [[ "$COMMIT_MESSAGE" == *"[web]"* ]]; then
             echo "deploy=true" >> $GITHUB_OUTPUT
           else
             echo "deploy=false" >> $GITHUB_OUTPUT


### PR DESCRIPTION
## Problem

The CI workflow failed after merging PR #87 because the commit message contained special characters (parentheses) that broke the bash syntax.

The commit message "feat: add language selector UI with auto-detection support (#87)" was directly inserted into the bash comparison, causing a syntax error.

## Fix

Assign the commit message to a variable first before comparison to properly escape special characters.