### PR TITLE
fix(suspend): restart keyboard shortcut backend after resume

### DIFF
--- a/src/vocalinux/ui/tray_indicator.py
+++ b/src/vocalinux/ui/tray_indicator.py
@@ -476,6 +476,15 @@ class TrayIndicator:
             self.speech_engine.reinitialize_after_resume()
         except Exception:
             logger.error("Failed to reinitialize after resume", exc_info=True)
+
+        # evdev devices disconnect on suspend; monitor thread exits when all fds close.
+        # Full stop+start re-scans /dev/input and opens fresh file descriptors.
+        try:
+            logger.info("Restarting keyboard shortcuts after resume")
+            self._setup_keyboard_shortcuts()
+        except Exception:
+            logger.error("Failed to restart keyboard shortcuts after resume", exc_info=True)
+
         return GLib.SOURCE_REMOVE
 
     def _on_quit_clicked(self, widget):

--- a/tests/test_suspend_handler.py
+++ b/tests/test_suspend_handler.py
@@ -272,5 +272,58 @@ class TestReinitializeAfterResume(unittest.TestCase):
         mgr._update_state.assert_called_once_with(RecognitionState.ERROR)
 
 
+class TestTrayIndicatorResumeFlow(unittest.TestCase):
+    """Tests for TrayIndicator._reinit_after_resume keyboard restart."""
+
+    def _make_tray_indicator(self):
+        from vocalinux.ui.tray_indicator import TrayIndicator
+
+        with patch.object(TrayIndicator, "__init__", lambda self: None):
+            indicator = TrayIndicator.__new__(TrayIndicator)
+
+        indicator.speech_engine = MagicMock()
+        indicator._setup_keyboard_shortcuts = MagicMock()
+        return indicator
+
+    def test_reinit_after_resume_calls_speech_engine_reinit(self):
+        indicator = self._make_tray_indicator()
+
+        indicator._reinit_after_resume()
+
+        indicator.speech_engine.reinitialize_after_resume.assert_called_once()
+
+    def test_reinit_after_resume_restarts_keyboard_shortcuts(self):
+        indicator = self._make_tray_indicator()
+
+        indicator._reinit_after_resume()
+
+        indicator._setup_keyboard_shortcuts.assert_called_once()
+
+    def test_keyboard_restart_happens_even_if_speech_reinit_fails(self):
+        indicator = self._make_tray_indicator()
+        indicator.speech_engine.reinitialize_after_resume.side_effect = RuntimeError("boom")
+
+        indicator._reinit_after_resume()
+
+        indicator._setup_keyboard_shortcuts.assert_called_once()
+
+    def test_keyboard_restart_failure_does_not_crash(self):
+        indicator = self._make_tray_indicator()
+        indicator._setup_keyboard_shortcuts.side_effect = RuntimeError("no devices")
+
+        indicator._reinit_after_resume()
+
+        indicator.speech_engine.reinitialize_after_resume.assert_called_once()
+
+    def test_returns_source_remove(self):
+        from gi.repository import GLib
+
+        indicator = self._make_tray_indicator()
+
+        result = indicator._reinit_after_resume()
+
+        assert result == GLib.SOURCE_REMOVE
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

Fixes a bug introduced in #369 — after suspend/resume, the speech engine reinitializes but keyboard shortcut recognition stops working.

**Root cause**: On suspend, all evdev keyboard devices disconnect. The `_monitor_devices` thread has `if not self.device_fds: break` (line 307 of `evdev_backend.py`), so when all devices disconnect, the thread exits entirely. On resume, `_reinit_after_resume()` only reinitialized the speech engine — the keyboard backend was left with zero devices and no monitor thread.

**Fix**: Added `self._setup_keyboard_shortcuts()` to `_reinit_after_resume()`, which does a full stop → re-register callbacks → start cycle. This re-scans `/dev/input/`, opens fresh device file descriptors, and spawns a new monitor thread.

## Files changed

| File | Change |
|------|--------|
| `src/vocalinux/ui/tray_indicator.py` | Added keyboard shortcut restart to `_reinit_after_resume()` |
| `tests/test_suspend_handler.py` | Added 5 tests for keyboard restart on resume |

## Test plan

- [x] `pytest tests/test_suspend_handler.py` — 21/21 pass (16 existing + 5 new)
- [x] `pytest tests/` — 1402 passed, 8 pre-existing failures (instance lock from running app, unrelated)
- [x] `black --check --diff` + `flake8` — clean
- [x] Manual: suspend/resume cycle — verify keyboard shortcuts still work

Related to #367 