### PR TITLE
fix: Typo in gir1.2-ayatanaappindicator3-0.1 .deb package (Debian 13)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -73,7 +73,7 @@ This will:
    # On older Ubuntu/Debian:
    sudo apt install -y gir1.2-appindicator3-0.1
    # On Debian 13+ (trixie) or newer:
-   sudo apt install -y gir1.2-ayatana-appindicator3
+   sudo apt install -y gir1.2-ayatanaappindicator3-0.1
    ```
 
 3. **Set up Python environment:**

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -150,7 +150,7 @@ sudo apt install -y \
 # - On older Ubuntu/Debian versions:
 sudo apt install -y gir1.2-appindicator3-0.1
 # - On Debian 13+ (trixie) or newer Ubuntu versions:
-sudo apt install -y gir1.2-ayatana-appindicator3
+sudo apt install -y gir1.2-ayatanaappindicator3-0.1
 
 # For X11
 sudo apt install -y xdotool
@@ -257,7 +257,7 @@ sudo apt install python3-gi python3-gi-cairo
 # For appindicator (system tray icon) - try one of these:
 sudo apt install gir1.2-appindicator3-0.1  # For older Debian/Ubuntu
 # OR
-sudo apt install gir1.2-ayatana-appindicator3  # For Debian 13+ or newer Ubuntu
+sudo apt install gir1.2-ayatanaappindicator3-0.1  # For Debian 13+ or newer Ubuntu
 
 # Recreate venv with system packages
 rm -rf venv

--- a/install.sh
+++ b/install.sh
@@ -288,19 +288,19 @@ install_system_dependencies() {
                 sudo apt update || { print_error "Failed to update package lists"; exit 1; }
 
                 # Handle appindicator package: old package was deprecated in Debian 13+
-                # Try the old package first, fall back to ayatana-appindicator if unavailable
+                # Try the old package first, fall back to gir1.2-ayatanaappindicator3-0.1 if unavailable
                 if echo "$MISSING_PACKAGES" | grep -q "gir1.2-appindicator3-0.1"; then
                     # Remove appindicator from the package list for special handling
                     FILTERED_PACKAGES=$(echo "$MISSING_PACKAGES" | sed 's/gir1.2-appindicator3-0.1//' | xargs)
 
                     # Try to install the old package first (for older Debian/Ubuntu versions)
                     if ! sudo apt install -y gir1.2-appindicator3-0.1 2>/dev/null; then
-                        print_info "gir1.2-appindicator3-0.1 not available, trying gir1.2-ayatana-appindicator3..."
-                        if ! sudo apt install -y gir1.2-ayatana-appindicator3; then
-                            print_error "Failed to install appindicator package (tried both gir1.2-appindicator3-0.1 and gir1.2-ayatana-appindicator3)"
+                        print_info "gir1.2-appindicator3-0.1 not available, trying gir1.2-ayatanaappindicator3-0.1..."
+                        if ! sudo apt install -y gir1.2-ayatanaappindicator3-0.1; then
+                            print_error "Failed to install appindicator package (tried both gir1.2-appindicator3-0.1 and gir1.2-ayatanaappindicator3-0.1)"
                             exit 1
                         fi
-                        print_info "Successfully installed gir1.2-ayatana-appindicator3 (modern replacement)"
+                        print_info "Successfully installed gir1.2-ayatanaappindicator3-0.1 (modern replacement)"
                     fi
 
                     # Install remaining packages

--- a/src/vocalinux/main.py
+++ b/src/vocalinux/main.py
@@ -87,7 +87,7 @@ def check_dependencies():
         missing_deps.append(
             "GTK3 and AppIndicator3 (install with: sudo apt install "
             "python3-gi gir1.2-appindicator3-0.1) "
-            "Note: On Debian 13+ use gir1.2-ayatana-appindicator3 instead"
+            "Note: On Debian 13+ use gir1.2-ayatanaappindicator3-0.1 instead"
         )
 
     if missing_deps:


### PR DESCRIPTION
There was a typo in the gir1.2-ayatanaappindicator3-0.1 .deb package referred to in apt commands, submitted in commit 27ebbfe417f178eaabcf2ac10af63f37bc819fac gir1.2-ayatana-appindicator3 (typo) replaced with gir1.2-ayatanaappindicator3-0.1 per Debian package list at
https://packages.debian.org/search?keywords=gir1.2-ayatanaappindicator3-0.1 Will be backwards compatible with Debian 11 (bullseye), 12 (bookworm), and current 13 (trixie).

## Description

Changes:
- install.sh: gir1.2-ayatana-appindicator3 (typo) replaced with gir1.2-ayatanaappindicator3-0.1
- docs/INSTALL.md: gir1.2-ayatana-appindicator3 (typo) replaced with gir1.2-ayatanaappindicator3-0.1
- src/vocalinux/main.py: gir1.2-ayatana-appindicator3 (typo) replaced with gir1.2-ayatanaappindicator3-0.1
- CONTRIBUTING.md: gir1.2-ayatana-appindicator3 (typo) replaced with gir1.2-ayatanaappindicator3-0.1

## Related Issue

<!-- Link to the related issue if applicable -->
Fixes #69, #70 

## Type of Change

- [X] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [X] 📖 Documentation update
- [ ] 🧹 Code refactoring
- [ ] ✅ Test update

## Checklist

- [X] My code follows the code style of this project (black, isort)
- [X] I have updated the documentation accordingly
- [] I have added tests to cover my changes
- [ ] All new and existing tests pass locally
- [ ] Pre-commit hooks pass

## Screenshots (if applicable)

<!-- Add screenshots to help explain your changes -->

## Additional Notes

<!-- Add any additional notes for reviewers -->
