### PR TITLE
fix(settings): disable copy-to-clipboard by default

### DIFF
--- a/src/vocalinux/text_injection/text_injector.py
+++ b/src/vocalinux/text_injection/text_injector.py
@@ -384,10 +384,10 @@ class TextInjector:
             if os.path.exists(config_path):
                 with open(config_path, "r") as f:
                     config = json.load(f)
-                return config.get("text_injection", {}).get("copy_to_clipboard", True)
+                return config.get("text_injection", {}).get("copy_to_clipboard", False)
         except Exception as e:
             logger.debug(f"Could not read copy_to_clipboard setting: {e}")
-        return True  # Default to enabled
+        return False
 
     def _show_clipboard_fallback_notification(self):
         """Show a desktop notification when text is copied to clipboard as fallback."""

--- a/src/vocalinux/ui/config_manager.py
+++ b/src/vocalinux/ui/config_manager.py
@@ -50,7 +50,7 @@ DEFAULT_CONFIG = {
         "first_run": True,
     },
     "text_injection": {
-        "copy_to_clipboard": True,  # Always copy recognized text to clipboard
+        "copy_to_clipboard": False,  # Disabled by default; users can enable in Settings
     },
     "advanced": {
         "debug_logging": False,

--- a/src/vocalinux/ui/settings_dialog.py
+++ b/src/vocalinux/ui/settings_dialog.py
@@ -1453,7 +1453,7 @@ class SettingsDialog(Gtk.Dialog):
 
         autostart_enabled = general_settings.get("autostart", False)
         start_minimized = ui_settings.get("start_minimized", False)
-        copy_to_clipboard = text_injection_settings.get("copy_to_clipboard", True)
+        copy_to_clipboard = text_injection_settings.get("copy_to_clipboard", False)
 
         self.autostart_switch.set_active(autostart_enabled)
         self.start_minimized_switch.set_active(start_minimized)


### PR DESCRIPTION
## Summary

Disables the copy-to-clipboard feature by default on fresh installs. Users can still enable it in **Settings → Text Injection → Copy recognized text to clipboard**.

## Changes

| File | Change |
|------|--------|
| `config_manager.py` | Default `copy_to_clipboard` → `False` |
| `settings_dialog.py` | Fallback default → `False` |
| `text_injector.py` | Fallback default → `False` |

Existing users with `copy_to_clipboard: true` in their config are unaffected — this only changes the default for new installs.

## Why

- Avoids unexpected clipboard overwrites on fresh installs
- Reduces background `wl-copy`/`xclip` timeout warnings on Wayland where clipboard access from daemon threads can be unreliable
- Users who want this feature can opt in via Settings