### PR TITLE
fix(text-injection): use register_component for IBus engine activation

### DIFF
--- a/src/vocalinux/text_injection/ibus_engine.py
+++ b/src/vocalinux/text_injection/ibus_engine.py
@@ -68,6 +68,24 @@ ENGINE_LONGNAME = "Vocalinux"
 ENGINE_DESCRIPTION = "Vocalinux voice dictation (use as default input method)"
 COMPONENT_NAME = "org.freedesktop.IBus.Vocalinux"
 
+# Shared metadata used by component XML, --xml output, and runtime registration.
+# Kept in one place to prevent drift between the three consumers.
+ENGINE_RANK = 50
+_ENGINE_META = {
+    "language": "other",
+    "license": "GPL-3.0",
+    "author": "Vocalinux",
+    "icon": "audio-input-microphone",
+    "layout": "default",
+}
+_COMPONENT_META = {
+    "version": "1.0",
+    "license": "GPL-3.0",
+    "author": "Vocalinux",
+    "homepage": "https://github.com/jatinkrmalik/vocalinux",
+    "textdomain": "vocalinux",
+}
+
 
 def ensure_ibus_dir() -> None:
     """Ensure the IBus data directory exists with secure permissions."""
@@ -210,32 +228,38 @@ def start_ibus_daemon():
         return False
 
 
+def _get_exec_command() -> str:
+    """Return the engine exec command for component XML and runtime registration."""
+    engine_script = Path(__file__).resolve()
+    return f"{sys.executable} {engine_script} --ibus"
+
+
 def _get_expected_component_xml() -> str:
     """Generate the expected component XML content for the current installation."""
-    engine_script = Path(__file__).resolve()
-    python_exec = sys.executable
+    e = _ENGINE_META
+    c = _COMPONENT_META
 
     return f"""<?xml version="1.0" encoding="utf-8"?>
 <component>
     <name>{COMPONENT_NAME}</name>
     <description>{ENGINE_DESCRIPTION}</description>
-    <exec>{python_exec} {engine_script} --ibus</exec>
-    <version>1.0</version>
-    <author>Vocalinux</author>
-    <license>GPL-3.0</license>
-    <homepage>https://github.com/jatinkrmalik/vocalinux</homepage>
-    <textdomain>vocalinux</textdomain>
+    <exec>{_get_exec_command()}</exec>
+    <version>{c['version']}</version>
+    <author>{c['author']}</author>
+    <license>{c['license']}</license>
+    <homepage>{c['homepage']}</homepage>
+    <textdomain>{c['textdomain']}</textdomain>
     <engines>
         <engine>
             <name>{ENGINE_NAME}</name>
-            <language>other</language>
-            <license>GPL-3.0</license>
-            <author>Vocalinux</author>
-            <icon>audio-input-microphone</icon>
-            <layout>default</layout>
             <longname>{ENGINE_LONGNAME}</longname>
+            <language>{e['language']}</language>
+            <license>{e['license']}</license>
+            <author>{e['author']}</author>
+            <icon>{e['icon']}</icon>
+            <layout>{e['layout']}</layout>
             <description>{ENGINE_DESCRIPTION}</description>
-            <rank>50</rank>
+            <rank>{ENGINE_RANK}</rank>
         </engine>
     </engines>
 </component>
@@ -644,28 +668,24 @@ class VocalinuxEngineApplication:
         if exec_by_ibus:
             # IBus launched us — it already knows about our component,
             # just claim the well-known D-Bus name.
-            self.bus.request_name(COMPONENT_NAME, 0)
+            if not self.bus.request_name(COMPONENT_NAME, 0):
+                logger.error("bus.request_name() failed")
+                raise RuntimeError("Failed to acquire IBus D-Bus name")
         else:
             # Launched by Vocalinux directly — register the full component
             # so IBus discovers our engine without having launched us.
             component = IBus.Component(
                 name=COMPONENT_NAME,
                 description=ENGINE_DESCRIPTION,
-                version="1.0",
-                license="GPL-3.0",
-                author="Vocalinux",
-                homepage="https://github.com/jatinkrmalik/vocalinux",
-                textdomain="vocalinux",
+                command_line=_get_exec_command(),
+                **_COMPONENT_META,
             )
             engine_desc = IBus.EngineDesc(
                 name=ENGINE_NAME,
                 longname=ENGINE_LONGNAME,
                 description=ENGINE_DESCRIPTION,
-                language="other",
-                license="GPL-3.0",
-                author="Vocalinux",
-                icon="audio-input-microphone",
-                layout="default",
+                rank=ENGINE_RANK,
+                **_ENGINE_META,
             )
             component.add_engine(engine_desc)
             if not self.bus.register_component(component):
@@ -903,19 +923,21 @@ def _get_engines_xml() -> str:
     ``ibus list-engine`` to discover available engines.  The expected
     output is a bare ``<engines>`` block printed to stdout.
     """
+    e = _ENGINE_META
+
     return f"""<engines>
     <engine>
         <name>{ENGINE_NAME}</name>
         <longname>{ENGINE_LONGNAME}</longname>
-        <language>other</language>
-        <license>GPL-3.0</license>
-        <author>Vocalinux</author>
-        <icon>audio-input-microphone</icon>
-        <layout>default</layout>
+        <language>{e['language']}</language>
+        <license>{e['license']}</license>
+        <author>{e['author']}</author>
+        <icon>{e['icon']}</icon>
+        <layout>{e['layout']}</layout>
         <layout_variant />
         <layout_option />
         <description>{ENGINE_DESCRIPTION}</description>
-        <rank>50</rank>
+        <rank>{ENGINE_RANK}</rank>
     </engine>
 </engines>"""
 


### PR DESCRIPTION
Human disclaimer: This PR implements a fix that I found with the assistance of Claude Opus 4.6. As noted in issue #303 I personally have zero prior experience with IBus and am relying on AI debugging and diagnosis. I believe this is a valid fix, and I have taken care to try to make sure this has no cross-distro side effects. If there are any mistakes or hallucinations with this PR feel free to ping me and I will chastise the agent accordingly. This fix is in place on my personal system (Fedora 43 Workstation) and allows Vocalinux to work properly for me with no known system modification required.

## Description

Fix IBus engine activation so that text injection works correctly on non-US keyboard layouts and Wayland.

The core issue: when Vocalinux launches the IBus engine process itself (via `start_engine_process()`), the engine called `bus.request_name()` to register with IBus. This is only sufficient when IBus launched the process and already knows about the engine. Standalone-launched engines must call `bus.register_component()` with a full component/engine description so IBus can discover the factory. Without this, `set_global_engine('vocalinux')` timed out because IBus had no factory to route to, causing a fallback to xdotool which garbles text on non-US layouts.

The fix follows the same pattern used by ibus-typing-booster (the reference Python IBus engine shipped with Fedora):
- **`--ibus` flag**: when IBus launches the engine, use `request_name()` (it already knows the component)
- **No flag** (Vocalinux launches it): use `register_component()` to announce the engine
- **`--xml` flag**: print the `<engines>` XML block to stdout and exit (standard IBus engine discovery protocol)
- **`<exec>` line**: updated to include `--ibus` so IBus-launched processes take the correct path

Connection guards (`is_connected()` / `get_connection()` checks) were also added so the engine process fails fast with a clear error instead of silently registering a broken factory.

## Related Issue

Fixes #303

This is a refinement of the IBus engine introduced in PR #211 by @AntoineMontane. The original implementation works on some system configurations, but on others (e.g., Fedora 43 / GNOME Wayland) the standalone-launched engine process isn't discoverable by IBus without `register_component`.

See also: #164, #199, #292 — related issues where non-US layouts produce garbled text due to the IBus engine not activating on certain configurations.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Changes

- Change `VocalinuxEngineApplication.__init__` to accept `exec_by_ibus` parameter:
  - `True` (IBus launched): `bus.request_name()` (existing behavior)
  - `False` (Vocalinux launched): `bus.register_component()` with full component/engine description
- Add `--ibus` argv handling in `main()`, passed through to `VocalinuxEngineApplication`
- Add `--ibus` to the `<exec>` line in `_get_expected_component_xml()` so IBus-launched processes use `request_name`
- Add `_get_engines_xml()` and `--xml` argv handling in `main()` for IBus engine discovery protocol compliance
- Add `is_connected()` and `get_connection()` guards with clear error messages
- Add `register_component()` return value check

## Testing

- Verified on Fedora 43, GNOME/Wayland, US Dvorak layout
- Engine activation succeeds without timeout (previously timed out after 5s)
- End-to-end: dictated text appears correctly on Dvorak (previously garbled via xdotool fallback)
- `ibus_engine.py --xml` outputs valid `<engines>` XML and exits immediately
- `ibus write-cache && ibus list-engine | grep vocalinux` finds the engine
- Existing unit tests pass

## Checklist

- [x] My code follows the code style of this project (black, isort)
- [ ] I have updated the documentation accordingly (no user facing documentation required)
- [x] I have added tests to cover my changes
- [x] All new and existing tests pass locally
- [x] Pre-commit hooks pass

## Additional Notes

- The `register_component()` / `request_name()` pattern is identical to what ibus-typing-booster uses (maintained by Red Hat). The API has been stable since IBus 1.4; all current distributions ship IBus 1.5.26+.
- These changes are backwards-compatible: `--xml` and `--ibus` handlers only activate when those flags are explicitly passed, and `exec_by_ibus` defaults to `False`.
- The `--xml` handler is a protocol compliance measure. With the current inline component XML, IBus reads engine definitions directly from disk. However, supporting `--xml` follows the standard IBus engine convention and enables exec-based discovery if needed in the future.
