### PR TITLE
fix(installer): improve GPU detection to avoid false positives

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -660,34 +660,39 @@ detect_whispercpp_backends() {
     fi
 
     # Determine recommendation (Priority: CUDA > Vulkan > CPU)
+    # IMPORTANT: The installer WILL install dev libraries (libvulkan-dev, glslc, CUDA) later,
+    # so we recommend GPU if there's a compatible GPU regardless of current library status.
     local RECOMMENDED_BACKEND="cpu"
     local RECOMMENDED_REASON=""
     local CAN_BUILD_GPU=false
 
-    # NVIDIA with CUDA is the best option
-    if [[ "$HAS_NVIDIA_GPU" == "yes" && "$HAS_CUDA_DEV" == "true" ]]; then
+    # NVIDIA GPU - best option, uses CUDA
+    if [[ "$HAS_NVIDIA_GPU" == "yes" ]]; then
         RECOMMENDED_BACKEND="cuda"
-        RECOMMENDED_REASON="NVIDIA GPU with CUDA toolkit"
+        if [[ "$HAS_CUDA_DEV" == "true" ]]; then
+            RECOMMENDED_REASON="NVIDIA GPU with CUDA toolkit installed"
+        else
+            RECOMMENDED_REASON="NVIDIA GPU detected (CUDA toolkit will be installed)"
+        fi
         CAN_BUILD_GPU=true
-    # Vulkan is the second choice (AMD, Intel GPUs)
-    elif [[ "$HAS_VULKAN" == "yes" && "$HAS_VULKAN_DEV" == "true" && "$VULKAN_COMPATIBLE" == "compatible" ]]; then
+    # Vulkan-compatible GPU (AMD, Intel Gen8+) - second choice
+    elif [[ "$HAS_VULKAN" == "yes" && "$VULKAN_COMPATIBLE" == "compatible" ]]; then
         RECOMMENDED_BACKEND="vulkan"
-        RECOMMENDED_REASON="Vulkan GPU detected with dev libraries"
+        if [[ "$HAS_VULKAN_DEV" == "true" ]]; then
+            RECOMMENDED_REASON="Vulkan GPU detected with dev libraries"
+        else
+            RECOMMENDED_REASON="Vulkan GPU detected (dev libraries will be installed)"
+        fi
         CAN_BUILD_GPU=true
-    # Incompatible Vulkan GPU (old Intel Gen7)
+    # Vulkan GPU but compatibility unknown - allow GPU build as fallback
+    elif [[ "$HAS_VULKAN" == "yes" && "$VULKAN_COMPATIBLE" == "unknown" ]]; then
+        RECOMMENDED_BACKEND="vulkan"
+        RECOMMENDED_REASON="Possible Vulkan GPU (will verify during build)"
+        CAN_BUILD_GPU=true
+    # Incompatible Vulkan GPU (old Intel Gen7) - CPU only
     elif [[ "$VULKAN_COMPATIBLE" == "incompatible" ]]; then
         RECOMMENDED_BACKEND="cpu"
         RECOMMENDED_REASON="Incompatible GPU ($VULKAN_COMPAT_REASON) - CPU mode recommended"
-        CAN_BUILD_GPU=false
-    # NVIDIA without CUDA installed
-    elif [[ "$HAS_NVIDIA_GPU" == "yes" ]]; then
-        RECOMMENDED_BACKEND="cpu"
-        RECOMMENDED_REASON="NVIDIA GPU detected but CUDA not installed (will use CPU)"
-        CAN_BUILD_GPU=false
-    # Vulkan without dev libraries
-    elif [[ "$HAS_VULKAN" == "yes" ]]; then
-        RECOMMENDED_BACKEND="cpu"
-        RECOMMENDED_REASON="GPU detected but dev libraries missing (will use CPU)"
         CAN_BUILD_GPU=false
     else
         RECOMMENDED_BACKEND="cpu"


### PR DESCRIPTION
## Summary

Fixes false positive "incompatible GPU" warnings that appeared on modern systems with software renderers (llvmpipe) alongside real hardware GPUs.

### Problem

When a system has both:
- A modern NVIDIA GPU (e.g., RTX 5080) 
- A software renderer like llvmpipe (common in virtualized or containerized environments)

The installer would incorrectly warn about "incompatible GPU" because it checked ALL Vulkan devices, including llvmpipe which lacks `VK_KHR_16bit_storage` support.

### Changes

1. **Filter out software renderers** in `check_vulkan_gpu_compatibility()`:
   - Added patterns to skip: llvmpipe, swiftshader, lavapipe, zink, virtio, venus
   - Only evaluate real hardware GPUs for compatibility

2. **Skip Vulkan check for NVIDIA GPUs** in `detect_whispercpp_backends()`:
   - NVIDIA GPUs use CUDA, not Vulkan
   - Vulkan compatibility is irrelevant when CUDA is available

3. **Reordered backend priority**: CUDA > Vulkan > CPU

4. **Cleaner logic flow**: Only show the incompatible GPU warning for systems that would actually use Vulkan (AMD/Intel GPUs)

### Testing

- Script syntax verified with `bash -n install.sh`
- Pre-commit hooks passed

### Before (buggy)

```
[WARNING] Your GPU: NVIDIA GeForce RTX 5080, AMD Ryzen 7..., llvmpipe (missing VK_KHR_16bit_storage)
[WARNING] This Intel GPU lacks VK_KHR_16bit_storage support...
```

### After (fixed)

NVIDIA GPUs are correctly identified and no false warning is shown. The warning only appears for actual old Intel Gen7 GPUs that genuinely lack 16-bit storage support.