### PR TITLE
fix(transcription): add space after punctuation when transcribing again

### DIFF
--- a/src/vocalinux/main.py
+++ b/src/vocalinux/main.py
@@ -219,7 +219,36 @@ def main():
         # Create a wrapper function to track injected text for action handler
         def text_callback_wrapper(text: str):
             """Wrapper to track injected text and handle it."""
-            success = text_system.inject_text(text)
+            # Check if we need to add a space before the new text
+            text_to_inject = text
+
+            # Punctuation and characters that typically need a space after them
+            chars_needing_space = {
+                ".",
+                ",",
+                "!",
+                "?",
+                ";",
+                ":",
+                ")",
+                "]",
+                "}",
+                "-",
+                "_",
+                # Also quotes
+                '"',
+                "'",
+            }
+
+            # If last injected text exists and ends with a character that needs space,
+            # add a space before the new text
+            if action_handler.last_injected_text and action_handler.last_injected_text.strip():
+                last_char = action_handler.last_injected_text[-1]
+                if last_char in chars_needing_space:
+                    text_to_inject = " " + text_to_inject
+                    logger.debug(f"Added space before new text (last char: '{last_char}')")
+
+            success = text_system.inject_text(text_to_inject)
             if success:
                 action_handler.set_last_injected_text(text)
 


### PR DESCRIPTION
This PR fixes the issue where new text was being injected immediately after punctuation without a space when transcribing multiple times.

## Problem
When transcribing text continuously (stop speaking and start again), the new text was being injected immediately after the last character without a space. This caused issues like:

Before: "Hello world.This is a test"
After: "Hello world. This is a test"

## Root Cause
The text callback simply injected the transcribed text directly without checking if the previous text ended with a character that typically needs a space after it.

## Solution
Added logic to  in main.py:

1. Check if the last injected text exists and is not empty
2. Get the last character of the previously injected text
3. If that character is in the set of characters needing space, prepend a space to the new text
4. Inject the text with the space prepended
5. Log when space is added for debugging

## Characters Requiring Space

Punctuation and special characters:
- Period (.)
- Comma (,)
- Exclamation mark (!)
- Question mark (?)
- Semicolon (;)
- Colon (:)
- Closing brackets/braces ())]}}
- Hyphen (-)
- Underscore (_)
- Quotes (" and ')

## Changes
- Modified  function in main.py
- Added  set with characters that need space after them
- Added logic to check last character and prepend space if needed

## Verification
- All 462 tests in full test suite passing
- Pre-commit hooks passing

Closes #151