### PR TITLE
fix(ci): safely handle multi-line commit messages in deploy check

### DIFF
--- a/.github/workflows/unified-pipeline.yml
+++ b/.github/workflows/unified-pipeline.yml
@@ -45,20 +45,24 @@ jobs:
               - '.github/workflows/**'
       - name: Check if website should deploy
         id: deploy_check
+        env:
+          COMMIT_MESSAGE: ${{ github.event.head_commit.message }}
         run: |
           # Deploy if web files changed OR python files changed (for version updates)
-          COMMIT_MESSAGE="${{ github.event.head_commit.message }}"
+          # Use heredoc to safely handle multi-line commit messages
+          COMMIT_MSG_FILE=$(mktemp)
+          printenv COMMIT_MESSAGE > "$COMMIT_MSG_FILE"
 
-          # Escape the commit message properly for shell comparison
-          # Use case-insensitive matching with grep instead of glob patterns
+          # Use case-insensitive matching with grep
           if [[ "${{ steps.filter.outputs.web }}" == "true" ]] || \
              [[ "${{ steps.filter.outputs.python }}" == "true" ]] || \
              [[ "${{ github.event_name }}" == "workflow_dispatch" ]] || \
-             echo "$COMMIT_MESSAGE" | grep -iE "(feat\(website\)|docs\(website\)|chore\(website\)|fix\(website\)|refactor\(website\))"; then
+             grep -iE "(feat\(website\)|docs\(website\)|chore\(website\)|fix\(website\)|refactor\(website\))" "$COMMIT_MSG_FILE"; then
             echo "deploy=true" >> $GITHUB_OUTPUT
           else
             echo "deploy=false" >> $GITHUB_OUTPUT
           fi
+          rm -f "$COMMIT_MSG_FILE"
 
   python-lint:
     name: 🔍 Lint Python


### PR DESCRIPTION
## Summary
- Fixes CI failure caused by multi-line commit messages being directly interpolated into shell script
- Passes commit message via environment variable instead of inline interpolation
- Writes to temp file before grepping to avoid shell injection issues

## Problem
The previous implementation directly interpolated the commit message into the shell script. When the commit message contained newlines (like PR #192), words like "not" were interpreted as shell commands.

## Solution
Use GitHub Actions env to safely pass the commit message, then write to a temp file using printenv before grepping.

Fixes CI failure from #192