### PR TITLE
fix(ci): delete local tags before creating nightly release

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -100,6 +100,7 @@ jobs:
                 echo "Deleting old nightly release: $tag (created: $(date -d @$RELEASE_DATE -u +"%Y-%m-%d %H:%M:%S UTC"))"
                 gh release delete "$tag" --yes --repo ${{ github.repository }} 2>/dev/null || true
                 git push origin :refs/tags/"$tag" 2>/dev/null || true
+                git tag -d "$tag" 2>/dev/null || true
               else
                 echo "Keeping nightly release: $tag (created: $(date -d @$RELEASE_DATE -u +"%Y-%m-%d %H:%M:%S UTC"))"
               fi
@@ -210,6 +211,7 @@ jobs:
           # If a release for today already exists, delete it first
           gh release delete "$RELEASE_TAG" --yes --repo ${{ github.repository }} 2>/dev/null || true
           git push origin :refs/tags/"$RELEASE_TAG" 2>/dev/null || true
+          git tag -d "$RELEASE_TAG" 2>/dev/null || true
           
           gh release create "$RELEASE_TAG" \
             --title "Nightly Build - ${{ steps.version.outputs.version }}" \


### PR DESCRIPTION
## Problem
The nightly workflow fails when re-running on the same day with the error:
```
tag nightly-2026-02-17 exists locally but has not been pushed to jatinkrmalik/vocalinux, please push it before continuing or specify the `--target` flag to create a new tag
```

## Root Cause
After deleting the remote release and tag, the local tag still exists in the runner's Git checkout. When we try to create a new release with the same tag name, GitHub CLI sees the local tag and expects it to be pushed to remote first.

## Solution
Added `git tag -d "$tag"` to delete local tags after deleting remote tags in:
1. The "Cleanup old nightly releases" step (for old nightly tags)
2. The "Create nightly release" step (for same-day re-runs)

This ensures a clean state before creating new releases.

## Testing
This fix allows the workflow to be re-run multiple times on the same day without errors.