### PR TITLE
feat(audio): customizable sound effects with custom files

### DIFF
--- a/src/vocalinux/ui/audio_feedback.py
+++ b/src/vocalinux/ui/audio_feedback.py
@@ -10,6 +10,7 @@ import shutil
 import subprocess
 import sys
 from pathlib import Path  # noqa: F401
+from typing import Dict, Optional, Tuple
 
 logger = logging.getLogger(__name__)
 
@@ -51,6 +52,19 @@ START_SOUND = _resource_manager.get_sound_path("start_recording")
 STOP_SOUND = _resource_manager.get_sound_path("stop_recording")
 ERROR_SOUND = _resource_manager.get_sound_path("error")
 
+SOUND_EVENTS = {
+    "start": START_SOUND,
+    "stop": STOP_SOUND,
+    "error": ERROR_SOUND,
+}
+SOUND_CONFIG_KEYS = {
+    "start": "start_sound_path",
+    "stop": "stop_sound_path",
+    "error": "error_sound_path",
+}
+SUPPORTED_CUSTOM_SOUND_EXTENSIONS = {".wav", ".ogg", ".oga"}
+MAX_CUSTOM_SOUND_SIZE_BYTES = 2 * 1024 * 1024
+
 
 def _get_audio_player():
     """
@@ -63,11 +77,11 @@ def _get_audio_player():
     # but only when not running pytest (to avoid interfering with unit tests)
     if _is_ci_mode():
         logger.info("CI mode: Using mock audio player")
-        return "mock_player", ["wav"]
+        return "mock_player", ["wav", "ogg", "oga"]
 
     # Check for PulseAudio paplay (preferred)
     if shutil.which("paplay"):
-        return "paplay", ["wav"]
+        return "paplay", ["wav", "ogg", "oga"]
 
     # Check for ALSA aplay
     if shutil.which("aplay"):
@@ -75,15 +89,94 @@ def _get_audio_player():
 
     # Check for play (from SoX)
     if shutil.which("play"):
-        return "play", ["wav"]
+        return "play", ["wav", "ogg", "oga"]
 
     # Check for mplayer
     if shutil.which("mplayer"):
-        return "mplayer", ["wav"]
+        return "mplayer", ["wav", "ogg", "oga"]
 
     # No suitable player found
     logger.warning("No suitable audio player found for sound notifications")
     return None, []
+
+
+def validate_custom_sound_file(sound_path: str) -> Tuple[bool, str]:
+    if not sound_path:
+        return False, "No file selected"
+
+    if not os.path.exists(sound_path):
+        return False, "File does not exist"
+
+    extension = Path(sound_path).suffix.lower()
+    if extension not in SUPPORTED_CUSTOM_SOUND_EXTENSIONS:
+        valid_extensions = ", ".join(sorted(SUPPORTED_CUSTOM_SOUND_EXTENSIONS))
+        return False, f"Unsupported format. Use one of: {valid_extensions}"
+
+    try:
+        size_bytes = os.path.getsize(sound_path)
+    except OSError:
+        return False, "Unable to read file metadata"
+
+    if size_bytes > MAX_CUSTOM_SOUND_SIZE_BYTES:
+        max_mb = MAX_CUSTOM_SOUND_SIZE_BYTES / (1024 * 1024)
+        return False, f"File too large. Maximum allowed size is {max_mb:.0f} MB"
+
+    return True, ""
+
+
+def _get_sound_effects_settings() -> Dict[str, object]:
+    try:
+        from .config_manager import ConfigManager
+
+        return ConfigManager().get_sound_effects_settings()
+    except Exception as e:
+        logger.debug(f"Falling back to default sound effects settings: {e}")
+        return {
+            "enabled": True,
+            "start_sound_path": "",
+            "stop_sound_path": "",
+            "error_sound_path": "",
+        }
+
+
+def get_sound_path_for_event(event_name: str) -> Optional[str]:
+    default_sound = SOUND_EVENTS.get(event_name)
+    if not default_sound:
+        logger.warning(f"Unknown sound event: {event_name}")
+        return None
+
+    sound_settings = _get_sound_effects_settings()
+    if not sound_settings.get("enabled", True):
+        return None
+
+    custom_key = SOUND_CONFIG_KEYS[event_name]
+    custom_path = str(sound_settings.get(custom_key, "") or "").strip()
+    if not custom_path:
+        return default_sound
+
+    is_valid, error_message = validate_custom_sound_file(custom_path)
+    if not is_valid:
+        logger.warning(f"Ignoring invalid custom sound for '{event_name}': {error_message}")
+        return default_sound
+
+    player, formats = _get_audio_player()
+    if player:
+        extension = Path(custom_path).suffix.lower().lstrip(".")
+        if extension not in formats:
+            logger.warning(
+                f"Custom '{event_name}' sound format '.{extension}' is not supported by {player}. "
+                "Falling back to default sound."
+            )
+            return default_sound
+
+    return custom_path
+
+
+def play_custom_sound(sound_path: str) -> bool:
+    is_valid, _ = validate_custom_sound_file(sound_path)
+    if not is_valid:
+        return False
+    return _play_sound_file(sound_path)
 
 
 def _play_sound_file(sound_path):
@@ -96,6 +189,9 @@ def _play_sound_file(sound_path):
     Returns:
         bool: True if sound was played successfully, False otherwise
     """
+    if not sound_path:
+        return False
+
     if not os.path.exists(sound_path):
         logger.warning(f"Sound file not found: {sound_path}")
         return False
@@ -110,6 +206,11 @@ def _play_sound_file(sound_path):
         player = "ci_test_player"
 
     if not player:
+        return False
+
+    extension = Path(sound_path).suffix.lower().lstrip(".")
+    if formats and extension not in formats:
+        logger.warning(f"Audio player {player} does not support '.{extension}' files")
         return False
 
     # In CI mode, just pretend we played the sound and return success
@@ -163,7 +264,7 @@ def play_start_sound():
     Returns:
         bool: True if sound was played successfully, False otherwise
     """
-    return _play_sound_file(START_SOUND)
+    return _play_sound_file(get_sound_path_for_event("start"))
 
 
 def play_stop_sound():
@@ -173,7 +274,7 @@ def play_stop_sound():
     Returns:
         bool: True if sound was played successfully, False otherwise
     """
-    return _play_sound_file(STOP_SOUND)
+    return _play_sound_file(get_sound_path_for_event("stop"))
 
 
 def play_error_sound():
@@ -183,4 +284,4 @@ def play_error_sound():
     Returns:
         bool: True if sound was played successfully, False otherwise
     """
-    return _play_sound_file(ERROR_SOUND)
+    return _play_sound_file(get_sound_path_for_event("error"))

--- a/src/vocalinux/ui/config_manager.py
+++ b/src/vocalinux/ui/config_manager.py
@@ -32,6 +32,12 @@ DEFAULT_CONFIG = {
         "device_index": None,  # Audio input device index (None for system default)
         "device_name": None,  # Saved device name for display/reference
     },
+    "sound_effects": {
+        "enabled": True,
+        "start_sound_path": "",
+        "stop_sound_path": "",
+        "error_sound_path": "",
+    },
     "shortcuts": {
         "toggle_recognition": "ctrl+ctrl",  # Double-tap modifier key
         "mode": "toggle",  # "toggle" or "push_to_talk"
@@ -51,6 +57,8 @@ DEFAULT_CONFIG = {
         "wayland_mode": False,
     },
 }
+
+SOUND_EFFECT_EVENTS = {"start", "stop", "error"}
 
 
 class ConfigManager:
@@ -276,6 +284,30 @@ class ConfigManager:
         for key, value in settings.items():
             self.config["speech_recognition"][key] = value
         logger.info(f"Updated speech recognition settings: {settings}")
+
+    def get_sound_effects_settings(self) -> Dict[str, Any]:
+        sound_settings = self.config.get("sound_effects", {})
+        return {
+            "enabled": bool(sound_settings.get("enabled", True)),
+            "start_sound_path": sound_settings.get("start_sound_path", ""),
+            "stop_sound_path": sound_settings.get("stop_sound_path", ""),
+            "error_sound_path": sound_settings.get("error_sound_path", ""),
+        }
+
+    def set_sound_effect_enabled(self, enabled: bool):
+        if "sound_effects" not in self.config:
+            self.config["sound_effects"] = {}
+        self.config["sound_effects"]["enabled"] = bool(enabled)
+
+    def set_sound_effect_path(self, event: str, path: str):
+        if event not in SOUND_EFFECT_EVENTS:
+            raise ValueError(f"Unsupported sound event: {event}")
+
+        if "sound_effects" not in self.config:
+            self.config["sound_effects"] = {}
+
+        key = f"{event}_sound_path"
+        self.config["sound_effects"][key] = path or ""
 
     def _update_dict_recursive(self, target: Dict, source: Dict):
         """

--- a/src/vocalinux/ui/settings_dialog.py
+++ b/src/vocalinux/ui/settings_dialog.py
@@ -36,6 +36,7 @@ from ..utils.whispercpp_model_info import (
 )
 from ..utils.whispercpp_model_info import get_recommended_model as get_recommended_whispercpp_model
 from ..utils.whispercpp_model_info import is_model_downloaded as is_whispercpp_model_downloaded
+from . import audio_feedback  # noqa: E402
 from .keyboard_backends import (  # noqa: E402
     SHORTCUT_DISPLAY_NAMES,
     SHORTCUT_MODES,
@@ -916,9 +917,175 @@ class SettingsDialog(Gtk.Dialog):
         self.audio_tab.pack_start(group, False, False, 0)
         self.audio_tab.pack_start(self.audio_test_status, False, False, 0)
 
+        self._build_sound_feedback_section()
+
         # Populate devices
         self._populate_audio_devices()
         self.audio_device_combo.connect("changed", self._on_audio_device_changed)
+
+    def _build_sound_feedback_section(self):
+        sound_group = PreferencesGroup(
+            title="Sound Feedback",
+            description="Customize start, stop, and error sounds for voice typing",
+        )
+
+        self.sound_effects_switch = Gtk.Switch()
+        sound_enabled_row = PreferenceRow(
+            title="Enable Sound Effects",
+            subtitle="Play sounds when recording starts, stops, or errors occur",
+            widget=self.sound_effects_switch,
+        )
+        sound_group.add_row(sound_enabled_row)
+
+        self.start_sound_label = Gtk.Label(label="Default", xalign=0)
+        self.start_sound_label.set_max_width_chars(24)
+        self.start_sound_label.set_ellipsize(Pango.EllipsizeMode.END)
+        start_row = PreferenceRow(
+            title="Start Sound",
+            subtitle="Played when voice typing starts",
+            widget=self._create_sound_controls("start", self.start_sound_label),
+        )
+        sound_group.add_row(start_row)
+
+        self.stop_sound_label = Gtk.Label(label="Default", xalign=0)
+        self.stop_sound_label.set_max_width_chars(24)
+        self.stop_sound_label.set_ellipsize(Pango.EllipsizeMode.END)
+        stop_row = PreferenceRow(
+            title="Stop Sound",
+            subtitle="Played when voice typing stops",
+            widget=self._create_sound_controls("stop", self.stop_sound_label),
+        )
+        sound_group.add_row(stop_row)
+
+        self.error_sound_label = Gtk.Label(label="Default", xalign=0)
+        self.error_sound_label.set_max_width_chars(24)
+        self.error_sound_label.set_ellipsize(Pango.EllipsizeMode.END)
+        error_row = PreferenceRow(
+            title="Error Sound",
+            subtitle="Played when recording fails or an error occurs",
+            widget=self._create_sound_controls("error", self.error_sound_label),
+        )
+        sound_group.add_row(error_row)
+
+        self.sound_feedback_status = Gtk.Label(label="", use_markup=True, xalign=0)
+        self.sound_feedback_status.set_margin_start(16)
+        self.sound_feedback_status.set_margin_top(4)
+        self.sound_feedback_status.get_style_context().add_class("status-info")
+
+        self.audio_tab.pack_start(sound_group, False, False, 0)
+        self.audio_tab.pack_start(self.sound_feedback_status, False, False, 0)
+
+        self.sound_effects_switch.connect("state-set", self._on_sound_effects_toggled)
+
+    def _create_sound_controls(self, event: str, label: Gtk.Label) -> Gtk.Box:
+        controls = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=6)
+        controls.pack_start(label, False, False, 0)
+
+        choose_button = Gtk.Button(label="Choose")
+        choose_button.connect("clicked", lambda _widget: self._on_choose_sound(event))
+        controls.pack_start(choose_button, False, False, 0)
+
+        preview_button = Gtk.Button(label="Preview")
+        preview_button.connect("clicked", lambda _widget: self._on_preview_sound(event))
+        controls.pack_start(preview_button, False, False, 0)
+
+        reset_button = Gtk.Button(label="Reset")
+        reset_button.connect("clicked", lambda _widget: self._on_reset_sound(event))
+        controls.pack_start(reset_button, False, False, 0)
+
+        return controls
+
+    def _on_sound_effects_toggled(self, _widget, state):
+        if self._initializing or self._applying_settings:
+            return False
+
+        self.config_manager.set_sound_effect_enabled(bool(state))
+        self.config_manager.save_settings()
+        status = "enabled" if state else "disabled"
+        self.sound_feedback_status.set_markup(
+            f"<span foreground='#26a269'>Sound effects {status}</span>"
+        )
+        return False
+
+    def _show_sound_feedback_error(self, message: str):
+        dialog = Gtk.MessageDialog(
+            transient_for=self,
+            flags=0,
+            message_type=Gtk.MessageType.ERROR,
+            buttons=Gtk.ButtonsType.OK,
+            text="Invalid Sound File",
+        )
+        dialog.format_secondary_text(message)
+        dialog.run()
+        dialog.destroy()
+
+    def _on_choose_sound(self, event: str):
+        chooser = Gtk.FileChooserDialog(
+            title="Select Custom Sound",
+            transient_for=self,
+            action=Gtk.FileChooserAction.OPEN,
+        )
+        chooser.add_buttons(
+            Gtk.STOCK_CANCEL,
+            Gtk.ResponseType.CANCEL,
+            Gtk.STOCK_OPEN,
+            Gtk.ResponseType.OK,
+        )
+
+        audio_filter = Gtk.FileFilter()
+        audio_filter.set_name("Supported audio files")
+        audio_filter.add_pattern("*.wav")
+        audio_filter.add_pattern("*.ogg")
+        audio_filter.add_pattern("*.oga")
+        chooser.add_filter(audio_filter)
+
+        response = chooser.run()
+        selected_path = chooser.get_filename() if response == Gtk.ResponseType.OK else None
+        chooser.destroy()
+
+        if not selected_path:
+            return
+
+        is_valid, error_message = audio_feedback.validate_custom_sound_file(selected_path)
+        if not is_valid:
+            self._show_sound_feedback_error(error_message)
+            return
+
+        self.config_manager.set_sound_effect_path(event, selected_path)
+        self.config_manager.save_settings()
+        self._update_sound_feedback_labels()
+        self.sound_feedback_status.set_markup(
+            "<span foreground='#26a269'>Custom sound saved</span>"
+        )
+
+    def _on_reset_sound(self, event: str):
+        self.config_manager.set_sound_effect_path(event, "")
+        self.config_manager.save_settings()
+        self._update_sound_feedback_labels()
+        self.sound_feedback_status.set_markup("<i>Sound reset to default</i>")
+
+    def _on_preview_sound(self, event: str):
+        sound_path = audio_feedback.get_sound_path_for_event(event)
+        if not sound_path:
+            self.sound_feedback_status.set_markup("<i>Sound effects are currently disabled</i>")
+            return
+
+        if audio_feedback.play_custom_sound(sound_path):
+            self.sound_feedback_status.set_markup("<i>Preview played</i>")
+        else:
+            self.sound_feedback_status.set_markup(
+                "<span foreground='#c01c28'>Could not play preview</span>"
+            )
+
+    def _update_sound_feedback_labels(self):
+        sound_settings = self.config_manager.get_sound_effects_settings()
+        for event, label in [
+            ("start", self.start_sound_label),
+            ("stop", self.stop_sound_label),
+            ("error", self.error_sound_label),
+        ]:
+            path_value = str(sound_settings.get(f"{event}_sound_path", "") or "").strip()
+            label.set_text(os.path.basename(path_value) if path_value else "Default")
 
     def _build_general_section(self):
         """Build the General section with autostart and UI settings."""
@@ -1385,6 +1552,10 @@ class SettingsDialog(Gtk.Dialog):
 
         self.autostart_switch.set_active(autostart_enabled)
         self.start_minimized_switch.set_active(start_minimized)
+
+        sound_settings = self.config_manager.get_sound_effects_settings()
+        self.sound_effects_switch.set_active(sound_settings.get("enabled", True))
+        self._update_sound_feedback_labels()
 
         # Populate engine combo with only available engines
         available_engines = get_available_engines()

--- a/tests/test_audio_feedback.py
+++ b/tests/test_audio_feedback.py
@@ -71,7 +71,7 @@ class TestAudioFeedback(unittest.TestCase):
 
             # Verify the correct player was detected
             self.assertEqual(player, "paplay")
-            self.assertEqual(formats, ["wav"])
+            self.assertEqual(formats, ["wav", "ogg", "oga"])
 
     def test_get_audio_player_alsa(self):
         """Test detecting ALSA player."""
@@ -119,7 +119,7 @@ class TestAudioFeedback(unittest.TestCase):
 
             # Verify the correct player was detected
             self.assertEqual(player, "play")
-            self.assertEqual(formats, ["wav"])
+            self.assertEqual(formats, ["wav", "ogg", "oga"])
 
     def test_get_audio_player_mplayer(self):
         """Test detecting MPlayer."""
@@ -143,7 +143,7 @@ class TestAudioFeedback(unittest.TestCase):
 
             # Verify the correct player was detected
             self.assertEqual(player, "mplayer")
-            self.assertEqual(formats, ["wav"])
+            self.assertEqual(formats, ["wav", "ogg", "oga"])
 
     def test_get_audio_player_none(self):
         """Test behavior when no audio player is available."""
@@ -362,3 +362,100 @@ class TestAudioFeedback(unittest.TestCase):
                 mock_popen.assert_called_once()
                 args, _ = mock_popen.call_args
                 self.assertEqual(args[0][0], "ci_test_player")
+
+    def test_validate_custom_sound_file_success(self):
+        import vocalinux.ui.audio_feedback as audio_feedback
+
+        with patch.object(audio_feedback.os.path, "exists", return_value=True), patch.object(
+            audio_feedback.os.path, "getsize", return_value=1024
+        ):
+            is_valid, error = audio_feedback.validate_custom_sound_file("/tmp/custom.wav")
+
+        self.assertTrue(is_valid)
+        self.assertEqual(error, "")
+
+    def test_validate_custom_sound_file_invalid_extension(self):
+        import vocalinux.ui.audio_feedback as audio_feedback
+
+        with patch.object(audio_feedback.os.path, "exists", return_value=True), patch.object(
+            audio_feedback.os.path, "getsize", return_value=1024
+        ):
+            is_valid, error = audio_feedback.validate_custom_sound_file("/tmp/custom.mp3")
+
+        self.assertFalse(is_valid)
+        self.assertIn("Unsupported format", error)
+
+    def test_validate_custom_sound_file_too_large(self):
+        import vocalinux.ui.audio_feedback as audio_feedback
+
+        with patch.object(audio_feedback.os.path, "exists", return_value=True), patch.object(
+            audio_feedback.os.path,
+            "getsize",
+            return_value=audio_feedback.MAX_CUSTOM_SOUND_SIZE_BYTES + 1,
+        ):
+            is_valid, error = audio_feedback.validate_custom_sound_file("/tmp/custom.wav")
+
+        self.assertFalse(is_valid)
+        self.assertIn("File too large", error)
+
+    def test_get_sound_path_for_event_defaults(self):
+        import vocalinux.ui.audio_feedback as audio_feedback
+
+        with patch.object(
+            audio_feedback,
+            "_get_sound_effects_settings",
+            return_value={
+                "enabled": True,
+                "start_sound_path": "",
+                "stop_sound_path": "",
+                "error_sound_path": "",
+            },
+        ):
+            self.assertEqual(
+                audio_feedback.get_sound_path_for_event("start"),
+                audio_feedback.START_SOUND,
+            )
+            self.assertEqual(
+                audio_feedback.get_sound_path_for_event("stop"),
+                audio_feedback.STOP_SOUND,
+            )
+            self.assertEqual(
+                audio_feedback.get_sound_path_for_event("error"),
+                audio_feedback.ERROR_SOUND,
+            )
+
+    def test_get_sound_path_for_event_custom_sound(self):
+        import vocalinux.ui.audio_feedback as audio_feedback
+
+        with patch.object(
+            audio_feedback,
+            "_get_sound_effects_settings",
+            return_value={
+                "enabled": True,
+                "start_sound_path": "/tmp/custom-start.wav",
+                "stop_sound_path": "",
+                "error_sound_path": "",
+            },
+        ), patch.object(
+            audio_feedback,
+            "validate_custom_sound_file",
+            return_value=(True, ""),
+        ), patch.object(
+            audio_feedback,
+            "_get_audio_player",
+            return_value=("paplay", ["wav", "ogg", "oga"]),
+        ):
+            self.assertEqual(
+                audio_feedback.get_sound_path_for_event("start"),
+                "/tmp/custom-start.wav",
+            )
+
+    def test_get_sound_path_for_event_when_disabled(self):
+        import vocalinux.ui.audio_feedback as audio_feedback
+
+        with patch.object(
+            audio_feedback,
+            "_get_sound_effects_settings",
+            return_value={"enabled": False},
+        ):
+            self.assertIsNone(audio_feedback.get_sound_path_for_event("start"))

--- a/tests/test_config_manager.py
+++ b/tests/test_config_manager.py
@@ -49,6 +49,8 @@ class TestConfigManager(unittest.TestCase):
         """Test initialization with default configuration."""
         config_manager = ConfigManager()
         self.assertEqual(config_manager.config, DEFAULT_CONFIG)
+        self.assertIn("sound_effects", config_manager.config)
+        self.assertTrue(config_manager.config["sound_effects"]["enabled"])
         self.mock_logger.info.assert_called_with(
             f"Config file not found at {self.temp_config_file}. Using defaults."
         )
@@ -407,3 +409,30 @@ class TestConfigManager(unittest.TestCase):
         config_manager = ConfigManager()
         self.assertEqual(config_manager.config["shortcuts"]["toggle_recognition"], "alt+alt")
         self.assertEqual(config_manager.config["shortcuts"]["mode"], "push_to_talk")
+
+    def test_get_sound_effects_settings_defaults(self):
+        config_manager = ConfigManager()
+        sound_settings = config_manager.get_sound_effects_settings()
+
+        self.assertTrue(sound_settings["enabled"])
+        self.assertEqual(sound_settings["start_sound_path"], "")
+        self.assertEqual(sound_settings["stop_sound_path"], "")
+        self.assertEqual(sound_settings["error_sound_path"], "")
+
+    def test_set_sound_effect_enabled(self):
+        config_manager = ConfigManager()
+        config_manager.set_sound_effect_enabled(False)
+        self.assertFalse(config_manager.config["sound_effects"]["enabled"])
+
+    def test_set_sound_effect_path(self):
+        config_manager = ConfigManager()
+        config_manager.set_sound_effect_path("start", "/tmp/custom-start.wav")
+        self.assertEqual(
+            config_manager.config["sound_effects"]["start_sound_path"],
+            "/tmp/custom-start.wav",
+        )
+
+    def test_set_sound_effect_path_invalid_event(self):
+        config_manager = ConfigManager()
+        with self.assertRaises(ValueError):
+            config_manager.set_sound_effect_path("unknown", "/tmp/invalid.wav")


### PR DESCRIPTION
## Summary
- Add a full sound feedback customization flow in Settings so users can enable/disable sound effects, choose custom start/stop/error files, preview them, and reset to defaults.
- Add validation and safe fallback logic for custom sounds (supported extensions, max size, invalid file handling, per-player compatibility checks) while preserving reliable default behavior.
- Extend config and tests to cover sound effect settings persistence and custom sound selection/validation behavior.

## Verification
- `PYTHONPATH=\"/home/clawd-user/github/vocalinux/src\" pytest`
- `PYTHONPATH=\"/home/clawd-user/github/vocalinux/src\" make lint`
- `PYTHONPATH=\"/home/clawd-user/github/vocalinux/src\" pytest tests/test_audio_feedback.py tests/test_config_manager.py tests/test_settings_dialog.py tests/test_recognition_manager.py`

Closes #283