### PR TITLE
fix(clipboard): copy to clipboard after IBus text injection

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1121,21 +1121,21 @@ install_system_dependencies() {
     fi
 
     # Define package names for different distributions
-    local APT_PACKAGES_UBUNTU="python3-pip python3-gi python3-gi-cairo gir1.2-gtk-3.0 gir1.2-appindicator3-0.1 gir1.2-ibus-1.0 libgirepository1.0-dev python3-dev build-essential portaudio19-dev python3-venv pkg-config wget curl unzip vulkan-tools libvulkan-dev $VULKAN_SHADER_PKG"
-    local APT_PACKAGES_DEBIAN_BASE="python3-pip python3-gi python3-gi-cairo gir1.2-gtk-3.0 gir1.2-ibus-1.0 libcairo2-dev python3-dev build-essential portaudio19-dev python3-venv pkg-config wget curl unzip vulkan-tools libvulkan-dev $VULKAN_SHADER_PKG"
+    local APT_PACKAGES_UBUNTU="python3-pip python3-gi python3-gi-cairo gir1.2-gtk-3.0 gir1.2-appindicator3-0.1 gir1.2-ibus-1.0 libgirepository1.0-dev python3-dev build-essential portaudio19-dev python3-venv pkg-config wget curl unzip vulkan-tools libvulkan-dev $VULKAN_SHADER_PKG xclip wl-clipboard"
+    local APT_PACKAGES_DEBIAN_BASE="python3-pip python3-gi python3-gi-cairo gir1.2-gtk-3.0 gir1.2-ibus-1.0 libcairo2-dev python3-dev build-essential portaudio19-dev python3-venv pkg-config wget curl unzip vulkan-tools libvulkan-dev $VULKAN_SHADER_PKG xclip wl-clipboard"
     local APT_PACKAGES_DEBIAN_11_12="$APT_PACKAGES_DEBIAN_BASE libgirepository1.0-dev gir1.2-ayatanaappindicator3-0.1"
     local APT_PACKAGES_DEBIAN_13_PLUS="$APT_PACKAGES_DEBIAN_BASE libgirepository-2.0-dev gir1.2-ayatanaappindicator3-0.1"
-    local DNF_PACKAGES="python3-pip python3-gobject gtk3 libappindicator-gtk3 ibus-devel gobject-introspection-devel python3-devel portaudio-devel python3-virtualenv pkg-config wget curl unzip vulkan-tools vulkan-loader-devel glslang"
-    local PACMAN_PACKAGES="python-pip python-gobject gtk3 libappindicator-gtk3 ibus gobject-introspection python-cairo portaudio python-virtualenv pkg-config wget curl unzip base-devel vulkan-tools vulkan-headers glslang"
-    local ZYPPER_PACKAGES="python3-pip python3-gobject python3-gobject-cairo gtk3 libappindicator-gtk3 ibus-devel gobject-introspection-devel python3-devel portaudio-devel python3-virtualenv pkg-config wget curl unzip vulkan-tools vulkan-devel glslang"
+    local DNF_PACKAGES="python3-pip python3-gobject gtk3 libappindicator-gtk3 ibus-devel gobject-introspection-devel python3-devel portaudio-devel python3-virtualenv pkg-config wget curl unzip vulkan-tools vulkan-loader-devel glslang xclip wl-clipboard"
+    local PACMAN_PACKAGES="python-pip python-gobject gtk3 libappindicator-gtk3 ibus gobject-introspection python-cairo portaudio python-virtualenv pkg-config wget curl unzip base-devel vulkan-tools vulkan-headers glslang xclip wl-clipboard"
+    local ZYPPER_PACKAGES="python3-pip python3-gobject python3-gobject-cairo gtk3 libappindicator-gtk3 ibus-devel gobject-introspection-devel python3-devel portaudio-devel python3-virtualenv pkg-config wget curl unzip vulkan-tools vulkan-devel glslang xclip wl-clipboard"
     # Gentoo uses Portage and different package naming convention
-    local EMERGE_PACKAGES="dev-python/pygobject:3 x11-libs/gtk+:3 dev-libs/libayatana-appindicator media-libs/portaudio dev-lang/python:3.8 pkgconf dev-util/glslang"
+    local EMERGE_PACKAGES="dev-python/pygobject:3 x11-libs/gtk+:3 dev-libs/libayatana-appindicator media-libs/portaudio dev-lang/python:3.8 pkgconf dev-util/glslang x11-misc/xclip gui-apps/wl-clipboard"
     # Alpine Linux uses apk and has musl libc
-    local APK_PACKAGES="py3-gobject3 py3-pip gtk+3.0 py3-cairo portaudio-dev py3-virtualenv pkgconf wget curl unzip glslang vulkan-tools"
+    local APK_PACKAGES="py3-gobject3 py3-pip gtk+3.0 py3-cairo portaudio-dev py3-virtualenv pkgconf wget curl unzip glslang vulkan-tools xclip wl-clipboard"
     # Void Linux uses xbps
-    local XBPS_PACKAGES="python3-pip python3-gobject gtk+3 libappindicator-gtk3 gobject-introspection portaudio-devel python3-devel pkg-config wget curl unzip glslang Vulkan-Tools"
+    local XBPS_PACKAGES="python3-pip python3-gobject gtk+3 libappindicator-gtk3 gobject-introspection portaudio-devel python3-devel pkg-config wget curl unzip glslang Vulkan-Tools xclip wl-clipboard"
     # Solus uses eopkg
-    local EOPKG_PACKAGES="python3-pip python3-gobject gtk3 libappindicator gobject-introspection-devel portaudio-devel python3-virtualenv pkg-config wget curl unzip glslang vulkan-tools"
+    local EOPKG_PACKAGES="python3-pip python3-gobject gtk3 libappindicator gobject-introspection-devel portaudio-devel python3-virtualenv pkg-config wget curl unzip glslang vulkan-tools xclip wl-clipboard"
 
     local MISSING_PACKAGES=""
     local INSTALL_CMD=""

--- a/src/vocalinux/text_injection/text_injector.py
+++ b/src/vocalinux/text_injection/text_injector.py
@@ -442,7 +442,13 @@ class TextInjector:
                 or self.environment == DesktopEnvironment.X11_IBUS
             ):
                 if self._ibus_injector is not None:
-                    return self._ibus_injector.inject_text(text)
+                    result = self._ibus_injector.inject_text(text)
+                    if result:
+                        logger.info("Text injection completed successfully")
+                        if self._should_copy_to_clipboard():
+                            self._copy_to_clipboard(text)
+                            logger.debug("Text also copied to clipboard (setting enabled)")
+                    return result
                 else:
                     logger.error("IBus injector not initialized")
                     return False


### PR DESCRIPTION
## Summary

- **Fix IBus clipboard copy bug**: The IBus text injection path (`WAYLAND_IBUS` / `X11_IBUS`) had an early `return` that skipped the clipboard copy logic entirely. Now stores the injection result, copies to clipboard if the setting is enabled, then returns.
- **Add clipboard tools to install.sh**: Added `xclip` and `wl-clipboard` to all distro package lists (Ubuntu, Debian, Fedora, Arch, openSUSE, Gentoo, Alpine, Void, Solus) so clipboard functionality works out of the box.

## Root Cause

In `text_injector.py` line 445, the IBus path did:
```python
return self._ibus_injector.inject_text(text)
```
This returned immediately, never reaching the clipboard copy code at lines 474-476. The xdotool and wayland tool paths correctly fell through to the clipboard logic, but IBus users never got clipboard copy.

## Changes

### `src/vocalinux/text_injection/text_injector.py`
- Store IBus injection result instead of returning immediately
- Copy to clipboard when injection succeeds and setting is enabled
- Add success log message consistent with other injection paths

### `install.sh`
- Add `xclip` and `wl-clipboard` to all 9 distro package lists
- Uses distro-appropriate package names (e.g., `x11-misc/xclip` and `gui-apps/wl-clipboard` for Gentoo)

## Testing

- All 565 tests pass (7 pre-existing `single_instance` lock failures unrelated to this change)
- All pre-commit hooks pass (black, isort, flake8, trailing whitespace, EOF)