### PR TITLE
fix(install): fix model download and VOSK-only option in interactive mode

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1396,7 +1396,7 @@ install_icons() {
     fi
 }
 
-# Function to update icon cache
+# Function to update icon cache and desktop database
 update_icon_cache() {
     print_info "Updating icon cache..."
 
@@ -1407,6 +1407,16 @@ update_icon_cache() {
         }
     else
         print_warning "gtk-update-icon-cache command not found, skipping icon cache update"
+    fi
+
+    # Update desktop database so the app appears in application menus immediately
+    print_info "Updating desktop database..."
+    if command_exists update-desktop-database; then
+        update-desktop-database "${XDG_DATA_HOME:-$HOME/.local/share}/applications" 2>/dev/null || {
+            print_warning "Failed to update desktop database"
+        }
+    else
+        print_warning "update-desktop-database command not found - app may not appear in menu until next login"
     fi
 }
 


### PR DESCRIPTION
## Summary

Fixes three issues in the install.sh script:

1. **Option 3 (VOSK-only) in interactive prompt didn't work properly** - The interactive menu offered 3 options but option 3 had no handler code, so selecting VOSK-only didn't create the required config file to set VOSK as the default engine
2. **Options 1 and 2 didn't set flags correctly** - The `WITH_WHISPER` and `WHISPER_CPU` flags weren't being set when selecting options 1 or 2 in the interactive prompt
3. **Whisper tiny model not downloaded when Whisper is installed** - The model download logic relied on flag combinations that didn't work correctly in all scenarios

## Root Cause Analysis

### Issue 1: Missing Option 3 Handler
The interactive prompt (lines 985-1008) only had handlers for options 1 and 2:
```bash
if [[ $REPLY == "1" ]]; then
    # GPU whisper
elif [[ $REPLY == "2" ]]; then
    # CPU whisper
fi  # <- option 3 fell through with no action!
```

This meant selecting option 3 would:
- Not install Whisper (correct)
- Not create a VOSK config (bug! - the app defaults to Whisper)
- User launches app -> tries to use Whisper -> fails because no model

### Issue 2: Flags Not Set
When using the interactive prompt, the `WITH_WHISPER` variable wasn't being set to `"yes"`, which caused the model download section to skip downloading the Whisper model even though Whisper was installed.

### Issue 3: Flawed Model Download Logic
The original condition was:
```bash
if [ "$WITH_WHISPER" = "yes" ] || [ "$NON_INTERACTIVE" = "yes" ]; then
```

This was problematic because:
- In non-interactive curl | bash mode, it would always try to check for whisper
- The flag state wasn't reliable across all code paths
- Using `python -c "import whisper"` without the venv activated could give wrong results

## Changes Made

1. **Added option 3 handler** that creates a VOSK config file (mirroring the `--no-whisper` flag behavior)

2. **Set flags correctly** for options 1 and 2:
   - Option 1: `WITH_WHISPER="yes"`
   - Option 2: `WITH_WHISPER="yes"` and `WHISPER_CPU="yes"`

3. **Fixed model download logic** to:
   - Check if Whisper is actually importable using the venv's python
   - Download model whenever Whisper is installed (since it's the default engine)
   - Show informative messages about what's happening

## Testing

To test these changes:

```bash
# Test interactive mode - option 1 (GPU Whisper)
./install.sh -i
# Select 1, verify Whisper model is downloaded

# Test interactive mode - option 2 (CPU Whisper) 
./install.sh -i
# Select 2, verify Whisper model is downloaded

# Test interactive mode - option 3 (VOSK only)
./install.sh -i
# Select 3, verify VOSK config is created at ~/.config/vocalinux/config.json
# Verify engine is set to "vosk"
```