### PR TITLE
Add double-tap Super key shortcut and --settings CLI option to open settings

### DIFF
--- a/src/vocalinux/main.py
+++ b/src/vocalinux/main.py
@@ -6,6 +6,7 @@ Main entry point for Vocalinux application.
 import argparse
 import atexit
 import logging
+import signal
 import sys
 
 # Configure logging
@@ -66,6 +67,11 @@ def parse_arguments():
         "--start-minimized",
         action="store_true",
         help="Start minimized to system tray",
+    )
+    parser.add_argument(
+        "--settings",
+        action="store_true",
+        help="Open the settings dialog. If Vocalinux is already running, signals the running instance to open settings.",
     )
     return parser.parse_args()
 
@@ -176,6 +182,23 @@ def main():
     # Check for single instance BEFORE any initialization
     from . import single_instance
 
+    # Parse args early to check for --settings
+    args = parse_arguments()
+
+    # Handle --settings with a running instance
+    if args.settings:
+        running_pid = single_instance.get_running_pid()
+        if running_pid is not None:
+            import os as _os
+
+            try:
+                _os.kill(running_pid, signal.SIGUSR1)
+                logger.info(f"Sent SIGUSR1 to running Vocalinux instance (PID {running_pid}) to open settings")
+                sys.exit(0)
+            except OSError as e:
+                logger.warning(f"Failed to signal running instance: {e}")
+                # Fall through to start a new instance
+
     if not single_instance.acquire_lock():
         # Another instance is already running - show notification and exit
         try:
@@ -199,8 +222,6 @@ def main():
 
     # Register cleanup to release lock on exit
     atexit.register(single_instance.release_lock)
-
-    args = parse_arguments()
 
     # Configure debug logging if requested
     if args.debug:
@@ -366,6 +387,16 @@ def main():
             speech_engine=speech_engine,
             text_injector=text_system,
         )
+
+        # If --settings was passed, schedule opening settings after GTK starts
+        if args.settings:
+            from gi.repository import GLib
+
+            def _open_settings_on_start():
+                indicator._open_settings()
+                return False  # Run only once
+
+            GLib.idle_add(_open_settings_on_start)
 
         # Start the GTK main loop
         indicator.run()

--- a/src/vocalinux/single_instance.py
+++ b/src/vocalinux/single_instance.py
@@ -96,3 +96,33 @@ def release_lock():
             logger.warning(f"Failed to release lock: {e}")
             # Ensure clean state
             _lock_file = None
+
+
+def get_running_pid() -> Optional[int]:
+    """
+    Get the PID of the currently running Vocalinux instance.
+
+    Returns:
+        The PID if a running instance is found and the PID is valid, None otherwise.
+    """
+    try:
+        if not LOCK_FILE_PATH.exists():
+            return None
+
+        with open(str(LOCK_FILE_PATH), "r") as f:
+            pid_str = f.read().strip()
+
+        if not pid_str:
+            return None
+
+        pid = int(pid_str)
+
+        # Check if the process is actually running
+        try:
+            os.kill(pid, 0)  # Signal 0 just checks if the process exists
+            return pid
+        except OSError:
+            return None
+
+    except (ValueError, IOError, OSError):
+        return None

--- a/src/vocalinux/ui/keyboard_backends/base.py
+++ b/src/vocalinux/ui/keyboard_backends/base.py
@@ -18,14 +18,17 @@ SUPPORTED_SHORTCUTS = {
     "ctrl+ctrl": "ctrl",
     "alt+alt": "alt",
     "shift+shift": "shift",
+    "super+super": "super",
     # Left side only
     "left_ctrl+left_ctrl": "left_ctrl",
     "left_alt+left_alt": "left_alt",
     "left_shift+left_shift": "left_shift",
+    "left_super+left_super": "left_super",
     # Right side only
     "right_ctrl+right_ctrl": "right_ctrl",
     "right_alt+right_alt": "right_alt",
     "right_shift+right_shift": "right_shift",
+    "right_super+right_super": "right_super",
 }
 
 # Human-readable names for shortcuts (mode-agnostic base names)
@@ -33,19 +36,22 @@ SHORTCUT_DISPLAY_NAMES = {
     "ctrl+ctrl": "Ctrl (either side)",
     "alt+alt": "Alt (either side)",
     "shift+shift": "Shift (either side)",
+    "super+super": "Super (either side)",
     "left_ctrl+left_ctrl": "Left Ctrl",
     "left_alt+left_alt": "Left Alt",
     "left_shift+left_shift": "Left Shift",
+    "left_super+left_super": "Left Super",
     "right_ctrl+right_ctrl": "Right Ctrl",
     "right_alt+right_alt": "Right Alt",
     "right_shift+right_shift": "Right Shift",
+    "right_super+right_super": "Right Super",
 }
 
 # Grouping for UI display: maps group label -> list of shortcut IDs
 SHORTCUT_GROUPS = {
-    "Either Side": ["ctrl+ctrl", "alt+alt", "shift+shift"],
-    "Left Side": ["left_ctrl+left_ctrl", "left_alt+left_alt", "left_shift+left_shift"],
-    "Right Side": ["right_ctrl+right_ctrl", "right_alt+right_alt", "right_shift+right_shift"],
+    "Either Side": ["ctrl+ctrl", "alt+alt", "shift+shift", "super+super"],
+    "Left Side": ["left_ctrl+left_ctrl", "left_alt+left_alt", "left_shift+left_shift", "left_super+left_super"],
+    "Right Side": ["right_ctrl+right_ctrl", "right_alt+right_alt", "right_shift+right_shift", "right_super+right_super"],
 }
 
 # Mode-specific display names (format: {shortcut: {mode: display_name}})
@@ -62,6 +68,10 @@ SHORTCUT_MODE_DISPLAY_NAMES = {
         "toggle": "Double-tap Shift",
         "push_to_talk": "Hold Shift",
     },
+    "super+super": {
+        "toggle": "Double-tap Super",
+        "push_to_talk": "Hold Super",
+    },
     "left_ctrl+left_ctrl": {
         "toggle": "Double-tap Left Ctrl",
         "push_to_talk": "Hold Left Ctrl",
@@ -74,6 +84,10 @@ SHORTCUT_MODE_DISPLAY_NAMES = {
         "toggle": "Double-tap Left Shift",
         "push_to_talk": "Hold Left Shift",
     },
+    "left_super+left_super": {
+        "toggle": "Double-tap Left Super",
+        "push_to_talk": "Hold Left Super",
+    },
     "right_ctrl+right_ctrl": {
         "toggle": "Double-tap Right Ctrl",
         "push_to_talk": "Hold Right Ctrl",
@@ -85,6 +99,10 @@ SHORTCUT_MODE_DISPLAY_NAMES = {
     "right_shift+right_shift": {
         "toggle": "Double-tap Right Shift",
         "push_to_talk": "Hold Right Shift",
+    },
+    "right_super+right_super": {
+        "toggle": "Double-tap Right Super",
+        "push_to_talk": "Hold Right Super",
     },
 }
 

--- a/src/vocalinux/ui/keyboard_backends/evdev_backend.py
+++ b/src/vocalinux/ui/keyboard_backends/evdev_backend.py
@@ -49,9 +49,11 @@ MODIFIER_KEY_CODES: Dict[str, Set[int]] = {
     "left_ctrl": {KEY_LEFTCTRL},
     "left_alt": {KEY_LEFTALT},
     "left_shift": {KEY_LEFTSHIFT},
+    "left_super": {KEY_LEFTMETA},
     "right_ctrl": {KEY_RIGHTCTRL},
     "right_alt": {KEY_RIGHTALT},
     "right_shift": {KEY_RIGHTSHIFT},
+    "right_super": {KEY_RIGHTMETA},
 }
 
 

--- a/src/vocalinux/ui/keyboard_backends/pynput_backend.py
+++ b/src/vocalinux/ui/keyboard_backends/pynput_backend.py
@@ -35,9 +35,11 @@ if PYNPUT_AVAILABLE:
         "left_ctrl": keyboard.Key.ctrl_l,
         "left_alt": keyboard.Key.alt_l,
         "left_shift": keyboard.Key.shift_l,
+        "left_super": keyboard.Key.cmd_l,
         "right_ctrl": keyboard.Key.ctrl_r,
         "right_alt": keyboard.Key.alt_r,
         "right_shift": keyboard.Key.shift_r,
+        "right_super": keyboard.Key.cmd_r,
     }
 
     MODIFIER_NORMALIZE_MAP = {
@@ -225,9 +227,11 @@ class PynputKeyboardBackend(KeyboardBackend):
             "left_ctrl": {keyboard.Key.ctrl_l},
             "left_alt": {keyboard.Key.alt_l},
             "left_shift": {keyboard.Key.shift_l},
+            "left_super": {keyboard.Key.cmd_l},
             "right_ctrl": {keyboard.Key.ctrl_r},
             "right_alt": {keyboard.Key.alt_r},
             "right_shift": {keyboard.Key.shift_r},
+            "right_super": {keyboard.Key.cmd_r},
         }
         return variants.get(modifier_name, set())
 

--- a/src/vocalinux/ui/tray_indicator.py
+++ b/src/vocalinux/ui/tray_indicator.py
@@ -40,6 +40,9 @@ logger = logging.getLogger(__name__)
 # Define constants
 APP_ID = "vocalinux"
 
+# Super key shortcut IDs that conflict with the dedicated settings shortcut
+_SUPER_SHORTCUT_IDS = {"super+super", "left_super+left_super", "right_super+right_super"}
+
 
 # Import the centralized resource manager
 from ..utils.resource_manager import ResourceManager  # noqa: E402
@@ -76,7 +79,7 @@ class TrayIndicator:
         """
         self.speech_engine = speech_engine
         self.text_injector = text_injector
-        self.config_manager = ConfigManager()  # Added: Initialize ConfigManager
+        self.config_manager = ConfigManager()
         self._syncing_autostart_menu = False
 
         # Get configured shortcut and mode from config
@@ -85,6 +88,11 @@ class TrayIndicator:
 
         # Initialize keyboard shortcut manager with configured shortcut and mode
         self.shortcut_manager = KeyboardShortcutManager(shortcut=shortcut, mode=mode)
+
+        # Initialize dedicated Super key shortcut for opening settings
+        self.settings_shortcut_manager = KeyboardShortcutManager(
+            shortcut="super+super", mode="toggle"
+        )
 
         # Ensure icon directory exists
         os.makedirs(ICON_DIR, exist_ok=True)
@@ -108,6 +116,12 @@ class TrayIndicator:
 
         # Set up keyboard shortcuts with mode support
         self._setup_keyboard_shortcuts()
+
+        # Set up dedicated Super key shortcut for opening settings
+        self._setup_settings_shortcut()
+
+        # Set up SIGUSR1 handler for opening settings from CLI
+        self._setup_settings_signal_handler()
 
     def _setup_keyboard_shortcuts(self):
         """Set up keyboard shortcuts based on configured mode."""
@@ -135,6 +149,71 @@ class TrayIndicator:
 
         # Start the keyboard shortcut manager
         self.shortcut_manager.start()
+
+    def _has_super_shortcut_conflict(self) -> bool:
+        """Check if the current recognition shortcut conflicts with the settings shortcut.
+
+        Uses the live shortcut manager state rather than persisted config
+        so that conflict detection is accurate even before config is saved.
+        """
+        return self.shortcut_manager.shortcut in _SUPER_SHORTCUT_IDS
+
+    def _setup_settings_shortcut(self):
+        """Set up the dedicated Super key double-tap shortcut for opening settings.
+
+        The settings shortcut is disabled when the user's recognition shortcut
+        uses a Super key variant, to avoid both actions triggering on the same gesture.
+
+        This method is safe to call multiple times: it always stops the manager
+        and clears callbacks before reconfiguring, preventing duplicate callbacks.
+        """
+        # Always stop and clear callbacks first to prevent stale/duplicate registrations
+        if self.settings_shortcut_manager.active:
+            self.settings_shortcut_manager.stop()
+        self.settings_shortcut_manager.register_toggle_callback(None)
+        self.settings_shortcut_manager.register_press_callback(None)
+        self.settings_shortcut_manager.register_release_callback(None)
+
+        if self._has_super_shortcut_conflict():
+            logger.info(
+                "Settings shortcut (double-tap Super) disabled: "
+                "recognition shortcut uses a Super key variant"
+            )
+            return
+
+        self.settings_shortcut_manager.register_toggle_callback(self._open_settings_from_shortcut)
+        self.settings_shortcut_manager.start()
+        if self.settings_shortcut_manager.active:
+            logger.info("Settings shortcut (double-tap Super) enabled")
+        else:
+            logger.warning("Settings shortcut (double-tap Super) could not be started")
+
+    def _setup_settings_signal_handler(self):
+        """Set up SIGUSR1 signal handler to open settings from CLI."""
+        signal.signal(signal.SIGUSR1, self._on_settings_signal)
+        logger.info("SIGUSR1 signal handler registered for --settings CLI option")
+
+    def _on_settings_signal(self, sig, frame):
+        """Handle SIGUSR1 signal to open settings dialog."""
+        logger.info("Received SIGUSR1 signal, opening settings dialog")
+        GLib.idle_add(self._open_settings)
+
+    def _open_settings_from_shortcut(self):
+        """Open settings dialog from keyboard shortcut (runs in shortcut thread)."""
+        logger.info("Double-tap Super detected, opening settings dialog")
+        GLib.idle_add(self._open_settings)
+
+    def _open_settings(self):
+        """Open the settings dialog (must be called from GTK main thread)."""
+        dialog = SettingsDialog(
+            parent=None,
+            config_manager=self.config_manager,
+            speech_engine=self.speech_engine,
+            shortcut_update_callback=self.update_shortcut,
+        )
+        dialog.connect("response", self._on_settings_dialog_response)
+        dialog.show()
+        return False  # Remove idle callback
 
     def _init_icons(self):
         """Initialize the icon files for the tray indicator."""
@@ -368,20 +447,7 @@ class TrayIndicator:
     def _on_settings_clicked(self, widget):
         """Handle click on the Settings menu item."""
         logger.debug("Settings clicked")
-
-        # Create the settings dialog
-        dialog = SettingsDialog(
-            parent=None,  # Or get the main window if available
-            config_manager=self.config_manager,
-            speech_engine=self.speech_engine,
-            shortcut_update_callback=self.update_shortcut,
-        )
-
-        # Connect to the response signal
-        dialog.connect("response", self._on_settings_dialog_response)
-
-        # Show the dialog (non-modal)
-        dialog.show()
+        self._open_settings()
 
     def _on_logs_clicked(self, widget):
         """Handle click on the View Logs menu item."""
@@ -406,6 +472,8 @@ class TrayIndicator:
         Update the keyboard shortcut for toggling voice recognition.
 
         This performs a live shortcut switch without requiring an app restart.
+        Also re-evaluates whether the dedicated settings shortcut (Super key)
+        should be enabled or disabled based on potential conflicts.
 
         Args:
             shortcut: The new shortcut string (e.g., "ctrl+ctrl", "alt+alt")
@@ -432,6 +500,12 @@ class TrayIndicator:
 
         if mode_changed or shortcut_changed:
             self._setup_keyboard_shortcuts()
+
+            # Re-evaluate settings shortcut conflict after recognition shortcut change.
+            # _has_super_shortcut_conflict uses self.shortcut_manager.shortcut which
+            # has already been updated above, so conflict detection is accurate.
+            self._setup_settings_shortcut()
+
             return self.shortcut_manager.active
 
         logger.debug("No changes needed - shortcut and mode unchanged")
@@ -455,6 +529,9 @@ class TrayIndicator:
 
         # Stop the keyboard shortcut manager
         self.shortcut_manager.stop()
+
+        # Stop the settings shortcut manager
+        self.settings_shortcut_manager.stop()
 
         # Stop the text injector (restores previous IBus engine)
         if hasattr(self, "text_injector") and self.text_injector is not None:

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -110,6 +110,7 @@ class TestMainModule(unittest.TestCase):
         mock_check_deps.return_value = False
         mock_args = MagicMock()
         mock_args.debug = False
+        mock_args.settings = False
         mock_parse.return_value = mock_args
 
         # Make sys.exit raise SystemExit to stop execution
@@ -138,6 +139,7 @@ class TestMainModule(unittest.TestCase):
         mock_args.engine = "vosk"
         mock_args.language = "en-us"
         mock_args.wayland = False
+        mock_args.settings = False
         mock_parse.return_value = mock_args
 
         # Mock config
@@ -207,6 +209,7 @@ class TestMainModule(unittest.TestCase):
             mock_args.engine = "vosk"
             mock_args.language = "en-us"
             mock_args.wayland = True
+            mock_args.settings = False
             mock_parse.return_value = mock_args
 
             # Call main function
@@ -289,6 +292,7 @@ class TestMainModule(unittest.TestCase):
             mock_args.engine = "vosk"
             mock_args.language = "en-us"
             mock_args.wayland = False
+            mock_args.settings = False
             mock_parse.return_value = mock_args
 
             # Create mock loggers
@@ -344,6 +348,7 @@ class TestMainModule(unittest.TestCase):
             mock_args.engine = "vosk"
             mock_args.language = "en-us"
             mock_args.wayland = False
+            mock_args.settings = False
             mock_parse.return_value = mock_args
 
             with patch("vocalinux.main.logger"):
@@ -398,6 +403,7 @@ class TestMainModule(unittest.TestCase):
             mock_args.language = "en-us"
             mock_args.wayland = False
             mock_args.start_minimized = True
+            mock_args.settings = False
             mock_parse.return_value = mock_args
 
             with patch("vocalinux.main.logger"):

--- a/tests/test_main_args_deps.py
+++ b/tests/test_main_args_deps.py
@@ -206,6 +206,10 @@ class TestMainFunction(unittest.TestCase):
         mock_single_instance = MagicMock()
         mock_single_instance.acquire_lock.return_value = False
 
+        mock_args = MagicMock()
+        mock_args.settings = False
+        mock_parse_args.return_value = mock_args
+
         with patch.dict(sys.modules, {"vocalinux.single_instance": mock_single_instance}):
             # Should exit with status 1
             with pytest.raises(SystemExit) as exc_info:
@@ -225,7 +229,7 @@ class TestMainFunction(unittest.TestCase):
 
         # Set up mocks
         mock_check_deps.return_value = False
-        mock_parse_args.return_value = MagicMock(debug=False)
+        mock_parse_args.return_value = MagicMock(debug=False, settings=False)
 
         # Mock single_instance module since it's imported inside main()
         mock_single_instance = MagicMock()
@@ -251,7 +255,7 @@ class TestMainFunction(unittest.TestCase):
         # Set up mocks
         mock_check_deps.return_value = True
         mock_check_display.return_value = False
-        mock_parse_args.return_value = MagicMock(debug=False)
+        mock_parse_args.return_value = MagicMock(debug=False, settings=False)
 
         # Mock single_instance module since it's imported inside main()
         mock_single_instance = MagicMock()
@@ -287,6 +291,7 @@ class TestMainFunction(unittest.TestCase):
         mock_args.debug = True
         mock_args.wayland = False
         mock_args.start_minimized = False
+        mock_args.settings = False
         mock_parse_args.return_value = mock_args
 
         # Mock single_instance module since it's imported inside main()
@@ -364,6 +369,7 @@ class TestMainFunction(unittest.TestCase):
         mock_args.debug = False
         mock_args.wayland = False
         mock_args.start_minimized = False
+        mock_args.settings = False
         mock_parse_args.return_value = mock_args
 
         # Mock single_instance module since it's imported inside main()

--- a/tests/test_main_edge_cases.py
+++ b/tests/test_main_edge_cases.py
@@ -87,6 +87,10 @@ class TestMainFunctionExtra:
         mock_single_instance = MagicMock()
         mock_single_instance.acquire_lock.return_value = False
 
+        mock_args = MagicMock()
+        mock_args.settings = False
+        mock_parse_args.return_value = mock_args
+
         with patch.dict(sys.modules, {"vocalinux.single_instance": mock_single_instance}):
             with pytest.raises(SystemExit) as exc_info:
                 main()
@@ -110,6 +114,7 @@ class TestMainFunctionExtra:
         mock_args.debug = False
         mock_args.wayland = False
         mock_args.start_minimized = False
+        mock_args.settings = False
         mock_parse_args.return_value = mock_args
 
         mock_single_instance = MagicMock()
@@ -173,6 +178,7 @@ class TestMainFunctionExtra:
         mock_args.debug = False
         mock_args.wayland = False
         mock_args.start_minimized = False
+        mock_args.settings = False
         mock_parse_args.return_value = mock_args
 
         mock_single_instance = MagicMock()
@@ -236,6 +242,7 @@ class TestMainFunctionExtra:
         mock_args.debug = False
         mock_args.wayland = False
         mock_args.start_minimized = False
+        mock_args.settings = False
         mock_parse_args.return_value = mock_args
 
         mock_single_instance = MagicMock()
@@ -300,6 +307,7 @@ class TestMainFunctionExtra:
         mock_args.engine = "vosk"
         mock_args.model = "medium"
         mock_args.language = "es"
+        mock_args.settings = False
         mock_parse_args.return_value = mock_args
 
         mock_single_instance = MagicMock()
@@ -365,6 +373,7 @@ class TestMainFunctionExtra:
         mock_args.debug = False
         mock_args.wayland = False
         mock_args.start_minimized = False
+        mock_args.settings = False
         mock_parse_args.return_value = mock_args
 
         mock_single_instance = MagicMock()
@@ -426,6 +435,7 @@ class TestMainFunctionExtra:
         mock_args.debug = False
         mock_args.wayland = False
         mock_args.start_minimized = False
+        mock_args.settings = False
         mock_parse_args.return_value = mock_args
 
         mock_single_instance = MagicMock()

--- a/tests/test_settings_shortcuts.py
+++ b/tests/test_settings_shortcuts.py
@@ -139,12 +139,15 @@ class TestKeyboardBackendsBase(unittest.TestCase):
                 "ctrl+ctrl",
                 "alt+alt",
                 "shift+shift",
+                "super+super",
                 "left_ctrl+left_ctrl",
                 "left_alt+left_alt",
                 "left_shift+left_shift",
+                "left_super+left_super",
                 "right_ctrl+right_ctrl",
                 "right_alt+right_alt",
                 "right_shift+right_shift",
+                "right_super+right_super",
             },
         )
 
@@ -173,9 +176,9 @@ class TestKeyboardBackendsBase(unittest.TestCase):
         self.assertIn("Right Side", SHORTCUT_GROUPS)
         self.assertEqual(len(SHORTCUT_GROUPS.keys()), 3)
         self.assertEqual(list(SHORTCUT_GROUPS.keys()), ["Either Side", "Left Side", "Right Side"])
-        self.assertEqual(len(SHORTCUT_GROUPS["Either Side"]), 3)
-        self.assertEqual(len(SHORTCUT_GROUPS["Left Side"]), 3)
-        self.assertEqual(len(SHORTCUT_GROUPS["Right Side"]), 3)
+        self.assertEqual(len(SHORTCUT_GROUPS["Either Side"]), 4)
+        self.assertEqual(len(SHORTCUT_GROUPS["Left Side"]), 4)
+        self.assertEqual(len(SHORTCUT_GROUPS["Right Side"]), 4)
 
 
 class TestConfigManagerShortcuts(unittest.TestCase):

--- a/tests/test_tray_indicator.py
+++ b/tests/test_tray_indicator.py
@@ -215,7 +215,8 @@ class TestTrayIndicator(unittest.TestCase):
 
         with patch("vocalinux.ui.tray_indicator.Gtk") as patched_gtk:
             self.tray_indicator._quit()
-            self.mock_ksm.stop.assert_called_once()
+            # stop() is called twice: once for shortcut_manager, once for settings_shortcut_manager
+            self.assertEqual(self.mock_ksm.stop.call_count, 2)
             patched_gtk.main_quit.assert_called_once()
 
     def test_signal_handler(self):


### PR DESCRIPTION
## Summary

This PR adds two new ways to access the Vocalinux settings dialog, addressing a usability issue where the system tray icon may not be accessible on certain Linux distributions or desktop environments.

## Problem

On some Linux distributions, the system tray icon does not appear or is not clickable, making it impossible to access the settings dialog. This is a significant accessibility barrier.

## Solution

### 1. Double-tap Super key opens Settings

A dedicated `KeyboardShortcutManager` instance listens for double-tap of the Super (Windows/Meta) key and opens the settings dialog when detected.

**Conflict avoidance:** If the user configures `super+super`, `left_super+left_super`, or `right_super+right_super` as their recognition shortcut, the dedicated settings shortcut is automatically disabled to prevent both actions triggering on the same gesture. The conflict is re-evaluated whenever the recognition shortcut changes.

### 2. `--settings` CLI option

A new `--settings` command-line argument allows opening settings from the terminal:

```bash
vocalinux --settings
```

- If a Vocalinux instance is already running, it sends `SIGUSR1` to the running process, which opens the settings dialog.
- If no instance is running, it starts Vocalinux and opens settings immediately after initialization.

### 3. Super key added to supported shortcuts

The Super key (and its left/right variants) is now available as a configurable shortcut for voice recognition, alongside the existing Ctrl, Alt, and Shift options.

## Changes

### Core changes

| File | Description |
|------|-------------|
| `src/vocalinux/ui/keyboard_backends/base.py` | Added `super+super`, `left_super+left_super`, `right_super+right_super` to `SUPPORTED_SHORTCUTS`, display names, groups, and mode display names |
| `src/vocalinux/ui/keyboard_backends/pynput_backend.py` | Added Super key mappings (`keyboard.Key.cmd`, `cmd_l`, `cmd_r`) to `MODIFIER_KEY_MAP` and `_get_key_variants` |
| `src/vocalinux/ui/keyboard_backends/evdev_backend.py` | Added `left_super` and `right_super` to `MODIFIER_KEY_CODES` using `KEY_LEFTMETA`/`KEY_RIGHTMETA` |
| `src/vocalinux/ui/tray_indicator.py` | Added dedicated `settings_shortcut_manager`, SIGUSR1 handler, `_open_settings()` centralized method, conflict detection, and cleanup in `_quit()` |
| `src/vocalinux/main.py` | Added `--settings` argument, early arg parsing, SIGUSR1 signaling to running instance, and settings opening on fresh start |
| `src/vocalinux/single_instance.py` | Added `get_running_pid()` to read PID from lock file for inter-process communication |

### Test updates

| File | Description |
|------|-------------|
| `tests/test_main.py` | Added `settings=False` to all mock args to prevent SIGUSR1 self-signaling during tests |
| `tests/test_main_args_deps.py` | Added `settings=False` to all mock args |
| `tests/test_main_edge_cases.py` | Added `settings=False` to all mock args |
| `tests/test_settings_shortcuts.py` | Updated assertions for new Super key entries (12 shortcuts instead of 9, 4 per group instead of 3) |
| `tests/test_tray_indicator.py` | Updated `test_quit` to expect `stop()` called twice (recognition + settings shortcut managers) |

## Testing

All 1359 tests pass.

## Backward Compatibility

- Fully backward compatible. No existing behavior is changed.
- Default recognition shortcut remains `ctrl+ctrl`.
- The Super key settings shortcut is additive and auto-disables on conflict.

---