### PR TITLE
feat(text-injection): add hallucination filter for background noise and silence

### DIFF
--- a/src/vocalinux/main.py
+++ b/src/vocalinux/main.py
@@ -67,6 +67,11 @@ def parse_arguments():
         action="store_true",
         help="Start minimized to system tray",
     )
+    parser.add_argument(
+        "--hallucination-filter",
+        action="store_true",
+        help="Filter out commonly hallucinated phrases",
+    )
     return parser.parse_args()
 
 
@@ -326,7 +331,9 @@ def main():
         )
 
         # Initialize text injection system
-        text_system = text_injector.TextInjector(wayland_mode=args.wayland)
+        text_system = text_injector.TextInjector(
+            wayland_mode=args.wayland, hallucination_filter=args.hallucination_filter
+        )
 
         # Initialize action handler
         action_handler = ActionHandler(text_system)

--- a/src/vocalinux/text_injection/hallucination_filter.py
+++ b/src/vocalinux/text_injection/hallucination_filter.py
@@ -1,0 +1,51 @@
+import logging
+import re
+from abc import ABC, abstractmethod
+from typing import Optional
+
+logger = logging.getLogger(__name__)
+
+
+class HallucinationFilter(ABC):
+
+    @abstractmethod
+    def filter(self, input_str: Optional[str]) -> Optional[str]:
+        pass
+
+
+class BackgroundNoiseHallucinationFilter(HallucinationFilter):
+    """Ignore transcripts of background noise (indicated by parenthesis)"""
+
+    IGNORE_PATTERN = re.compile(r"^\(.*\)$")
+
+    def filter(self, input_str: Optional[str]) -> Optional[str]:
+        if input_str is None or input_str.strip() is None:
+            return None
+
+        input_str = input_str.strip()
+        if self.IGNORE_PATTERN.fullmatch(input_str.strip()) is not None:
+            logger.info(f"Ignoring: {input_str}")
+
+            return None
+        return input_str
+
+
+class SilenceHallucinationFilter(HallucinationFilter):
+    """Ignore phrases commonly hallucinated when there is silence."""
+
+    ignore_list = {
+        "Thank you.",
+        "Thank you for watching.",
+        "See you later!",
+    }
+
+    def filter(self, input_str: Optional[str]) -> Optional[str]:
+        if input_str is None or input_str.strip() is None:
+            return None
+
+        input_str = input_str.strip()
+
+        if input_str in self.ignore_list:
+            logger.info(f"Ignoring: {input_str}")
+            return None
+        return input_str

--- a/src/vocalinux/text_injection/hallucination_filter.py
+++ b/src/vocalinux/text_injection/hallucination_filter.py
@@ -19,7 +19,7 @@ class BackgroundNoiseHallucinationFilter(HallucinationFilter):
     IGNORE_PATTERN = re.compile(r"^\(.*\)$")
 
     def filter(self, input_str: Optional[str]) -> Optional[str]:
-        if input_str is None or input_str.strip() is None:
+        if not input_str or not input_str.strip():
             return None
 
         input_str = input_str.strip()
@@ -40,7 +40,7 @@ class SilenceHallucinationFilter(HallucinationFilter):
     }
 
     def filter(self, input_str: Optional[str]) -> Optional[str]:
-        if input_str is None or input_str.strip() is None:
+        if not input_str or not input_str.strip():
             return None
 
         input_str = input_str.strip()

--- a/src/vocalinux/text_injection/text_injector.py
+++ b/src/vocalinux/text_injection/text_injector.py
@@ -12,7 +12,13 @@ import subprocess
 import threading
 import time
 from enum import Enum
-from typing import Optional  # noqa: F401
+from typing import Optional
+
+from vocalinux.text_injection.hallucination_filter import (
+    BackgroundNoiseHallucinationFilter,
+    HallucinationFilter,
+    SilenceHallucinationFilter,
+)
 
 from .ibus_engine import (
     IBusTextInjector,
@@ -43,7 +49,7 @@ class TextInjector:
     application window, supporting both X11 and Wayland environments.
     """
 
-    def __init__(self, wayland_mode: bool = False):
+    def __init__(self, wayland_mode: bool = False, hallucination_filter: bool = False):
         """
         Initialize the text injector.
 
@@ -59,6 +65,11 @@ class TextInjector:
             self.environment = DesktopEnvironment.WAYLAND
 
         logger.info(f"Using text injection for {self.environment.value} environment")
+
+        self._filters: list[HallucinationFilter] = []
+        if hallucination_filter:
+            self._filters.append(SilenceHallucinationFilter())
+            self._filters.append(BackgroundNoiseHallucinationFilter())
 
         # Check for required tools
         self._check_dependencies()
@@ -408,7 +419,7 @@ class TextInjector:
         except Exception as e:
             logger.debug(f"Could not show clipboard notification: {e}")
 
-    def inject_text(self, text: str) -> bool:
+    def inject_text(self, text: Optional[str]) -> bool:
         """
         Inject text into the currently focused application.
 
@@ -418,6 +429,10 @@ class TextInjector:
         Returns:
             True if injection was successful, False otherwise
         """
+
+        for filter in self._filters:
+            text = filter.filter(text)
+
         if not text or not text.strip():
             logger.debug("Empty text provided, skipping injection")
             return True

--- a/tests/test_hallucination_filters.py
+++ b/tests/test_hallucination_filters.py
@@ -1,0 +1,28 @@
+"""Test optional filters for commonly hallucinated text"""
+
+import unittest
+
+from vocalinux.text_injection.hallucination_filter import (
+    BackgroundNoiseHallucinationFilter,
+    HallucinationFilter,
+    SilenceHallucinationFilter,
+)
+
+
+class TestHallucinationFilters(unittest.TestCase):
+
+    def test_silence_filter(self) -> None:
+        f: HallucinationFilter = SilenceHallucinationFilter()
+        assert f.filter("Thank you.") is None
+        assert f.filter("Thank you") == "Thank you"
+        assert f.filter(" Hello ") == "Hello"
+
+    def test_background_noise_filter(self) -> None:
+        f: HallucinationFilter = BackgroundNoiseHallucinationFilter()
+        assert f.filter("(drum beating)") is None
+        assert f.filter("(footsteps)") is None
+        assert f.filter("(any text)") is None
+        assert f.filter(" (any test with spaces) ") is None
+        assert f.filter(" drum beating ") == "drum beating"
+        assert f.filter("footsteps)") == "footsteps)"
+        assert f.filter("(footsteps") == "(footsteps"

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -207,6 +207,7 @@ class TestMainModule(unittest.TestCase):
             mock_args.engine = "vosk"
             mock_args.language = "en-us"
             mock_args.wayland = True
+            mock_args.hallucination_filter = True
             mock_parse.return_value = mock_args
 
             # Call main function
@@ -222,7 +223,7 @@ class TestMainModule(unittest.TestCase):
                 audio_device_index=None,
                 voice_commands_enabled=None,
             )
-            mock_text.assert_called_once_with(wayland_mode=True)
+            mock_text.assert_called_once_with(wayland_mode=True, hallucination_filter=True)
             mock_action_handler.assert_called_once_with(mock_text_instance)
             mock_tray.assert_called_once_with(
                 speech_engine=mock_speech_instance, text_injector=mock_text_instance

--- a/tests/test_text_injector.py
+++ b/tests/test_text_injector.py
@@ -283,6 +283,18 @@ class TestTextInjector(unittest.TestCase):
         # Still no subprocess calls
         self.mock_subprocess.assert_not_called()
 
+        # Try with empty string (for full coverage)
+        injector.inject_text("")
+
+        # Still no subprocess calls
+        self.mock_subprocess.assert_not_called()
+
+        # Try with a non-filtered string
+        injector.inject_text("non-filtered text")
+
+        # The subprocess should be invoked now
+        self.mock_subprocess.assert_called()
+
     def test_empty_text_injection(self):
         """Test injecting empty text (should do nothing)."""
         injector = TextInjector()

--- a/tests/test_text_injector.py
+++ b/tests/test_text_injector.py
@@ -265,6 +265,24 @@ class TestTextInjector(unittest.TestCase):
                 "Text should not be shell-escaped when passed to xdotool",
             )
 
+    def test_hallucination_filter(self):
+        injector = TextInjector(hallucination_filter=True)
+
+        # Reset the subprocess mock to clear previous calls
+        self.mock_subprocess.reset_mock()
+
+        # Inject text hallucinated with silence
+        injector.inject_text("Thank you.")
+
+        # No subprocess calls should have been made
+        self.mock_subprocess.assert_not_called()
+
+        # Try with background noise
+        injector.inject_text("(keyboard clicking)")
+
+        # Still no subprocess calls
+        self.mock_subprocess.assert_not_called()
+
     def test_empty_text_injection(self):
         """Test injecting empty text (should do nothing)."""
         injector = TextInjector()

--- a/tests/test_text_injector_ext.py
+++ b/tests/test_text_injector_ext.py
@@ -43,6 +43,7 @@ def _make_injector(env):
 
     obj = TextInjector.__new__(TextInjector)
     obj._ibus_injector = None
+    obj._filters = []
     obj.environment = env
     return obj
 


### PR DESCRIPTION
## Summary
- Adds optional `--hallucination-filter` CLI flag to filter out common speech recognition hallucinations before text injection
- Filters background noise transcripts (text in parentheses like `(music)`) and silence hallucinations (e.g. "Thank you.", "Thank you for watching.")
- New `HallucinationFilter` abstract base class with `BackgroundNoiseHallucinationFilter` and `SilenceHallucinationFilter` implementations

Fixes #363

## Test plan
- [ ] Run `vocalinux --debug --hallucination-filter` and verify hallucinated phrases are filtered
- [ ] Run `pytest tests/test_hallucination_filters.py` to verify filter unit tests pass
- [ ] Run `pytest tests/test_text_injector_ext.py` to verify existing text injector tests still pass
- [ ] Verify normal transcription still works without `--hallucination-filter` flag

🤖 Generated with [Claude Code](https://claude.com/claude-code)