### PR TITLE
docs: add star history chart to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -400,6 +400,10 @@ If you find Vocalinux useful, please consider:
 
 This project is licensed under the **GNU General Public License v3.0** - see the [LICENSE](LICENSE) file for details.
 
+## Star Chart
+
+[![Star History Chart](https://api.star-history.com/svg?repos=jatinkrmalik/vocalinux&type=Date)](https://star-history.com/#jatinkrmalik/vocalinux&Date)
+
 ---
 
 <p align="center">


### PR DESCRIPTION
## Summary

- Adds a **Star Chart** section at the end of the README with an auto-updating chart from [star-history.com](https://star-history.com)
- The chart renders as an SVG showing stars over time, and links to the interactive view
- Placed after the License section, before the closing footer