### PR TITLE
fix(evdev): handle SYN_DROPPED to prevent stale modifier state

### DIFF
--- a/src/vocalinux/ui/keyboard_backends/evdev_backend.py
+++ b/src/vocalinux/ui/keyboard_backends/evdev_backend.py
@@ -160,6 +160,7 @@ class EvdevKeyboardBackend(KeyboardBackend):
         self.key_pressed_devices: set[int] = set()
 
         self._devices_lock = threading.Lock()
+        self._dropped_devices: set[int] = set()  # fds with SYN_DROPPED pending
 
         if not EVDEV_AVAILABLE:
             logger.error("python-evdev not available")
@@ -247,6 +248,7 @@ class EvdevKeyboardBackend(KeyboardBackend):
         self.devices = []
         self.device_fds = []
         self.key_pressed_devices = set()
+        self._dropped_devices = set()
 
         for device_path in device_paths:
             try:
@@ -321,6 +323,22 @@ class EvdevKeyboardBackend(KeyboardBackend):
 
                         # Read events from this device
                         for event in device.read():
+                            if event.type == ecodes.EV_SYN:
+                                if event.code == ecodes.SYN_DROPPED:
+                                    # Kernel buffer overflowed — discard until SYN_REPORT
+                                    self._dropped_devices.add(fd)
+                                    logger.warning(
+                                        f"SYN_DROPPED on {device.name} (fd={fd}), "
+                                        "resetting key state"
+                                    )
+                                elif event.code == ecodes.SYN_REPORT:
+                                    if fd in self._dropped_devices:
+                                        # End of dropped sequence — clear stale state
+                                        self._dropped_devices.discard(fd)
+                                        self.key_pressed_devices.discard(id(device))
+                                continue
+                            if fd in self._dropped_devices:
+                                continue
                             if event.type == ecodes.EV_KEY:
                                 self._handle_key_event(event, device)
 
@@ -343,6 +361,7 @@ class EvdevKeyboardBackend(KeyboardBackend):
                         if fd in self.device_fds:
                             with self._devices_lock:
                                 self.device_fds.remove(fd)
+                        self._dropped_devices.discard(fd)
                         continue
 
             except (OSError, ValueError) as e:


### PR DESCRIPTION
## Description

Handle `SYN_DROPPED` events in the evdev keyboard backend to prevent stale modifier key state.

When the kernel's evdev client buffer overflows, it inserts a `SYN_DROPPED` event to signal that events were lost ([kernel docs](https://www.kernel.org/doc/html/latest/input/event-codes.html)). Without handling this, a missed key-release event can leave `key_pressed_devices` in a stale state — for push-to-talk users this means recording may never stop or never start.

The fix discards all events between `SYN_DROPPED` and the next `SYN_REPORT`, then resets modifier key state for the affected device. The handling is per-device, so a drop on one keyboard does not affect another.

Reference: [libevdev SYN_DROPPED guide](https://www.freedesktop.org/software/libevdev/doc/latest/syn_dropped.html)

## Related Issue

Fixes #338

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Test update

## Checklist

- [x] Code follows project style (black, isort)
- [x] All tests pass locally
- [x] Pre-commit hooks pass

## Additional Notes

This is an edge case — keyboard events are sparse and the kernel buffer holds 64+ events, so overflow requires the reader thread to stall for multiple seconds. But the fix is ~15 lines, zero risk, and prevents a catastrophic stuck-key failure mode.