### PR TITLE
ci: add path-based filtering to skip unnecessary builds

### DIFF
--- a/.github/workflows/distro-test-matrix.yml
+++ b/.github/workflows/distro-test-matrix.yml
@@ -3,8 +3,24 @@ name: Distro Test Matrix
 on:
   push:
     branches: [ main, master ]
+    paths:
+      - 'install.sh'
+      - 'scripts/**'
+      - 'pyproject.toml'
+      - 'setup.py'
+      - 'setup.cfg'
+      - 'src/vocalinux/version.py'
+      - '.github/workflows/distro-test-matrix.yml'
   pull_request:
     branches: [ main, master ]
+    paths:
+      - 'install.sh'
+      - 'scripts/**'
+      - 'pyproject.toml'
+      - 'setup.py'
+      - 'setup.cfg'
+      - 'src/vocalinux/version.py'
+      - '.github/workflows/distro-test-matrix.yml'
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/unified-pipeline.yml
+++ b/.github/workflows/unified-pipeline.yml
@@ -32,7 +32,7 @@ jobs:
           filters: |
             web:
               - 'web/**'
-              - '.github/workflows/**'
+              - '.github/workflows/unified-pipeline.yml'
             python:
               - 'src/**'
               - 'tests/**'
@@ -42,7 +42,7 @@ jobs:
               - 'requirements*.txt'
               - 'Makefile'
               - '.pre-commit-config.yaml'
-              - '.github/workflows/**'
+              - '.github/workflows/unified-pipeline.yml'
       - name: Check if website should deploy
         id: deploy_check
         env:


### PR DESCRIPTION
## Summary

- **Tighten `unified-pipeline.yml` path filters**: Replace blanket `.github/workflows/**` glob with `.github/workflows/unified-pipeline.yml` in both `web` and `python` change-detection filters. Previously, editing *any* workflow file (e.g., `nightly.yml`, `release.yml`) triggered the full Python lint → test → web build matrix unnecessarily.
- **Add path filters to `distro-test-matrix.yml`**: This workflow had zero path filtering — all 4 distro containers (Ubuntu 22.04/24.04, Debian 12, Fedora 39) spun up on every push/PR, even for README-only or website-only changes. Now it only runs when installer, scripts, packaging, or version files change.

## What triggers what (after this PR)

| Change | Python lint/test | Web build | Distro matrix |
|--------|:---:|:---:|:---:|
| `src/**`, `tests/**`, `pyproject.toml` | ✅ | ❌ | ❌ |
| `web/**` | ❌ | ✅ | ❌ |
| `install.sh`, `scripts/**` | ❌ | ❌ | ✅ |
| `README.md`, `docs/**`, `CONTRIBUTING.md` | ❌ | ❌ | ❌ |
| `nightly.yml`, `release.yml` | ❌ | ❌ | ❌ |
| `unified-pipeline.yml` | ✅ | ✅ | ❌ |
| `distro-test-matrix.yml` | ❌ | ❌ | ✅ |
| `workflow_dispatch` (manual) | ✅ | ✅ | ✅ |

## Why

CI was burning minutes on every push regardless of what changed. Doc-only PRs triggered the full Python test matrix across 4 Python versions + 4 distro containers — ~8 unnecessary jobs.