### PR TITLE
fix(install): handle curl|bash piped stdin by redirecting to /dev/tty

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -113,11 +113,17 @@ HAS_VULKAN="no"
 VULKAN_DEVICE=""
 
 # Detect if running non-interactively (e.g., via curl | bash)
-# Interactive mode is now default, so only auto-detect non-interactive for curl pipes
+# If stdin is a pipe but /dev/tty exists, redirect stdin so user input works normally.
+# If no terminal is available at all (headless/CI), fall back to automatic mode.
 if [ ! -t 0 ]; then
-    # When piped via curl, we'll still try to be interactive if possible
-    # User can force non-interactive with --auto
-    INTERACTIVE_MODE="ask"
+    if [ -e /dev/tty ] && [ -r /dev/tty ]; then
+        exec < /dev/tty
+        INTERACTIVE_MODE="ask"
+    else
+        AUTO_MODE="yes"
+        INTERACTIVE_MODE="no"
+        NON_INTERACTIVE="yes"
+    fi
 fi
 
 while [[ $# -gt 0 ]]; do
@@ -1089,8 +1095,8 @@ if [[ "$INTERACTIVE_MODE" == "yes" ]]; then
     # Check if we have a TTY (required for interactive mode)
     if [ ! -t 0 ]; then
         print_error "Interactive mode requires a terminal (TTY)."
-        print_error "Please run from a terminal, or use automatic mode:"
-        print_error "  curl -fsSL https://raw.githubusercontent.com/jatinkrmalik/vocalinux/main/install.sh | bash"
+        print_error "Download and run the installer directly from a terminal:"
+        print_error "  curl -fsSL https://raw.githubusercontent.com/jatinkrmalik/vocalinux/main/install.sh -o /tmp/vl.sh && bash /tmp/vl.sh"
         exit 1
     fi
 


### PR DESCRIPTION
## Problem

Running the one-liner installer via pipe fails with an unhelpful error:

```
[ERROR] Interactive mode requires a terminal (TTY).
[ERROR] Please run from a terminal, or use automatic mode:
[ERROR]   curl -fsSL .../main/install.sh | bash   ← same broken command!
curl: (23) Failure writing output to destination
```

**Root cause**: When running `curl ... | bash`, bash's stdin (fd 0) is the pipe — not the terminal. The script detects this and sets `INTERACTIVE_MODE="ask"`, but the subsequent `read` prompt also reads from the pipe (EOF/garbage), so it defaults to interactive mode, which then immediately errors out because there's still no TTY.

## Fix

When stdin is a pipe but `/dev/tty` is accessible (i.e. the user is in a real terminal session), redirect stdin with `exec < /dev/tty`. This makes all subsequent `read` calls work against the actual terminal, so the guided install experience works correctly with `curl | bash`.

If `/dev/tty` is not accessible at all (headless environment, CI, SSH without TTY), fall back to automatic mode instead of erroring.

Also fix the error message which was suggesting the exact same `curl | bash` command that just failed.

## Behaviour After Fix

| Scenario | Before | After |
|----------|--------|-------|
| `curl \| bash` in a terminal | ❌ errors immediately | ✅ shows interactive mode prompt |
| Headless / CI (no `/dev/tty`) | ❌ errors | ✅ auto mode (whisper.cpp defaults) |
| `bash /tmp/vl.sh` directly | ✅ works | ✅ works (unchanged) |
| `bash /tmp/vl.sh --auto` | ✅ works | ✅ works (unchanged) |