### PR TITLE
fix(shortcuts): pass configured mode to KeyboardShortcutManager on startup

### DIFF
--- a/src/vocalinux/ui/tray_indicator.py
+++ b/src/vocalinux/ui/tray_indicator.py
@@ -79,11 +79,12 @@ class TrayIndicator:
         self.config_manager = ConfigManager()  # Added: Initialize ConfigManager
         self._syncing_autostart_menu = False
 
-        # Get configured shortcut from config
+        # Get configured shortcut and mode from config
         shortcut = self.config_manager.get("shortcuts", "toggle_recognition", "ctrl+ctrl")
+        mode = self.config_manager.get("shortcuts", "mode", "toggle")
 
-        # Initialize keyboard shortcut manager with configured shortcut
-        self.shortcut_manager = KeyboardShortcutManager(shortcut=shortcut)
+        # Initialize keyboard shortcut manager with configured shortcut and mode
+        self.shortcut_manager = KeyboardShortcutManager(shortcut=shortcut, mode=mode)
 
         # Ensure icon directory exists
         os.makedirs(ICON_DIR, exist_ok=True)


### PR DESCRIPTION
## Summary

- Fix push-to-talk shortcuts not binding on app restart by passing the configured `mode` to `KeyboardShortcutManager` during initialization in `TrayIndicator.__init__`

## Root Cause

In `tray_indicator.py`, the `KeyboardShortcutManager` was created with only the `shortcut` parameter but **not** the `mode` parameter:

```python
# Before (broken)
shortcut = self.config_manager.get("shortcuts", "toggle_recognition", "ctrl+ctrl")
self.shortcut_manager = KeyboardShortcutManager(shortcut=shortcut)
```

This caused the backend to always default to `"toggle"` mode regardless of the user's saved configuration. When a user configured push-to-talk mode, saved it, and restarted the app:

1. Config correctly had `"mode": "push_to_talk"`
2. `_setup_keyboard_shortcuts()` registered press/release callbacks (correct)
3. But the backend's internal `_mode` remained `"toggle"` (the default), so the backend ran double-tap logic instead of push-to-talk logic
4. The press/release callbacks never fired → shortcuts appeared "lost"

## Fix

```python
# After (fixed)
shortcut = self.config_manager.get("shortcuts", "toggle_recognition", "ctrl+ctrl")
mode = self.config_manager.get("shortcuts", "mode", "toggle")
self.shortcut_manager = KeyboardShortcutManager(shortcut=shortcut, mode=mode)
```

## Testing

- All 107 keyboard/shortcut/tray tests pass
- All 543 non-flaky tests pass (7 pre-existing failures in `test_main.py` due to instance lock — unrelated)

Fixes #296