### PR TITLE
fix(install): dynamically resolve latest release tag via GitHub API

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -174,7 +174,7 @@ while [[ $# -gt 0 ]]; do
             echo "  --test           Run tests after installation"
             echo "  --venv-dir=PATH  Specify custom virtual environment directory"
             echo "  --skip-models    Skip downloading speech models during installation"
-            echo "  --tag=TAG        Install specific release tag (default: v0.8.0-beta)"
+            echo "  --tag=TAG        Install specific release tag (default: latest release)"
             echo "  --help           Show this help message"
             echo ""
             echo "Examples:"
@@ -215,7 +215,24 @@ echo ""
 
 check_running_processes
 
-INSTALL_TAG="${INSTALL_TAG:-v0.8.0-beta}"
+resolve_install_tag() {
+    if [ -n "$INSTALL_TAG" ]; then
+        return
+    fi
+    if command_exists curl; then
+        local latest
+        latest=$(curl -fsSL --connect-timeout 5 \
+            "https://api.github.com/repos/jatinkrmalik/vocalinux/releases/latest" \
+            2>/dev/null | grep '"tag_name"' | head -1 | cut -d'"' -f4)
+        if [ -n "$latest" ]; then
+            INSTALL_TAG="$latest"
+            return
+        fi
+    fi
+    INSTALL_TAG="v0.9.0-beta"
+}
+
+resolve_install_tag
 
 # Check if running from within the vocalinux repo or remotely (via curl)
 REPO_URL="https://github.com/jatinkrmalik/vocalinux.git"
@@ -1073,7 +1090,7 @@ if [[ "$INTERACTIVE_MODE" == "yes" ]]; then
     if [ ! -t 0 ]; then
         print_error "Interactive mode requires a terminal (TTY)."
         print_error "Please run from a terminal, or use automatic mode:"
-        print_error "  curl -fsSL https://raw.githubusercontent.com/jatinkrmalik/vocalinux/v0.8.0-beta/install.sh | bash"
+        print_error "  curl -fsSL https://raw.githubusercontent.com/jatinkrmalik/vocalinux/main/install.sh | bash"
         exit 1
     fi
 


### PR DESCRIPTION
## Problem

`install.sh` had the release tag hardcoded in three places:

- Line 177: help text (`--tag=TAG` default)
- Line 218: `INSTALL_TAG="${INSTALL_TAG:-v0.8.0-beta}"`
- Line 1076: error message URL

This meant every release required a manual bump to `install.sh`, and users running the curl command would still install the old version if they hadn't pulled the latest script.

## Fix

Replaced the hardcoded default with a `resolve_install_tag()` function:

```bash
resolve_install_tag() {
    if [ -n "$INSTALL_TAG" ]; then
        return  # --tag= was explicitly passed, respect it
    fi
    # Query GitHub API for the latest release
    if command_exists curl; then
        local latest
        latest=$(curl -fsSL --connect-timeout 5 \
            "https://api.github.com/repos/jatinkrmalik/vocalinux/releases/latest" \
            2>/dev/null | grep '"tag_name"' | head -1 | cut -d'"' -f4)
        if [ -n "$latest" ]; then
            INSTALL_TAG="$latest"
            return
        fi
    fi
    INSTALL_TAG="v0.9.0-beta"  # fallback if API unreachable
}
```

**Behaviour:**
| Scenario | Result |
|---|---|
| `curl .../install.sh \| bash` | Fetches latest tag from GitHub API |
| `bash install.sh --tag=v0.8.0-beta` | Respects the explicit `--tag` flag |
| GitHub API unreachable | Falls back to `v0.9.0-beta` |

The error message URL was also updated to point to `main` (always latest) instead of a pinned tag.