### PR TITLE
fix(web): make quick install command fully visible

### DIFF
--- a/web/src/app/page.tsx
+++ b/web/src/app/page.tsx
@@ -362,7 +362,7 @@ export default function HomePage() {
                     <CopyButton text={interactiveInstallCommand} />
                   </div>
                   <div className="p-4 sm:p-5">
-                    <pre className="font-mono text-sm sm:text-base text-green-400 text-left whitespace-pre">
+                    <pre className="font-mono text-sm sm:text-base text-green-400 text-left whitespace-pre-wrap">
                       <span className="text-zinc-500 select-none">$ </span>{interactiveInstallCommand}
                     </pre>
                   </div>


### PR DESCRIPTION
## Summary
- Fixed quick install command visibility issue by changing `whitespace-pre` to `whitespace-pre-wrap`
- The full command is now always visible without needing to scroll or hover
- Simple and transparent solution for better UX

## Changes
- Modified `web/src/app/page.tsx` to use `whitespace-pre-wrap` CSS property
- This allows the long install command to wrap and be fully visible at all times