### PR TITLE
fix(docs): point all install curl URLs to main/install.sh

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ Here are some screenshots showcasing Vocalinux in action:
 Our new interactive installer guides you through setup with intelligent hardware detection:
 
 ```bash
-curl -fsSL raw.githubusercontent.com/jatinkrmalik/vocalinux/v0.9.0-beta/install.sh -o /tmp/vl.sh && bash /tmp/vl.sh
+curl -fsSL raw.githubusercontent.com/jatinkrmalik/vocalinux/main/install.sh -o /tmp/vl.sh && bash /tmp/vl.sh
 ```
 
 **Choose your engine:**
@@ -131,25 +131,25 @@ The installer will:
 - **Download the appropriate model** (~39MB for whisper.cpp tiny)
 - **Install in ~1-2 minutes** (vs 5-10 min with old Whisper)
 
-> **Note**: Installs v0.9.0-beta. For other versions, check [GitHub Releases](https://github.com/jatinkrmalik/vocalinux/releases).
+> **Note**: Always installs the latest release. For a specific version, check [GitHub Releases](https://github.com/jatinkrmalik/vocalinux/releases).
 
 ### Installation Options
 
 **Default (whisper.cpp - recommended):**
 ```bash
-curl -fsSL raw.githubusercontent.com/jatinkrmalik/vocalinux/v0.9.0-beta/install.sh -o /tmp/vl.sh && bash /tmp/vl.sh
+curl -fsSL raw.githubusercontent.com/jatinkrmalik/vocalinux/main/install.sh -o /tmp/vl.sh && bash /tmp/vl.sh
 ```
 Fastest installation (~1-2 min), universal GPU support via Vulkan.
 
 **Whisper (OpenAI) - if you prefer PyTorch:**
 ```bash
-curl -fsSL raw.githubusercontent.com/jatinkrmalik/vocalinux/v0.9.0-beta/install.sh -o /tmp/vl.sh && bash /tmp/vl.sh --engine=whisper
+curl -fsSL raw.githubusercontent.com/jatinkrmalik/vocalinux/main/install.sh -o /tmp/vl.sh && bash /tmp/vl.sh --engine=whisper
 ```
 NVIDIA GPU only (~5-10 min, downloads PyTorch + CUDA).
 
 **VOSK only - for low-RAM systems:**
 ```bash
-curl -fsSL raw.githubusercontent.com/jatinkrmalik/vocalinux/v0.9.0-beta/install.sh -o /tmp/vl.sh && bash /tmp/vl.sh --engine=vosk
+curl -fsSL raw.githubusercontent.com/jatinkrmalik/vocalinux/main/install.sh -o /tmp/vl.sh && bash /tmp/vl.sh --engine=vosk
 ```
 Lightweight option (~40MB), works on systems with 4GB RAM.
 

--- a/docs/DISTRO_COMPATIBILITY.md
+++ b/docs/DISTRO_COMPATIBILITY.md
@@ -225,7 +225,7 @@ If `vocalinux-gui` fails to start:
 
 For the best experience with automatic dependency handling, use the official installer:
 ```bash
-curl -fsSL https://raw.githubusercontent.com/jatinkrmalik/vocalinux/v0.8.0-beta/install.sh | bash
+curl -fsSL https://raw.githubusercontent.com/jatinkrmalik/vocalinux/main/install.sh | bash
 ```
 
 This installer automatically detects your distribution and installs all required system packages.

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -7,10 +7,10 @@ This guide provides detailed instructions for installing Vocalinux on Linux syst
 ### One-liner Installation (Recommended)
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/jatinkrmalik/vocalinux/v0.9.0-beta/install.sh | bash
+curl -fsSL https://raw.githubusercontent.com/jatinkrmalik/vocalinux/main/install.sh | bash
 ```
 
-> **Note**: Installs v0.9.0-beta with **whisper.cpp** (our default engine). For other versions, check [GitHub Releases](https://github.com/jatinkrmalik/vocalinux/releases).
+> **Note**: Always installs the latest release with **whisper.cpp** (our default engine). For a specific version, check [GitHub Releases](https://github.com/jatinkrmalik/vocalinux/releases).
 
 That's it! The installer handles everything automatically:
 - ✅ Installs whisper.cpp (~1-2 minutes, no heavy dependencies!)
@@ -508,7 +508,7 @@ Already have Vocalinux installed? See the [Update Guide](UPDATE.md) for instruct
 
 Quick update command:
 ```bash
-curl -fsSL https://raw.githubusercontent.com/jatinkrmalik/vocalinux/v0.9.0-beta/install.sh | bash
+curl -fsSL https://raw.githubusercontent.com/jatinkrmalik/vocalinux/main/install.sh | bash
 ```
 
 ## Getting Help

--- a/docs/UPDATE.md
+++ b/docs/UPDATE.md
@@ -79,7 +79,7 @@ See the [full changelog](https://github.com/jatinkrmalik/vocalinux/releases/tag/
 Simply re-run the installation command:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/jatinkrmalik/vocalinux/v0.9.0-beta/install.sh | bash
+curl -fsSL https://raw.githubusercontent.com/jatinkrmalik/vocalinux/main/install.sh | bash
 ```
 
 The installer will:
@@ -129,7 +129,7 @@ If your update doesn't go smoothly, try a clean reinstall:
 ./uninstall.sh
 
 # Reinstall fresh
-curl -fsSL https://raw.githubusercontent.com/jatinkrmalik/vocalinux/v0.8.0-beta/install.sh | bash
+curl -fsSL https://raw.githubusercontent.com/jatinkrmalik/vocalinux/main/install.sh | bash
 ```
 
 ### Old Version Still Running

--- a/src/vocalinux/main.py
+++ b/src/vocalinux/main.py
@@ -141,7 +141,7 @@ def check_dependencies():
             logger.error("")
             logger.error("For the best experience, use the recommended installer:")
             logger.error(
-                "  curl -fsSL https://raw.githubusercontent.com/jatinkrmalik/vocalinux/v0.9.0-beta/install.sh | bash"
+                "  curl -fsSL https://raw.githubusercontent.com/jatinkrmalik/vocalinux/main/install.sh | bash"
             )
         return False
 

--- a/tests/distro-testing-checklist.md
+++ b/tests/distro-testing-checklist.md
@@ -40,7 +40,7 @@ Use this checklist when testing Vocalinux on a new Linux distribution.
 ### Standard Installation
 - [ ] Download installer
   ```bash
-  curl -fsSL https://raw.githubusercontent.com/jatinkrmalik/vocalinux/v0.8.0-beta/install.sh -o /tmp/vl.sh
+  curl -fsSL https://raw.githubusercontent.com/jatinkrmalik/vocalinux/main/install.sh -o /tmp/vl.sh
   ```
 
 - [ ] Run installer

--- a/web/src/app/page.tsx
+++ b/web/src/app/page.tsx
@@ -35,18 +35,18 @@ import { CodeBlock } from "@/components/code-block";
 import { useInView } from "react-intersection-observer";
 
 // The one-liner install command (split into three lines for display)
-// Downloads install.sh from the specific release tag to ensure version consistency
-const getInstallCommands = (latestRelease: string) => ({
-  interactiveInstallCommand: `curl -fsSL raw.githubusercontent.com/jatinkrmalik/vocalinux/${latestRelease}/install.sh -o /tmp/vl.sh && bash /tmp/vl.sh --interactive`,
+// Always uses main/install.sh — the installer dynamically resolves the latest release tag via GitHub API
+const installCommands = {
+  interactiveInstallCommand: `curl -fsSL raw.githubusercontent.com/jatinkrmalik/vocalinux/main/install.sh -o /tmp/vl.sh && bash /tmp/vl.sh --interactive`,
 
-  oneClickInstallCommand: `curl -fsSL raw.githubusercontent.com/jatinkrmalik/vocalinux/${latestRelease}/install.sh -o /tmp/vl.sh && bash /tmp/vl.sh`,
+  oneClickInstallCommand: `curl -fsSL raw.githubusercontent.com/jatinkrmalik/vocalinux/main/install.sh -o /tmp/vl.sh && bash /tmp/vl.sh`,
 
-  oneClickInstallWhisper: `curl -fsSL raw.githubusercontent.com/jatinkrmalik/vocalinux/${latestRelease}/install.sh -o /tmp/vl.sh && bash /tmp/vl.sh --engine=whisper`,
+  oneClickInstallWhisper: `curl -fsSL raw.githubusercontent.com/jatinkrmalik/vocalinux/main/install.sh -o /tmp/vl.sh && bash /tmp/vl.sh --engine=whisper`,
 
-  oneClickInstallVosk: `curl -fsSL raw.githubusercontent.com/jatinkrmalik/vocalinux/${latestRelease}/install.sh -o /tmp/vl.sh && bash /tmp/vl.sh --engine=vosk`,
+  oneClickInstallVosk: `curl -fsSL raw.githubusercontent.com/jatinkrmalik/vocalinux/main/install.sh -o /tmp/vl.sh && bash /tmp/vl.sh --engine=vosk`,
 
-  uninstallCommand: `curl -fsSL https://raw.githubusercontent.com/jatinkrmalik/vocalinux/${latestRelease}/uninstall.sh -o /tmp/vul.sh && bash /tmp/vul.sh`,
-});
+  uninstallCommand: `curl -fsSL https://raw.githubusercontent.com/jatinkrmalik/vocalinux/main/uninstall.sh -o /tmp/vul.sh && bash /tmp/vul.sh`,
+};
 
 const homeJsonLd = [
   {
@@ -233,11 +233,9 @@ const FadeInSection = ({
 
 export default function HomePage() {
   const [stars, setStars] = useState<number | null>(null);
-  const [latestRelease, setLatestRelease] = useState<string>("main"); // Default to main for safety
   const [mobileMenuOpen, setMobileMenuOpen] = useState(false);
 
   useEffect(() => {
-    // Fetch actual GitHub stars and latest release
     fetch("https://api.github.com/repos/jatinkrmalik/vocalinux")
       .then((res) => res.json())
       .then((data) => {
@@ -249,19 +247,6 @@ export default function HomePage() {
         // Fallback if API fails
         setStars(null);
       });
-
-    // Fetch latest release tag for stable install commands
-    fetch("https://api.github.com/repos/jatinkrmalik/vocalinux/releases/latest")
-      .then((res) => res.json())
-      .then((data) => {
-        if (data.tag_name) {
-          setLatestRelease(data.tag_name);
-        }
-      })
-      .catch(() => {
-        // Fallback to main if API fails
-        setLatestRelease("main");
-      });
   }, []);
 
   const navLinks = [
@@ -272,8 +257,6 @@ export default function HomePage() {
     { href: "#faq", label: "FAQ" },
   ];
 
-  // Get install commands based on the latest release
-  const installCommands = getInstallCommands(latestRelease);
   const { interactiveInstallCommand, oneClickInstallCommand, oneClickInstallWhisper, oneClickInstallVosk, uninstallCommand } = installCommands;
 
   return (


### PR DESCRIPTION
## Problem

`install.sh` on `main` was updated (PR #313) to dynamically resolve the latest release tag via GitHub API. However, all install command URLs across docs and the website were still pointing to versioned tag URLs (e.g. `v0.9.0-beta/install.sh`, `v0.8.0-beta/install.sh`) — which run the **old hardcoded installer** that installs the wrong version.

## Solution

Point all curl install commands to `main/install.sh`. The script itself now handles version resolution, so there's no benefit to pinning the URL to a specific tag.

## Files Changed

| File | Change |
|------|--------|
| `README.md` | 4 URLs → `main` + note text updated to "Always installs the latest release" |
| `docs/INSTALL.md` | 2 URLs + note text |
| `docs/UPDATE.md` | 2 URLs (v0.9.0-beta + v0.8.0-beta both updated) |
| `docs/DISTRO_COMPATIBILITY.md` | 1 URL |
| `tests/distro-testing-checklist.md` | 1 URL |
| `src/vocalinux/main.py` | 1 URL (shown in install error message) |
| `web/src/app/page.tsx` | Removed dynamic GitHub releases API fetch; hardcode `main` in all install/uninstall commands |

## Website Note

The website was dynamically fetching the latest release tag and constructing install URLs like `v0.9.0-beta/install.sh`. Since `v0.9.0-beta/install.sh` still has the old hardcoded version, this was broken. The GitHub releases API fetch is removed — install commands now use `main/install.sh` directly, consistent with everything else.

The `uninstall.sh` URL is also updated to `main/uninstall.sh` for the same reason.