### PR TITLE
fix(install): prevent silent exit on systems without NVIDIA GPU

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -326,7 +326,7 @@ EOF
     print_header "Step 1: Your System"
     echo "Detected: $DISTRO_NAME $DISTRO_VERSION"
 
-    detect_nvidia_gpu
+    detect_nvidia_gpu || true
     if [[ "$HAS_NVIDIA_GPU" == "yes" ]]; then
         echo "GPU: $GPU_NAME ($GPU_MEMORY)"
         RECOMMENDED_ENGINE="whisper-gpu"
@@ -470,7 +470,7 @@ fi
 # Auto-detect GPU for non-interactive mode when no explicit Whisper choice
 # This helps users who run curl | bash without any flags
 if [[ "$NON_INTERACTIVE" == "yes" ]] && [[ "$WITH_WHISPER" == "no" ]] && [[ "$NO_WHISPER_EXPLICIT" == "no" ]] && [[ "$INTERACTIVE_MODE" == "no" ]]; then
-    detect_nvidia_gpu
+    detect_nvidia_gpu || true
     if [[ "$HAS_NVIDIA_GPU" == "yes" ]]; then
         WITH_WHISPER="yes"
         print_info "NVIDIA GPU detected: $GPU_NAME"


### PR DESCRIPTION
Fixes #172.

## Summary
The interactive installation mode was silently exiting at "Step 1: Your System" on systems without an NVIDIA GPU.

## Root Cause
The script uses  which treats any non-zero return code as a fatal error. The  function returns 1 when no NVIDIA GPU is detected, causing the entire script to exit immediately.

## Fix
Added  to both  function calls (lines 329 and 473) to prevent  from exiting the script when no NVIDIA GPU is found.

## Changes
- Line 329:  (interactive mode)
- Line 473:  (non-interactive auto-detection)

This allows the script to continue gracefully on systems with AMD GPUs or no discrete GPU at all.