### PR TITLE
fix(ci): upgrade deploy-website jobs to Node.js 24

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -135,6 +135,8 @@ jobs:
     name: Deploy Website
     runs-on: ubuntu-latest
     needs: [build-and-release, publish-pypi]
+    env:
+      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -142,7 +144,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '24'
           cache: 'npm'
           cache-dependency-path: './web/package-lock.json'
 

--- a/.github/workflows/unified-pipeline.yml
+++ b/.github/workflows/unified-pipeline.yml
@@ -234,13 +234,15 @@ jobs:
       github.ref == 'refs/heads/main' &&
       needs.changes.outputs.deploy_website == 'true' &&
       needs.web-build.result == 'success'
+    env:
+      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
     steps:
       - uses: actions/checkout@v4
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '24'
           cache: 'npm'
           cache-dependency-path: './web/package-lock.json'
 


### PR DESCRIPTION
## Summary

Fixes the Node.js 20 deprecation warning seen in the `pages-build-deployment` job:

> Node.js 20 actions are deprecated. The following actions are running on Node.js 20 and may not work as expected: `actions/deploy-pages@v4`. Actions will be forced to run with Node.js 24 by default starting **June 2nd, 2026**.

## Root Cause

The `pages-build-deployment` workflow is GitHub-managed (not in this repo) and internally uses `actions/deploy-pages@v4` on Node.js 20. It's triggered whenever our workflows push to the `gh-pages` branch via `peaceiris/actions-gh-pages`.

## Changes

Both `deploy-website` jobs (`release.yml` and `unified-pipeline.yml`):

- `node-version: '20'` → `node-version: '24'`
- Added `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true` job-level env variable, which opts the runner (including the downstream GitHub-managed `pages-build-deployment` workflow) into Node.js 24 — as recommended in the [GitHub changelog](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/)

## Testing

No functional change to deployment logic. The Next.js build and `peaceiris/actions-gh-pages` publish step are unaffected.