### PR TITLE
fix(ibus): skip IBus setup when daemon not running

### DIFF
--- a/src/vocalinux/text_injection/ibus_engine.py
+++ b/src/vocalinux/text_injection/ibus_engine.py
@@ -111,6 +111,28 @@ def is_ibus_available() -> bool:
     return IBUS_AVAILABLE
 
 
+def is_ibus_daemon_running() -> bool:
+    """
+    Check if the IBus daemon (ibus-daemon) is currently running.
+
+    This is important because on some desktop environments (e.g., Fedora KDE),
+    the IBus daemon is not started by default. Attempting to set up IBus
+    when the daemon isn't running will fail.
+
+    Returns:
+        True if ibus-daemon is running, False otherwise
+    """
+    try:
+        result = subprocess.run(
+            ["pgrep", "-x", "ibus-daemon"],
+            capture_output=True,
+            timeout=2,
+        )
+        return result.returncode == 0
+    except (subprocess.SubprocessError, FileNotFoundError):
+        return False
+
+
 def _get_expected_component_xml() -> str:
     """Generate the expected component XML content for the current installation."""
     engine_script = Path(__file__).resolve()

--- a/src/vocalinux/text_injection/text_injector.py
+++ b/src/vocalinux/text_injection/text_injector.py
@@ -16,6 +16,7 @@ from typing import Optional  # noqa: F401
 from .ibus_engine import (
     IBusTextInjector,
     is_ibus_available,
+    is_ibus_daemon_running,
 )
 
 logger = logging.getLogger(__name__)
@@ -134,18 +135,26 @@ class TextInjector:
         # Prefer IBus on both X11 and Wayland - it sends Unicode directly,
         # bypassing keyboard layout issues entirely
         if is_ibus_available():
-            try:
-                self._ibus_injector = IBusTextInjector(auto_activate=True)
-                if self.environment == DesktopEnvironment.X11:
-                    self.environment = DesktopEnvironment.X11_IBUS
-                else:
-                    self.environment = DesktopEnvironment.WAYLAND_IBUS
+            # Check if ibus-daemon is running before attempting setup
+            if not is_ibus_daemon_running():
                 logger.info(
-                    f"Using IBus for {self.environment.value} text injection (best compatibility)"
+                    "IBus daemon not running. This is normal on some desktop environments "
+                    "(e.g., KDE Plasma). Using alternative text injection method. "
+                    "For IBus setup, see: https://github.com/jatinkrmalik/vocalinux/wiki/IBus-Setup"
                 )
-                return
-            except Exception as e:
-                logger.warning(f"IBus initialization failed: {e}, trying alternatives")
+            else:
+                try:
+                    self._ibus_injector = IBusTextInjector(auto_activate=True)
+                    if self.environment == DesktopEnvironment.X11:
+                        self.environment = DesktopEnvironment.X11_IBUS
+                    else:
+                        self.environment = DesktopEnvironment.WAYLAND_IBUS
+                    logger.info(
+                        f"Using IBus for {self.environment.value} text injection (best compatibility)"
+                    )
+                    return
+                except Exception as e:
+                    logger.warning(f"IBus initialization failed: {e}, trying alternatives")
 
         if self.environment == DesktopEnvironment.X11:
             # Check for xdotool


### PR DESCRIPTION
## Summary

On desktop environments like KDE Plasma (Fedora, CachyOS, etc.), the IBus daemon is not started by default. Previously, Vocalinux would attempt to register its IBus engine anyway, leading to failures and confusing error messages.

## Changes

- Added `is_ibus_daemon_running()` function to check if `ibus-daemon` is running
- Modified `_check_dependencies()` to skip IBus setup when daemon isn't running
- Added informative log message explaining why IBus is skipped and linking to documentation

## Before

```
ERROR | Failed to register IBus engine
INFO | Using IBus for wayland-ibus text injection
# Then text injection fails silently
```

## After

```
INFO | IBus daemon not running. This is normal on some desktop environments (e.g., KDE Plasma). Using alternative text injection method. For IBus setup, see: https://github.com/jatinkrmalik/vocalinux/wiki/IBus-Setup
INFO | Using ydotool for Wayland text injection
# ydotool fallback works immediately
```

## Test plan

- [x] Test on Ubuntu/GNOME (IBus daemon running) - should use IBus as before
- [ ] Test on Fedora KDE (no IBus daemon) - should skip IBus and use ydotool
- [ ] Verify log message appears when IBus is skipped

Fixes #250