### PR TITLE
Fix #221: Add missing psutil dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,6 +49,7 @@ dependencies = [
     "pyaudio>=0.2.13",
     "python-xlib; sys_platform == 'linux'",
     "PyGObject; sys_platform == 'linux'",
+    "psutil>=5.9.0",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
pywhispercpp requires psutil internally but doesn't declare it as a dependency, causing vocalinux to fail on fresh installs with:

`Failed to import pywhispercpp: No module named 'psutil'`

This PR adds psutil>=5.9.0 to vocalinux's dependencies as a workaround.