### PR TITLE
feat(audio): add simple sound effects toggle

### DIFF
--- a/src/vocalinux/ui/audio_feedback.py
+++ b/src/vocalinux/ui/audio_feedback.py
@@ -52,6 +52,15 @@ STOP_SOUND = _resource_manager.get_sound_path("stop_recording")
 ERROR_SOUND = _resource_manager.get_sound_path("error")
 
 
+def _is_sound_effects_enabled() -> bool:
+    try:
+        from .config_manager import ConfigManager
+
+        return ConfigManager().is_sound_effects_enabled()
+    except Exception:
+        return True
+
+
 def _get_audio_player():
     """
     Determine the best available audio player on the system.
@@ -157,30 +166,12 @@ def _play_sound_file(sound_path):
 
 
 def play_start_sound():
-    """
-    Play the sound for starting voice recognition.
-
-    Returns:
-        bool: True if sound was played successfully, False otherwise
-    """
-    return _play_sound_file(START_SOUND)
+    return _play_sound_file(START_SOUND) if _is_sound_effects_enabled() else False
 
 
 def play_stop_sound():
-    """
-    Play the sound for stopping voice recognition.
-
-    Returns:
-        bool: True if sound was played successfully, False otherwise
-    """
-    return _play_sound_file(STOP_SOUND)
+    return _play_sound_file(STOP_SOUND) if _is_sound_effects_enabled() else False
 
 
 def play_error_sound():
-    """
-    Play the sound for error notifications.
-
-    Returns:
-        bool: True if sound was played successfully, False otherwise
-    """
-    return _play_sound_file(ERROR_SOUND)
+    return _play_sound_file(ERROR_SOUND) if _is_sound_effects_enabled() else False

--- a/src/vocalinux/ui/config_manager.py
+++ b/src/vocalinux/ui/config_manager.py
@@ -32,6 +32,9 @@ DEFAULT_CONFIG = {
         "device_index": None,  # Audio input device index (None for system default)
         "device_name": None,  # Saved device name for display/reference
     },
+    "sound_effects": {
+        "enabled": True,  # Play sounds for recording start/stop/error
+    },
     "shortcuts": {
         "toggle_recognition": "ctrl+ctrl",  # Double-tap modifier key
         "mode": "toggle",  # "toggle" or "push_to_talk"
@@ -279,6 +282,16 @@ class ConfigManager:
         for key, value in settings.items():
             self.config["speech_recognition"][key] = value
         logger.info(f"Updated speech recognition settings: {settings}")
+
+    def is_sound_effects_enabled(self) -> bool:
+        """Check if sound effects are enabled."""
+        return bool(self.config.get("sound_effects", {}).get("enabled", True))
+
+    def set_sound_effects_enabled(self, enabled: bool):
+        """Enable or disable sound effects."""
+        if "sound_effects" not in self.config:
+            self.config["sound_effects"] = {}
+        self.config["sound_effects"]["enabled"] = enabled
 
     def _update_dict_recursive(self, target: Dict, source: Dict):
         """

--- a/src/vocalinux/ui/settings_dialog.py
+++ b/src/vocalinux/ui/settings_dialog.py
@@ -917,6 +917,21 @@ class SettingsDialog(Gtk.Dialog):
         self.audio_tab.pack_start(group, False, False, 0)
         self.audio_tab.pack_start(self.audio_test_status, False, False, 0)
 
+        # Sound Effects section
+        sound_group = PreferencesGroup(title="Sound Effects")
+        self.sound_effects_switch = Gtk.Switch()
+        self.sound_effects_switch.set_tooltip_text(
+            "Play sounds when recording starts, stops, or encounters errors"
+        )
+        sound_row = PreferenceRow(
+            title="Enable Sound Effects",
+            subtitle="Play audio feedback for recording events",
+            widget=self.sound_effects_switch,
+        )
+        sound_group.add_row(sound_row)
+        self.audio_tab.pack_start(sound_group, False, False, 0)
+        self.sound_effects_switch.connect("state-set", self._on_sound_effects_toggled)
+
         # Populate devices
         self._populate_audio_devices()
         self.audio_device_combo.connect("changed", self._on_audio_device_changed)
@@ -1001,6 +1016,17 @@ class SettingsDialog(Gtk.Dialog):
         self.config_manager.set("text_injection", "copy_to_clipboard", enabled)
         self.config_manager.save_settings()
         logger.info(f"Copy to clipboard {'enabled' if enabled else 'disabled'}")
+        return False
+
+    def _on_sound_effects_toggled(self, widget, state):
+        if self._initializing or self._applying_settings:
+            return False
+
+        enabled = bool(state)
+        logger.info(f"Sound effects toggled: {enabled}")
+        self.config_manager.set_sound_effects_enabled(enabled)
+        self.config_manager.save_settings()
+        logger.info(f"Sound effects {'enabled' if enabled else 'disabled'}")
         return False
 
     def _build_engine_section(self):
@@ -1426,6 +1452,7 @@ class SettingsDialog(Gtk.Dialog):
         self.autostart_switch.set_active(autostart_enabled)
         self.start_minimized_switch.set_active(start_minimized)
         self.copy_to_clipboard_switch.set_active(copy_to_clipboard)
+        self.sound_effects_switch.set_active(self.config_manager.is_sound_effects_enabled())
 
         # Populate engine combo with only available engines
         available_engines = get_available_engines()

--- a/tests/test_audio_feedback.py
+++ b/tests/test_audio_feedback.py
@@ -362,3 +362,38 @@ class TestAudioFeedback(unittest.TestCase):
                 mock_popen.assert_called_once()
                 args, _ = mock_popen.call_args
                 self.assertEqual(args[0][0], "ci_test_player")
+
+    def test_play_start_sound_when_disabled(self):
+        """Test that start sound is not played when sound effects are disabled."""
+        import vocalinux.ui.audio_feedback as audio_feedback
+
+        with patch.object(audio_feedback, "_is_sound_effects_enabled", return_value=False):
+            result = audio_feedback.play_start_sound()
+            self.assertFalse(result)
+
+    def test_play_stop_sound_when_disabled(self):
+        """Test that stop sound is not played when sound effects are disabled."""
+        import vocalinux.ui.audio_feedback as audio_feedback
+
+        with patch.object(audio_feedback, "_is_sound_effects_enabled", return_value=False):
+            result = audio_feedback.play_stop_sound()
+            self.assertFalse(result)
+
+    def test_play_error_sound_when_disabled(self):
+        """Test that error sound is not played when sound effects are disabled."""
+        import vocalinux.ui.audio_feedback as audio_feedback
+
+        with patch.object(audio_feedback, "_is_sound_effects_enabled", return_value=False):
+            result = audio_feedback.play_error_sound()
+            self.assertFalse(result)
+
+    def test_is_sound_effects_enabled_returns_true_on_error(self):
+        """Test that sound effects are enabled by default when config is unavailable."""
+        import vocalinux.ui.audio_feedback as audio_feedback
+
+        with patch(
+            "vocalinux.ui.config_manager.ConfigManager",
+            side_effect=Exception("No config"),
+        ):
+            result = audio_feedback._is_sound_effects_enabled()
+            self.assertTrue(result)

--- a/tests/test_config_manager.py
+++ b/tests/test_config_manager.py
@@ -407,3 +407,25 @@ class TestConfigManager(unittest.TestCase):
         config_manager = ConfigManager()
         self.assertEqual(config_manager.config["shortcuts"]["toggle_recognition"], "alt+alt")
         self.assertEqual(config_manager.config["shortcuts"]["mode"], "push_to_talk")
+
+    def test_sound_effects_enabled_by_default(self):
+        """Test that sound effects are enabled by default."""
+        config_manager = ConfigManager()
+        self.assertTrue(config_manager.is_sound_effects_enabled())
+
+    def test_set_sound_effects_enabled(self):
+        """Test setting sound effects enabled state."""
+        config_manager = ConfigManager()
+        config_manager.set_sound_effects_enabled(False)
+        self.assertFalse(config_manager.is_sound_effects_enabled())
+        config_manager.set_sound_effects_enabled(True)
+        self.assertTrue(config_manager.is_sound_effects_enabled())
+
+    def test_sound_effects_config_persistence(self):
+        """Test that sound effects setting persists across ConfigManager instances."""
+        config_manager = ConfigManager()
+        config_manager.set_sound_effects_enabled(False)
+        config_manager.save_config()
+
+        new_config_manager = ConfigManager()
+        self.assertFalse(new_config_manager.is_sound_effects_enabled())


### PR DESCRIPTION
## Summary
- Add a single toggle switch to enable/disable sound effects in the Audio settings
- Simpler alternative to full sound customization (PR #287) while covering the most common use case
- Power users can still customize sounds via `scripts/generate_sounds.py` as documented in README

## Changes
- Add `sound_effects.enabled` config option (default: `true`)
- Add toggle switch in Audio settings tab under "Sound Effects" section
- Add `is_sound_effects_enabled()` and `set_sound_effects_enabled()` to ConfigManager
- Update `play_start_sound()`, `play_stop_sound()`, `play_error_sound()` to check enabled state

## Screenshots
New toggle in Audio settings:
```
[Sound Effects]
  [✓] Enable Sound Effects  - Play audio feedback for recording events
```

## Testing
- All 49 tests pass (4 new audio tests, 3 new config tests)
- Tests cover: disabled state, config persistence, default fallback on error

## Verification
```bash
PYTHONPATH=src pytest tests/test_audio_feedback.py tests/test_config_manager.py -v
```

Closes #283

🤖 Generated with [Claude Code](https://claude.ai/code)