### PR TITLE
fix(web): auto-detect browser language for live demo speech recognition

### DIFF
--- a/web/src/components/live-demo.tsx
+++ b/web/src/components/live-demo.tsx
@@ -66,7 +66,7 @@ export function LiveDemo() {
         const recognition = new SpeechRecognitionAPI();
         recognition.continuous = true;
         recognition.interimResults = true;
-        recognition.lang = "en-US";
+        recognition.lang = navigator.language || "en-US";
 
         recognition.onstart = () => {
             setIsListening(true);


### PR DESCRIPTION
## Description
Fixes the live browser demo to automatically detect and use the user's browser language for speech recognition instead of hardcoding English.

## Problem
The live demo only worked for English speech because `recognition.lang` was hardcoded to `"en-US"`. Users with French, German, Spanish, or other language browser settings couldn't test the demo in their native language.

## Solution
Changed from hardcoded language:
```javascript
recognition.lang = "en-US";
```

To auto-detect browser language with English fallback:
```javascript
recognition.lang = navigator.language || "en-US";
```

## Changes
- Modified `web/src/components/live-demo.tsx` to use `navigator.language` for automatic language detection
- Falls back to `"en-US"` if `navigator.language` is not available

## Testing
- [x] English browsers still work (fallback)
- [x] French browsers will now detect French speech
- [x] Other languages (German, Spanish, etc.) supported by Web Speech API will work automatically

## Related Issue
Closes #165