### PR TITLE
fix(install): prevent dnf check-update from exiting script on Fedora

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -986,7 +986,7 @@ install_system_dependencies() {
 
             if [ -n "$MISSING_PACKAGES" ]; then
                 print_info "Installing missing packages:$MISSING_PACKAGES"
-                $UPDATE_CMD
+                $UPDATE_CMD || true  # dnf check-update returns 100 if updates available
                 $INSTALL_CMD $MISSING_PACKAGES || { print_error "Failed to install dependencies"; exit 1; }
             else
                 print_info "All required packages are already installed."


### PR DESCRIPTION
## Summary
- Fixes Fedora installation failure where installer exits prematurely
- `dnf check-update` returns exit code 100 when system updates are available
- With `set -e` at script start, this caused immediate exit
- Added `|| true` to prevent this non-error condition from stopping the installer

## Problem
On Fedora, the installer would exit silently after printing "Installing missing packages: ..." because `dnf check-update` returns exit code 100 when system updates are available. This is documented dnf behavior but caused the script to fail due to `set -e`.

## Test plan
- [x] Verified syntax with `bash -n install.sh`
- [x] CI will test on Fedora 39 container
- [ ] User @pdchris77 can test on Fedora 43

Fixes #34 (Fedora installation failure)