### PR TITLE
fix: ensure VENV_DIR is absolute path in local install

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -123,6 +123,8 @@ if [ -f "setup.py" ] || [ -f "pyproject.toml" ]; then
     # Running from within the repo
     INSTALL_DIR="$(pwd)"
     print_info "Running from local repository: $INSTALL_DIR"
+    # Convert VENV_DIR to absolute path for wrapper scripts
+    VENV_DIR="$INSTALL_DIR/$VENV_DIR"
 else
     # Running remotely (e.g., via curl | bash)
     print_info "Installing Vocalinux version: ${INSTALL_TAG}"


### PR DESCRIPTION
## Problem
When installing from within the git repository, `VENV_DIR` remained as the relative path `"venv"`. This caused the wrapper scripts in `~/.local/bin/` to fail when executed from any directory other than the repo root.

This broke launching from app drawers/desktop entries since they execute commands without setting the working directory to the repo location.

## Root Cause
In `install.sh`:
- Line 28: `VENV_DIR="venv"` (default relative path)
- Lines 122-125: When running from local repo, `INSTALL_DIR` is set to absolute path but `VENV_DIR` stays relative
- Lines 800-807: Wrapper scripts use `$VENV_DIR` directly, embedding the relative path

## Fix
Convert `VENV_DIR` to an absolute path (`$INSTALL_DIR/$VENV_DIR`) when running from local repository.

This ensures `VENV_DIR` is always absolute:
- **Remote install** (via curl): `$HOME/.local/share/vocalinux/venv` (already absolute)
- **Local install** (from repo): `/path/to/repo/venv` (now absolute)

## Test Plan
- [ ] Install from within git repo directory
- [ ] Verify `~/.local/bin/vocalinux-gui` contains absolute path
- [ ] Run `vocalinux-gui` from different directories (home, /tmp, etc.)
- [ ] Launch from app drawer