### PR TITLE
fix(evdev): improve device disconnect handling

### DIFF
--- a/src/vocalinux/ui/keyboard_backends/evdev_backend.py
+++ b/src/vocalinux/ui/keyboard_backends/evdev_backend.py
@@ -152,6 +152,8 @@ class EvdevKeyboardBackend(KeyboardBackend):
         self.double_tap_threshold = 0.3  # seconds
         self.key_pressed_devices: Set[int] = set()
 
+        self._devices_lock = threading.Lock()
+
         if not EVDEV_AVAILABLE:
             logger.error("python-evdev not available")
 
@@ -317,14 +319,23 @@ class EvdevKeyboardBackend(KeyboardBackend):
 
                     except (OSError, IOError) as e:
                         # Device was disconnected - remove it to avoid busy loop
-                        logger.debug(f"Device disconnected (fd={fd}): {e}")
+                        device_name = (
+                            device.name if device and hasattr(device, "name") else "unknown"
+                        )
+                        logger.info(f"Device disconnected: {device_name} (fd={fd})")
                         if device is not None:
                             try:
-                                self.devices.remove(device)
+                                device.close()
+                            except Exception:
+                                pass
+                            try:
+                                with self._devices_lock:
+                                    self.devices.remove(device)
                             except ValueError:
                                 pass
                         if fd in self.device_fds:
-                            self.device_fds.remove(fd)
+                            with self._devices_lock:
+                                self.device_fds.remove(fd)
                         continue
 
             except (OSError, ValueError) as e:


### PR DESCRIPTION
## Summary

Implements the review comments from PR #242:

1. **Add `device.close()`** - Close the device file descriptor before removing from the device list
2. **Thread-safe modifications** - Add `threading.Lock` to protect device list modifications  
3. **Log device name** - Log which device was disconnected for troubleshooting (e.g., "AT Translated Set 2 keyboard")

## Changes

- Added `self._devices_lock = threading.Lock()` in `__init__`
- Modified exception handler to:
  - Log device name at INFO level (includes human-readable name)
  - Call `device.close()` before removing from list
  - Use lock when modifying `self.devices` and `self.device_fds`

## Testing

- [ ] Disconnect USB keyboard while Vocalinux is running
- [ ] Verify CPU stays normal
- [ ] Verify reconnect works after device comes back
- [ ] Check logs show device name when disconnected

## Related

- Fixes #241
- Addresses review comments from PR #242