### PR TITLE
fix(audio): handle 48kHz-only USB interfaces during channel probe

### DIFF
--- a/src/vocalinux/speech_recognition/recognition_manager.py
+++ b/src/vocalinux/speech_recognition/recognition_manager.py
@@ -102,13 +102,17 @@ def get_audio_input_devices() -> list:
     return devices
 
 
-def _get_supported_channels(audio, device_index: int = None) -> int:
+def _get_supported_channels(audio, device_index: Optional[int] = None) -> int:
     """
     Detect the supported number of channels for the audio device.
 
     Some audio devices (particularly professional audio interfaces and certain
     onboard audio chips) only support specific channel configurations. This
     function tests mono (1) and stereo (2) to find a working configuration.
+
+    Pro-audio USB interfaces (MUPRO, Vocaster, etc.) often only support 48kHz
+    and will reject 16kHz probes. This function uses the device's default
+    sample rate first, then falls back to common rates.
 
     Args:
         audio: PyAudio instance
@@ -121,41 +125,57 @@ def _get_supported_channels(audio, device_index: int = None) -> int:
 
     FORMAT = pyaudio.paInt16
     CHUNK = 1024
-    RATE = 16000  # Use standard rate for channel testing
 
-    # Try mono first (preferred for speech recognition)
+    COMMON_RATES = [48000, 44100, 32000, 22050, 16000, 8000]
+
+    rates_to_try = []
+    try:
+        if device_index is not None:
+            device_info = audio.get_device_info_by_index(device_index)
+        else:
+            device_info = audio.get_default_input_device_info()
+
+        default_rate = int(device_info.get("defaultSampleRate", 0))
+        if default_rate > 0:
+            rates_to_try.append(default_rate)
+            logger.debug(f"Device reports default sample rate: {default_rate}Hz")
+    except (IOError, OSError) as e:
+        logger.debug(f"Could not get device info for channel probing: {e}")
+
+    for rate in COMMON_RATES:
+        if rate not in rates_to_try:
+            rates_to_try.append(rate)
+
     for channels in [1, 2]:
-        try:
-            stream_kwargs = {
-                "format": FORMAT,
-                "channels": channels,
-                "rate": RATE,
-                "input": True,
-                "frames_per_buffer": CHUNK,
-            }
-            if device_index is not None:
-                stream_kwargs["input_device_index"] = device_index
+        for rate in rates_to_try:
+            try:
+                stream_kwargs = {
+                    "format": FORMAT,
+                    "channels": channels,
+                    "rate": rate,
+                    "input": True,
+                    "frames_per_buffer": CHUNK,
+                }
+                if device_index is not None:
+                    stream_kwargs["input_device_index"] = device_index
 
-            test_stream = audio.open(**stream_kwargs)
-            test_stream.close()
-            logger.debug(f"Device supports {channels} channel(s)")
-            return channels
-        except (IOError, OSError) as e:
-            error_str = str(e).lower()
-            if "invalid number of channels" in error_str or "-9998" in error_str:
-                logger.debug(f"Device does not support {channels} channel(s)")
-                continue
-            else:
-                # Different error, try next channel count anyway
-                logger.debug(f"Channel test failed for {channels} channel(s): {e}")
+                test_stream = audio.open(**stream_kwargs)
+                test_stream.close()
+                logger.debug(f"Device supports {channels} channel(s) at {rate}Hz")
+                return channels
+            except (IOError, OSError) as e:
+                error_str = str(e).lower()
+                if "invalid number of channels" in error_str or "-9998" in error_str:
+                    logger.debug(f"Device rejected {channels} channel(s) at {rate}Hz: {e}")
+                else:
+                    logger.debug(f"Channel test failed at {rate}Hz: {e}")
                 continue
 
-    # Default to mono if we couldn't determine
     logger.warning("Could not determine supported channel count, defaulting to 1")
     return 1
 
 
-def _get_supported_sample_rate(audio, device_index: int, channels: int = 1) -> int:
+def _get_supported_sample_rate(audio, device_index: Optional[int], channels: int = 1) -> int:
     """
     Get a supported sample rate for the audio device.
 

--- a/tests/test_recognition_manager_device_config.py
+++ b/tests/test_recognition_manager_device_config.py
@@ -86,6 +86,84 @@ class TestAudioDeviceDetection(unittest.TestCase):
             channels = _get_supported_channels(mock_audio, None)
             assert channels == 1
 
+    def test_get_supported_channels_48khz_only_device(self):
+        """Test channel detection on 48kHz-only pro audio devices (Issue #340).
+
+        Professional audio interfaces (MUPRO, Vocaster, etc.) only support 48kHz
+        and reject 16kHz probes with misleading "Invalid number of channels" error.
+        The fix should use the device's defaultSampleRate for channel probing.
+        """
+        mock_audio = MagicMock()
+        mock_stream = MagicMock()
+
+        def open_side_effect(**kwargs):
+            rate = kwargs.get("rate")
+            channels = kwargs.get("channels")
+
+            # Simulate 48kHz-only device: 16kHz fails, 48kHz succeeds
+            if rate == 16000:
+                raise IOError("[Errno -9998] Invalid number of channels")
+            elif rate == 48000 and channels == 1:
+                return mock_stream
+            else:
+                raise IOError("Unsupported configuration")
+
+        mock_audio.open.side_effect = open_side_effect
+        mock_audio.get_device_info_by_index.return_value = {"defaultSampleRate": 48000}
+        mock_pyaudio = MagicMock(paInt16=8)
+
+        with patch.dict("sys.modules", {"pyaudio": mock_pyaudio}):
+            channels = _get_supported_channels(mock_audio, 0)
+            assert channels == 1
+            # Verify that it tried using the device's default rate (48000)
+            assert any(
+                call[1].get("rate") == 48000 for call in mock_audio.open.call_args_list
+            ), "Should probe using device's defaultSampleRate (48000)"
+
+    def test_get_supported_channels_default_rate_fails_fallback(self):
+        """Test fallback when device's default rate fails during channel probing."""
+        mock_audio = MagicMock()
+        mock_stream = MagicMock()
+
+        def open_side_effect(**kwargs):
+            rate = kwargs.get("rate")
+            channels = kwargs.get("channels")
+
+            # Default rate (48000) fails, but 44100 works
+            if rate == 48000:
+                raise IOError("Device busy")
+            elif rate == 44100 and channels == 1:
+                return mock_stream
+            else:
+                raise IOError("Unsupported")
+
+        mock_audio.open.side_effect = open_side_effect
+        mock_audio.get_device_info_by_index.return_value = {"defaultSampleRate": 48000}
+        mock_pyaudio = MagicMock(paInt16=8)
+
+        with patch.dict("sys.modules", {"pyaudio": mock_pyaudio}):
+            channels = _get_supported_channels(mock_audio, 0)
+            assert channels == 1
+
+    def test_get_supported_channels_no_device_info(self):
+        """Test channel probing when device info is unavailable."""
+        mock_audio = MagicMock()
+        mock_stream = MagicMock()
+
+        def open_side_effect(**kwargs):
+            # Works with 44100Hz mono
+            if kwargs.get("rate") == 44100 and kwargs.get("channels") == 1:
+                return mock_stream
+            raise IOError("Unsupported")
+
+        mock_audio.open.side_effect = open_side_effect
+        mock_audio.get_device_info_by_index.side_effect = IOError("Device not found")
+        mock_pyaudio = MagicMock(paInt16=8)
+
+        with patch.dict("sys.modules", {"pyaudio": mock_pyaudio}):
+            channels = _get_supported_channels(mock_audio, 0)
+            assert channels == 1  # Should fallback through common rates and find 44100
+
     def test_get_supported_sample_rate_default_rate_works(self):
         """Test using device's default sample rate."""
         mock_audio = MagicMock()

--- a/tests/test_recognition_manager_init.py
+++ b/tests/test_recognition_manager_init.py
@@ -214,11 +214,13 @@ class TestGetSupportedChannels:
         mock_audio = MagicMock()
         mock_stream = MagicMock()
 
-        # Mono fails, stereo succeeds
-        mock_audio.open.side_effect = [
-            IOError("-9998 invalid number of channels"),
-            mock_stream,
-        ]
+        def open_side_effect(**kwargs):
+            if kwargs.get("channels") == 1:
+                raise IOError("-9998 invalid number of channels")
+            return mock_stream
+
+        mock_audio.open.side_effect = open_side_effect
+        mock_audio.get_default_input_device_info.return_value = {"defaultSampleRate": 48000}
 
         with patch.dict(
             "sys.modules",
@@ -233,11 +235,8 @@ class TestGetSupportedChannels:
 
         mock_audio = MagicMock()
 
-        # Both fail
-        mock_audio.open.side_effect = [
-            IOError("Mono failed"),
-            IOError("Stereo failed"),
-        ]
+        mock_audio.open.side_effect = IOError("All channel/rate probes failed")
+        mock_audio.get_default_input_device_info.return_value = {"defaultSampleRate": 48000}
 
         with patch.dict(
             "sys.modules",


### PR DESCRIPTION
## Summary
- Fixes #340 by changing `_get_supported_channels()` to probe with the device default sample rate first, then fallback rates (`48000, 44100, 32000, 22050, 16000, 8000`) instead of hardcoded 16kHz.
- Keeps mono-first preference, but now avoids false `Errno -9998 Invalid number of channels` failures on pro-audio interfaces that only accept 48kHz.
- Adds/updates tests for 48kHz-only devices, default-rate fallback behavior, and updated channel-probing expectations.

## Verification
- `PYTHONPATH=src python3 -m pytest tests/test_recognition_manager_device_config.py tests/test_recognition_manager_init.py -q`
- `PYTHONPATH=src python3 -m pytest tests/test_recognition_manager*.py -q`
- pre-commit hooks passed on commit (`black`, `isort`, `flake8`, whitespace/end-of-file checks)

## Notes
- Existing workspace Pyright reports unrelated baseline issues (missing optional deps like `whisper`/`torch` and pre-existing typing warnings), but this fix is functionally validated by targeted and broader recognition-manager tests.