### PR TITLE
fix(audio): resolve PyAudio paInt16 attribute error on reconnection

### DIFF
--- a/src/vocalinux/speech_recognition/recognition_manager.py
+++ b/src/vocalinux/speech_recognition/recognition_manager.py
@@ -1661,6 +1661,8 @@ class SpeechRecognitionManager:
         Returns:
             bool: True if reconnection was successful, False otherwise
         """
+        import pyaudio
+
         self._reconnection_attempts += 1
 
         if self._reconnection_attempts > self._max_reconnection_attempts:
@@ -1689,7 +1691,7 @@ class SpeechRecognitionManager:
 
             # Stream configuration
             CHUNK = 1024
-            FORMAT = audio_instance.paInt16
+            FORMAT = pyaudio.paInt16
             CHANNELS = 1
             RATE = 16000
 


### PR DESCRIPTION
## Summary
- Fixed incorrect reference to `paInt16` in `_attempt_audio_reconnection` method
- `paInt16` is a module-level constant in `pyaudio`, not an attribute of the `PyAudio` instance
- Added local import of `pyaudio` module and corrected the reference from `audio_instance.paInt16` to `pyaudio.paInt16`

## Root Cause
The `_attempt_audio_reconnection` method was trying to access `paInt16` as an attribute of a `PyAudio` instance (`audio_instance.paInt16`), but `paInt16` is a constant defined at the `pyaudio` module level, not on the instance itself.

Fixes #203