### PR TITLE
fix: Add missing keyboard_backends package to pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -85,7 +85,7 @@ Issues = "https://github.com/jatinkrmalik/vocalinux/issues"
 Changelog = "https://github.com/jatinkrmalik/vocalinux/releases"
 
 [tool.setuptools]
-packages = ["vocalinux", "vocalinux.speech_recognition", "vocalinux.text_injection", "vocalinux.ui", "vocalinux.utils"]
+packages = ["vocalinux", "vocalinux.speech_recognition", "vocalinux.text_injection", "vocalinux.ui", "vocalinux.ui.keyboard_backends", "vocalinux.utils"]
 package-dir = {"" = "src"}
 
 [tool.setuptools.dynamic]


### PR DESCRIPTION
## Problem
The `vocalinux.ui.keyboard_backends` module was not being installed because it wasn't listed in the packages configuration in `pyproject.toml`. This caused Vocalinux to fail to launch after installation with the error:



## Solution
Added `vocalinux.ui.keyboard_backends` to the packages list in pyproject.toml.

## Testing
- Installed Vocalinux locally and verified it now launches successfully
- The keyboard_backends module is properly included in the package installation

Fixes installation issue where the app fails to start immediately after install.