### PR TITLE
fix(web): prevent speech result duplication on mobile browsers

### DIFF
--- a/web/src/components/live-demo.tsx
+++ b/web/src/components/live-demo.tsx
@@ -126,6 +126,8 @@ export function LiveDemo() {
     const [detectedLanguage, setDetectedLanguage] = useState<string>("en-US");
     const recognitionRef = useRef<SpeechRecognition | null>(null);
     const isListeningRef = useRef(false);
+    // Track the index up to which results have been processed to prevent duplicates on mobile
+    const processedResultIndexRef = useRef(0);
 
     // Keep ref in sync with state for use in event handlers
     useEffect(() => {
@@ -163,20 +165,30 @@ export function LiveDemo() {
         };
 
         recognition.onresult = (event: SpeechRecognitionEvent) => {
+            // Get the base index - on some browsers (especially mobile), resultIndex
+            // may be 0 but the array contains all previous results. We need to
+            // track which results we've already processed to avoid duplicates.
+            const startIndex = Math.max(event.resultIndex, processedResultIndexRef.current);
+
             let interim = "";
             let final = "";
 
-            for (let i = event.resultIndex; i < event.results.length; i++) {
+            // Only process new results (from startIndex to end)
+            for (let i = startIndex; i < event.results.length; i++) {
                 const transcript = event.results[i][0].transcript;
                 if (event.results[i].isFinal) {
-                    final += transcript;
+                    final += transcript + " ";
                 } else {
                     interim += transcript;
                 }
             }
 
+            // Update processed index to the end of current results
+            // Any results before this have been handled
+            processedResultIndexRef.current = event.results.length;
+
             if (final) {
-                setTranscript((prev) => prev + final + " ");
+                setTranscript((prev) => prev + final);
                 setInterimTranscript("");
             } else {
                 setInterimTranscript(interim);
@@ -206,6 +218,7 @@ export function LiveDemo() {
         if (recognitionRef.current) {
             setTranscript("");
             setInterimTranscript("");
+            processedResultIndexRef.current = 0; // Reset processed result index
             try {
                 recognitionRef.current.start();
             } catch (e) {


### PR DESCRIPTION
## Summary

Fixes a critical bug in the Web Speech API integration where speech recognition would glitch on mobile browsers, causing exponential text duplication.

## Problem

On mobile browsers, the `onresult` event from the Web Speech API behaves differently than desktop:
- Desktop: `resultIndex` typically 0, array contains only new results
- Mobile: `resultIndex` stays 0, but array **accumulates all previous results**

This caused the existing loop to re-process all previous transcripts on every event, resulting in:
```
let's let's see let's see if let's see if this let's see if this actually let's see if this actually works
```

## Solution

Added `processedResultIndexRef` to track which results have already been processed:
- Only processes results from `startIndex` to `results.length`
- `startIndex = Math.max(event.resultIndex, processedResultIndexRef.current)`
- Updates `processedResultIndexRef.current = event.results.length` after processing

## Test plan

- [x] Code compiles successfully
- [ ] Test on desktop browser (Chrome/Edge) - should still work as before
- [ ] Test on mobile browser (Chrome mobile/Safari mobile) - should no longer duplicate text
- [ ] Verify the phrase "let's see if this actually works" transcribes correctly on mobile

Please test on a mobile device and verify the fix works as expected.

## Related

Fixes mobile speech duplication bug