### PR TITLE
Fix #219: Suppress [BLANK_AUDIO] tokens in whisper.cpp output

### DIFF
--- a/src/vocalinux/speech_recognition/recognition_manager.py
+++ b/src/vocalinux/speech_recognition/recognition_manager.py
@@ -633,7 +633,12 @@ class SpeechRecognitionManager:
             cpu_count = multiprocessing.cpu_count()
 
             load_start_time = time.time()
-            self.model = Model(model_path, n_threads=n_threads)
+            self.model = Model(
+                model_path,
+                n_threads=n_threads,
+                suppress_blank=True,
+                suppress_non_speech_tokens=True,
+            )
             load_duration = time.time() - load_start_time
 
             logger.info(


### PR DESCRIPTION
## Summary

This PR implements a fix for issue #219 where blank audio text was being inserted when users paused too long with the mic on.

## Root Cause

whisper.cpp outputs a special blank audio token when transcribing silent audio. Vocalinux was not filtering this out, so when a user paused with the mic on, the silence would be transcribed and inserted into the text field.

## Solution

This PR implements Option 2 from the investigation: Suppress blank audio at the whisper.cpp level by passing parameters during Model initialization.

The fix adds two parameters to the whisper.cpp Model initialization:
- suppress_blank=True - Suppress blank outputs (already the default, but set explicitly for clarity)
- suppress_non_speech_tokens=True - Suppress non-speech tokens including the blank audio token

## Changes

Modified _init_whispercpp() method in recognition_manager.py to pass the suppression parameters to the Model constructor.

## Alternative Approach

Option 1 (post-processing filter) exists as an alternative if this approach does not work as expected. That approach would involve filtering out blank audio strings after transcription completes. However, suppressing at the whisper.cpp level is cleaner and prevents the tokens from being generated in the first place.