### PR TITLE
fix(engine): stop recognition before switching engines to prevent segfault (fixes #350)

### DIFF
--- a/src/vocalinux/speech_recognition/recognition_manager.py
+++ b/src/vocalinux/speech_recognition/recognition_manager.py
@@ -2073,6 +2073,15 @@ class SpeechRecognitionManager:
 
         if restart_needed:
             logger.info("Engine or model changed, re-initializing...")
+
+            # Stop any active recognition before switching engines.
+            # This is critical to prevent segfaults when the old engine's
+            # native resources (e.g. whisper.cpp C model) are freed while
+            # a background thread is still using them.
+            if self.state != RecognitionState.IDLE:
+                logger.info("Stopping active recognition before engine switch...")
+                self.stop_recognition()
+
             # When reconfiguring from UI, allow downloads
             old_defer = self._defer_download
             self._defer_download = not force_download

--- a/src/vocalinux/ui/settings_dialog.py
+++ b/src/vocalinux/ui/settings_dialog.py
@@ -1916,6 +1916,13 @@ class SettingsDialog(Gtk.Dialog):
 
             self.config_manager.update_speech_recognition_settings(settings)
             self.config_manager.save_settings()
+
+            # Stop recognition before reconfiguring to avoid segfaults when
+            # switching between engines with native resources (e.g. whisper.cpp)
+            was_running = self.speech_engine.state != RecognitionState.IDLE
+            if was_running:
+                self.speech_engine.stop_recognition()
+
             self.speech_engine.reconfigure(**settings)
             logger.info("Settings auto-applied successfully")
         except Exception as e:


### PR DESCRIPTION
## Problem

When switching from whisper.cpp to VOSK via the settings dialog, the application crashes with a segmentation fault.

**Root cause:** The `_auto_apply_settings` code path called `reconfigure()` without first stopping active recognition. This allowed background audio/transcription threads to continue using the old engine's native C resources (e.g. the whisper.cpp model) while Python's GC freed them — causing a segfault.

The `_apply_settings_internal` method already had the correct pattern (stop → sleep → reconfigure), but `_auto_apply_settings` (triggered by engine combo changes) did not.

## Fix

- **`reconfigure()` now stops recognition itself** when the engine or model changes and recognition is active. This makes the API safe regardless of which caller triggers the reconfiguration.
- **Defense-in-depth:** Added `stop_recognition()` in `_auto_apply_settings` to match the existing pattern in `_apply_settings_internal`.

## Testing

All 1371 tests pass.

Fixes #350