### PR TITLE
fix(text-injection): handle non-ASCII characters with ydotool via clipboard paste (fixes #362)

### DIFF
--- a/src/vocalinux/text_injection/text_injector.py
+++ b/src/vocalinux/text_injection/text_injector.py
@@ -632,9 +632,90 @@ class TextInjector:
             logger.error(f"xdotool error: {e.stderr}")
             raise
 
+    def _has_non_ascii(self, text: str) -> bool:
+        """Check if text contains any non-ASCII characters."""
+        try:
+            text.encode("ascii")
+            return False
+        except UnicodeEncodeError:
+            return True
+
+    def _inject_via_clipboard_paste(self, text: str) -> bool:
+        """
+        Inject text by copying to clipboard and simulating Ctrl+V.
+
+        This is used as a workaround for tools like ydotool that cannot
+        handle non-ASCII/Unicode characters (accented letters, CJK, etc.)
+        because they simulate evdev key events which only cover US ASCII.
+
+        Returns:
+            True if successful, False otherwise
+        """
+        # Try clipboard tools in order of preference
+        clipboard_cmds = [
+            ["wl-copy", text],
+            ["xclip", "-selection", "clipboard"],
+            ["xsel", "--clipboard", "--input"],
+        ]
+
+        copied = False
+        for cmd in clipboard_cmds:
+            tool = cmd[0]
+            if not shutil.which(tool):
+                continue
+            try:
+                if tool in ("xclip", "xsel"):
+                    subprocess.run(
+                        cmd, input=text, check=True,
+                        stderr=subprocess.PIPE, text=True, timeout=3,
+                    )
+                else:
+                    subprocess.run(
+                        cmd, check=True,
+                        stderr=subprocess.PIPE, text=True, timeout=3,
+                    )
+                copied = True
+                logger.debug(f"Text copied to clipboard using {tool}")
+                break
+            except (subprocess.CalledProcessError, subprocess.TimeoutExpired) as e:
+                logger.debug(f"Clipboard copy with {tool} failed: {e}")
+                continue
+
+        if not copied:
+            logger.warning("Could not copy text to clipboard for paste injection")
+            return False
+
+        # Small delay to ensure clipboard is populated
+        time.sleep(0.05)
+
+        # Simulate Ctrl+V to paste
+        try:
+            if self.wayland_tool == "ydotool":
+                subprocess.run(
+                    ["ydotool", "key", "29:1", "47:1", "47:0", "29:0"],
+                    check=True, stderr=subprocess.PIPE, text=True, timeout=3,
+                )
+            else:  # wtype
+                subprocess.run(
+                    ["wtype", "-M", "ctrl", "v", "-m", "ctrl"],
+                    check=True, stderr=subprocess.PIPE, text=True, timeout=3,
+                )
+            logger.info(
+                f"Text injected via clipboard paste: '{text[:20]}...' ({len(text)} chars)"
+            )
+            return True
+        except (subprocess.CalledProcessError, subprocess.TimeoutExpired) as e:
+            logger.warning(f"Paste simulation failed: {e}")
+            return False
+
     def _inject_with_wayland_tool(self, text: str):
         """
         Inject text using a Wayland-compatible tool (wtype or ydotool).
+
+        For ydotool: if the text contains non-ASCII characters (accented
+        letters like á, é, ú, CJK characters, etc.), uses clipboard-based
+        injection instead, because ydotool simulates evdev key events which
+        only cover US ASCII keycodes. See issue #362.
 
         Args:
             text: The text to inject
@@ -642,6 +723,20 @@ class TextInjector:
         Raises:
             subprocess.CalledProcessError: If the tool fails, with stderr captured
         """
+        # ydotool can only handle ASCII characters because it works at the
+        # evdev keycode level. For non-ASCII text, use clipboard paste instead.
+        if self.wayland_tool == "ydotool" and self._has_non_ascii(text):
+            logger.info(
+                "Text contains non-ASCII characters, using clipboard paste "
+                "for ydotool (evdev keycodes are ASCII-only)"
+            )
+            if self._inject_via_clipboard_paste(text):
+                return
+            logger.warning(
+                "Clipboard paste failed, falling back to ydotool type "
+                "(non-ASCII characters may be dropped)"
+            )
+
         if self.wayland_tool == "wtype":
             cmd = ["wtype", text]
         else:  # ydotool

--- a/src/vocalinux/text_injection/text_injector.py
+++ b/src/vocalinux/text_injection/text_injector.py
@@ -642,77 +642,41 @@ class TextInjector:
 
     def _inject_via_clipboard_paste(self, text: str) -> bool:
         """
-        Inject text by copying to clipboard and simulating Ctrl+V.
+        Inject text by copying to clipboard and simulating Ctrl+V with ydotool.
 
-        This is used as a workaround for tools like ydotool that cannot
-        handle non-ASCII/Unicode characters (accented letters, CJK, etc.)
-        because they simulate evdev key events which only cover US ASCII.
+        This is the workaround for ydotool's inability to type non-ASCII/Unicode
+        characters (accented letters, CJK, etc.) because ydotool simulates evdev
+        key events which only cover US ASCII keycodes. See issue #362.
+
+        Note: this temporarily overwrites the user's clipboard. There is no
+        attempt to restore it afterward, as there is no safe race-free way to
+        do so on Wayland.
 
         Returns:
             True if successful, False otherwise
         """
-        # Try clipboard tools in order of preference
-        clipboard_cmds = [
-            ["wl-copy", text],
-            ["xclip", "-selection", "clipboard"],
-            ["xsel", "--clipboard", "--input"],
-        ]
+        logger.debug(
+            "Using clipboard-paste injection for non-ASCII text "
+            "(user clipboard will be temporarily overwritten)"
+        )
 
-        copied = False
-        for cmd in clipboard_cmds:
-            tool = cmd[0]
-            if not shutil.which(tool):
-                continue
-            try:
-                if tool in ("xclip", "xsel"):
-                    subprocess.run(
-                        cmd,
-                        input=text,
-                        check=True,
-                        stderr=subprocess.PIPE,
-                        text=True,
-                        timeout=3,
-                    )
-                else:
-                    subprocess.run(
-                        cmd,
-                        check=True,
-                        stderr=subprocess.PIPE,
-                        text=True,
-                        timeout=3,
-                    )
-                copied = True
-                logger.debug(f"Text copied to clipboard using {tool}")
-                break
-            except (subprocess.CalledProcessError, subprocess.TimeoutExpired) as e:
-                logger.debug(f"Clipboard copy with {tool} failed: {e}")
-                continue
-
-        if not copied:
+        if not self._copy_to_clipboard(text):
             logger.warning("Could not copy text to clipboard for paste injection")
             return False
 
-        # Small delay to ensure clipboard is populated
-        time.sleep(0.05)
-
-        # Simulate Ctrl+V to paste
+        # Simulate Ctrl+V via ydotool using evdev keycodes:
+        # KEY_LEFTCTRL=29, KEY_V=47; value 1=press, 0=release.
+        # wtype is intentionally not handled here: wtype uses the Wayland
+        # virtual-keyboard protocol which supports Unicode natively, so it
+        # never needs the clipboard-paste workaround.
         try:
-            if self.wayland_tool == "ydotool":
-                subprocess.run(
-                    ["ydotool", "key", "29:1", "47:1", "47:0", "29:0"],
-                    check=True,
-                    stderr=subprocess.PIPE,
-                    text=True,
-                    timeout=3,
-                )
-            else:  # wtype
-                subprocess.run(
-                    ["wtype", "-M", "ctrl", "v", "-m", "ctrl"],
-                    check=True,
-                    stderr=subprocess.PIPE,
-                    text=True,
-                    timeout=3,
-                )
+            subprocess.run(
+                ["ydotool", "key", "29:1", "47:1", "47:0", "29:0"],
+                check=True,
+                stderr=subprocess.PIPE,
+                text=True,
+                timeout=3,
+            )
             logger.info(f"Text injected via clipboard paste: '{text[:20]}...' ({len(text)} chars)")
             return True
         except (subprocess.CalledProcessError, subprocess.TimeoutExpired) as e:

--- a/src/vocalinux/text_injection/text_injector.py
+++ b/src/vocalinux/text_injection/text_injector.py
@@ -666,13 +666,20 @@ class TextInjector:
             try:
                 if tool in ("xclip", "xsel"):
                     subprocess.run(
-                        cmd, input=text, check=True,
-                        stderr=subprocess.PIPE, text=True, timeout=3,
+                        cmd,
+                        input=text,
+                        check=True,
+                        stderr=subprocess.PIPE,
+                        text=True,
+                        timeout=3,
                     )
                 else:
                     subprocess.run(
-                        cmd, check=True,
-                        stderr=subprocess.PIPE, text=True, timeout=3,
+                        cmd,
+                        check=True,
+                        stderr=subprocess.PIPE,
+                        text=True,
+                        timeout=3,
                     )
                 copied = True
                 logger.debug(f"Text copied to clipboard using {tool}")
@@ -693,16 +700,20 @@ class TextInjector:
             if self.wayland_tool == "ydotool":
                 subprocess.run(
                     ["ydotool", "key", "29:1", "47:1", "47:0", "29:0"],
-                    check=True, stderr=subprocess.PIPE, text=True, timeout=3,
+                    check=True,
+                    stderr=subprocess.PIPE,
+                    text=True,
+                    timeout=3,
                 )
             else:  # wtype
                 subprocess.run(
                     ["wtype", "-M", "ctrl", "v", "-m", "ctrl"],
-                    check=True, stderr=subprocess.PIPE, text=True, timeout=3,
+                    check=True,
+                    stderr=subprocess.PIPE,
+                    text=True,
+                    timeout=3,
                 )
-            logger.info(
-                f"Text injected via clipboard paste: '{text[:20]}...' ({len(text)} chars)"
-            )
+            logger.info(f"Text injected via clipboard paste: '{text[:20]}...' ({len(text)} chars)")
             return True
         except (subprocess.CalledProcessError, subprocess.TimeoutExpired) as e:
             logger.warning(f"Paste simulation failed: {e}")

--- a/tests/test_text_injector.py
+++ b/tests/test_text_injector.py
@@ -579,6 +579,110 @@ class TestTextInjector(unittest.TestCase):
             has_ydotool_type = any("'type'" in c for c in calls)
             self.assertTrue(has_ydotool_type, "Should fall back to ydotool type")
 
+    @patch("vocalinux.text_injection.text_injector.time.sleep")
+    @patch("vocalinux.text_injection.text_injector.shutil.which")
+    @patch("vocalinux.text_injection.text_injector.subprocess.run")
+    def test_clipboard_paste_uses_xclip_fallback(self, mock_run, mock_which, mock_sleep):
+        """Test clipboard paste falls back to xclip when wl-copy is unavailable (#362)."""
+        mock_which.side_effect = lambda x: x in ("xclip", "ydotool")
+        mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
+
+        with patch.dict("os.environ", {"XDG_SESSION_TYPE": "wayland", "WAYLAND_DISPLAY": "w-1"}):
+            injector = TextInjector()
+            injector.wayland_tool = "ydotool"
+            injector.environment = DesktopEnvironment.WAYLAND
+
+            result = injector._inject_via_clipboard_paste("café")
+
+            self.assertTrue(result)
+            calls = [c.args[0] for c in mock_run.call_args_list if c.args]
+            has_xclip = any(c[0] == "xclip" for c in calls)
+            self.assertTrue(has_xclip, "Should use xclip as fallback")
+
+    @patch("vocalinux.text_injection.text_injector.time.sleep")
+    @patch("vocalinux.text_injection.text_injector.shutil.which")
+    @patch("vocalinux.text_injection.text_injector.subprocess.run")
+    def test_clipboard_paste_uses_xsel_fallback(self, mock_run, mock_which, mock_sleep):
+        """Test clipboard paste falls back to xsel when wl-copy/xclip unavailable (#362)."""
+        mock_which.side_effect = lambda x: x in ("xsel", "ydotool")
+        mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
+
+        with patch.dict("os.environ", {"XDG_SESSION_TYPE": "wayland", "WAYLAND_DISPLAY": "w-1"}):
+            injector = TextInjector()
+            injector.wayland_tool = "ydotool"
+            injector.environment = DesktopEnvironment.WAYLAND
+
+            result = injector._inject_via_clipboard_paste("café")
+
+            self.assertTrue(result)
+            calls = [c.args[0] for c in mock_run.call_args_list if c.args]
+            has_xsel = any(c[0] == "xsel" for c in calls)
+            self.assertTrue(has_xsel, "Should use xsel as fallback")
+
+    @patch("vocalinux.text_injection.text_injector.time.sleep")
+    @patch("vocalinux.text_injection.text_injector.shutil.which")
+    @patch("vocalinux.text_injection.text_injector.subprocess.run")
+    def test_clipboard_paste_with_wtype(self, mock_run, mock_which, mock_sleep):
+        """Test clipboard paste uses wtype for Ctrl+V when wayland_tool is wtype (#362)."""
+        mock_which.side_effect = lambda x: x in ("wl-copy", "wtype")
+        mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
+
+        with patch.dict("os.environ", {"XDG_SESSION_TYPE": "wayland", "WAYLAND_DISPLAY": "w-1"}):
+            injector = TextInjector()
+            injector.wayland_tool = "wtype"
+            injector.environment = DesktopEnvironment.WAYLAND
+
+            result = injector._inject_via_clipboard_paste("café")
+
+            self.assertTrue(result)
+            calls = [c.args[0] for c in mock_run.call_args_list if c.args]
+            has_wtype_ctrl_v = any(c[0] == "wtype" and "-M" in c for c in calls)
+            self.assertTrue(has_wtype_ctrl_v, "Should use wtype for Ctrl+V paste")
+
+    @patch("vocalinux.text_injection.text_injector.time.sleep")
+    @patch("vocalinux.text_injection.text_injector.shutil.which")
+    @patch("vocalinux.text_injection.text_injector.subprocess.run")
+    def test_clipboard_paste_returns_false_on_paste_failure(self, mock_run, mock_which, mock_sleep):
+        """Test clipboard paste returns False when Ctrl+V simulation fails (#362)."""
+        mock_which.side_effect = lambda x: x in ("wl-copy", "ydotool")
+
+        def side_effect(*args, **kwargs):
+            cmd = args[0]
+            if cmd[0] == "wl-copy":
+                return MagicMock(returncode=0)
+            # ydotool key fails
+            raise subprocess.CalledProcessError(1, cmd)
+
+        mock_run.side_effect = side_effect
+
+        with patch.dict("os.environ", {"XDG_SESSION_TYPE": "wayland", "WAYLAND_DISPLAY": "w-1"}):
+            injector = TextInjector()
+            injector.wayland_tool = "ydotool"
+            injector.environment = DesktopEnvironment.WAYLAND
+
+            result = injector._inject_via_clipboard_paste("café")
+
+            self.assertFalse(result)
+
+    @patch("vocalinux.text_injection.text_injector.is_ibus_active_input_method", return_value=False)
+    @patch("vocalinux.text_injection.text_injector.is_ibus_available", return_value=False)
+    @patch("vocalinux.text_injection.text_injector.shutil.which")
+    def test_clipboard_paste_returns_false_when_no_clipboard_tools(
+        self, mock_which, mock_ibus_avail, mock_ibus_active
+    ):
+        """Test clipboard paste returns False when no clipboard tools available."""
+        # ydotool available for init, but no clipboard tools (wl-copy/xclip/xsel)
+        mock_which.side_effect = lambda x: x if x == "ydotool" else None
+
+        with patch.dict("os.environ", {"XDG_SESSION_TYPE": "wayland", "WAYLAND_DISPLAY": "w-1"}):
+            injector = TextInjector()
+            injector.wayland_tool = "ydotool"
+            injector.environment = DesktopEnvironment.WAYLAND
+
+            result = injector._inject_via_clipboard_paste("café")
+
+            self.assertFalse(result)
+
 
 class TestDesktopEnvironmentEnum(unittest.TestCase):
     """Tests for DesktopEnvironment enum."""

--- a/tests/test_text_injector.py
+++ b/tests/test_text_injector.py
@@ -486,6 +486,99 @@ class TestTextInjector(unittest.TestCase):
             # After failure, should have switched to WAYLAND_XDOTOOL
             self.assertEqual(injector.environment, DesktopEnvironment.WAYLAND_XDOTOOL)
 
+    def test_has_non_ascii_with_ascii_text(self):
+        """Test _has_non_ascii returns False for pure ASCII text."""
+        with patch.dict("os.environ", {"XDG_SESSION_TYPE": "x11"}):
+            injector = TextInjector()
+            self.assertFalse(injector._has_non_ascii("Hello world"))
+            self.assertFalse(injector._has_non_ascii("123 test!"))
+
+    def test_has_non_ascii_with_accented_text(self):
+        """Test _has_non_ascii returns True for accented characters (#362)."""
+        with patch.dict("os.environ", {"XDG_SESSION_TYPE": "x11"}):
+            injector = TextInjector()
+            self.assertTrue(injector._has_non_ascii("Esdrújula"))
+            self.assertTrue(injector._has_non_ascii("crème brûlée"))
+            self.assertTrue(injector._has_non_ascii("café"))
+            self.assertTrue(injector._has_non_ascii("niño"))
+
+    @patch("vocalinux.text_injection.text_injector.is_ibus_active_input_method", return_value=False)
+    @patch("vocalinux.text_injection.text_injector.is_ibus_available", return_value=False)
+    @patch("vocalinux.text_injection.text_injector.shutil.which")
+    @patch("vocalinux.text_injection.text_injector.subprocess.run")
+    def test_ydotool_non_ascii_uses_clipboard_paste(
+        self, mock_run, mock_which, mock_ibus_avail, mock_ibus_active
+    ):
+        """Test that ydotool uses clipboard paste for non-ASCII text (#362)."""
+        mock_which.side_effect = lambda x: x in ("ydotool", "wl-copy")
+        mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
+
+        with patch.dict("os.environ", {"XDG_SESSION_TYPE": "wayland", "WAYLAND_DISPLAY": "w-1"}):
+            injector = TextInjector()
+            injector.wayland_tool = "ydotool"
+            injector.environment = DesktopEnvironment.WAYLAND
+
+            # Reset call list so init calls don't interfere
+            mock_run.reset_mock()
+            injector._inject_with_wayland_tool("Esdrújula")
+
+            # Should have called wl-copy and ydotool key (Ctrl+V), not ydotool type
+            calls = [c.args[0] for c in mock_run.call_args_list]
+            has_wl_copy = any(c[0] == "wl-copy" for c in calls)
+            has_ydotool_key = any(c[:2] == ["ydotool", "key"] for c in calls)
+            has_ydotool_type = any(c[:2] == ["ydotool", "type"] for c in calls)
+
+            self.assertTrue(has_wl_copy, "Should use wl-copy for clipboard")
+            self.assertTrue(has_ydotool_key, "Should use ydotool key for Ctrl+V")
+            self.assertFalse(has_ydotool_type, "Should NOT use ydotool type for non-ASCII")
+
+    @patch("vocalinux.text_injection.text_injector.is_ibus_active_input_method", return_value=False)
+    @patch("vocalinux.text_injection.text_injector.is_ibus_available", return_value=False)
+    @patch("vocalinux.text_injection.text_injector.shutil.which")
+    @patch("vocalinux.text_injection.text_injector.subprocess.run")
+    def test_ydotool_ascii_uses_type_directly(
+        self, mock_run, mock_which, mock_ibus_avail, mock_ibus_active
+    ):
+        """Test that ydotool still uses type for plain ASCII text."""
+        mock_which.side_effect = lambda x: x in ("ydotool", "wl-copy")
+        mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
+
+        with patch.dict("os.environ", {"XDG_SESSION_TYPE": "wayland", "WAYLAND_DISPLAY": "w-1"}):
+            injector = TextInjector()
+            injector.wayland_tool = "ydotool"
+            injector.environment = DesktopEnvironment.WAYLAND
+
+            injector._inject_with_wayland_tool("Hello world")
+
+            # Should use ydotool type directly
+            calls = [str(c) for c in mock_run.call_args_list]
+            has_ydotool_type = any("'type'" in c for c in calls)
+            self.assertTrue(has_ydotool_type, "Should use ydotool type for ASCII text")
+
+    @patch("vocalinux.text_injection.text_injector.is_ibus_active_input_method", return_value=False)
+    @patch("vocalinux.text_injection.text_injector.is_ibus_available", return_value=False)
+    @patch("vocalinux.text_injection.text_injector.shutil.which")
+    @patch("vocalinux.text_injection.text_injector.subprocess.run")
+    def test_ydotool_non_ascii_falls_back_to_type_when_clipboard_fails(
+        self, mock_run, mock_which, mock_ibus_avail, mock_ibus_active
+    ):
+        """Test ydotool falls back to type when clipboard paste fails (#362)."""
+        mock_which.side_effect = lambda x: x == "ydotool"  # no wl-copy
+
+        mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
+
+        with patch.dict("os.environ", {"XDG_SESSION_TYPE": "wayland", "WAYLAND_DISPLAY": "w-1"}):
+            injector = TextInjector()
+            injector.wayland_tool = "ydotool"
+            injector.environment = DesktopEnvironment.WAYLAND
+
+            injector._inject_with_wayland_tool("café")
+
+            # Should fall back to ydotool type since no clipboard tool available
+            calls = [str(c) for c in mock_run.call_args_list]
+            has_ydotool_type = any("'type'" in c for c in calls)
+            self.assertTrue(has_ydotool_type, "Should fall back to ydotool type")
+
 
 class TestDesktopEnvironmentEnum(unittest.TestCase):
     """Tests for DesktopEnvironment enum."""

--- a/tests/test_text_injector.py
+++ b/tests/test_text_injector.py
@@ -548,12 +548,18 @@ class TestTextInjector(unittest.TestCase):
             injector.wayland_tool = "ydotool"
             injector.environment = DesktopEnvironment.WAYLAND
 
+            mock_run.reset_mock()
             injector._inject_with_wayland_tool("Hello world")
 
-            # Should use ydotool type directly
-            calls = [str(c) for c in mock_run.call_args_list]
-            has_ydotool_type = any("'type'" in c for c in calls)
-            self.assertTrue(has_ydotool_type, "Should use ydotool type for ASCII text")
+            calls = [c.args[0] for c in mock_run.call_args_list if c.args]
+            self.assertTrue(
+                any(c[:2] == ["ydotool", "type"] for c in calls),
+                "Should use ydotool type for ASCII text",
+            )
+            self.assertFalse(
+                any(c[0] == "wl-copy" for c in calls),
+                "Should NOT invoke clipboard for ASCII text",
+            )
 
     @patch("vocalinux.text_injection.text_injector.is_ibus_active_input_method", return_value=False)
     @patch("vocalinux.text_injection.text_injector.is_ibus_available", return_value=False)
@@ -579,10 +585,9 @@ class TestTextInjector(unittest.TestCase):
             has_ydotool_type = any("'type'" in c for c in calls)
             self.assertTrue(has_ydotool_type, "Should fall back to ydotool type")
 
-    @patch("vocalinux.text_injection.text_injector.time.sleep")
     @patch("vocalinux.text_injection.text_injector.shutil.which")
     @patch("vocalinux.text_injection.text_injector.subprocess.run")
-    def test_clipboard_paste_uses_xclip_fallback(self, mock_run, mock_which, mock_sleep):
+    def test_clipboard_paste_uses_xclip_fallback(self, mock_run, mock_which):
         """Test clipboard paste falls back to xclip when wl-copy is unavailable (#362)."""
         mock_which.side_effect = lambda x: x in ("xclip", "ydotool")
         mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
@@ -599,10 +604,9 @@ class TestTextInjector(unittest.TestCase):
             has_xclip = any(c[0] == "xclip" for c in calls)
             self.assertTrue(has_xclip, "Should use xclip as fallback")
 
-    @patch("vocalinux.text_injection.text_injector.time.sleep")
     @patch("vocalinux.text_injection.text_injector.shutil.which")
     @patch("vocalinux.text_injection.text_injector.subprocess.run")
-    def test_clipboard_paste_uses_xsel_fallback(self, mock_run, mock_which, mock_sleep):
+    def test_clipboard_paste_uses_xsel_fallback(self, mock_run, mock_which):
         """Test clipboard paste falls back to xsel when wl-copy/xclip unavailable (#362)."""
         mock_which.side_effect = lambda x: x in ("xsel", "ydotool")
         mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
@@ -619,12 +623,15 @@ class TestTextInjector(unittest.TestCase):
             has_xsel = any(c[0] == "xsel" for c in calls)
             self.assertTrue(has_xsel, "Should use xsel as fallback")
 
-    @patch("vocalinux.text_injection.text_injector.time.sleep")
+    @patch("vocalinux.text_injection.text_injector.is_ibus_active_input_method", return_value=False)
+    @patch("vocalinux.text_injection.text_injector.is_ibus_available", return_value=False)
     @patch("vocalinux.text_injection.text_injector.shutil.which")
     @patch("vocalinux.text_injection.text_injector.subprocess.run")
-    def test_clipboard_paste_with_wtype(self, mock_run, mock_which, mock_sleep):
-        """Test clipboard paste uses wtype for Ctrl+V when wayland_tool is wtype (#362)."""
-        mock_which.side_effect = lambda x: x in ("wl-copy", "wtype")
+    def test_wtype_injects_unicode_directly(
+        self, mock_run, mock_which, mock_ibus_avail, mock_ibus_active
+    ):
+        """wtype supports Unicode natively and must NOT use the clipboard-paste path."""
+        mock_which.side_effect = lambda x: x in ("wtype", "wl-copy")
         mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
 
         with patch.dict("os.environ", {"XDG_SESSION_TYPE": "wayland", "WAYLAND_DISPLAY": "w-1"}):
@@ -632,17 +639,22 @@ class TestTextInjector(unittest.TestCase):
             injector.wayland_tool = "wtype"
             injector.environment = DesktopEnvironment.WAYLAND
 
-            result = injector._inject_via_clipboard_paste("café")
+            mock_run.reset_mock()
+            injector._inject_with_wayland_tool("café")
 
-            self.assertTrue(result)
             calls = [c.args[0] for c in mock_run.call_args_list if c.args]
-            has_wtype_ctrl_v = any(c[0] == "wtype" and "-M" in c for c in calls)
-            self.assertTrue(has_wtype_ctrl_v, "Should use wtype for Ctrl+V paste")
+            self.assertTrue(
+                any(c[0] == "wtype" and c[1] == "café" for c in calls),
+                "wtype should inject text directly",
+            )
+            self.assertFalse(
+                any(c[0] == "wl-copy" for c in calls),
+                "wtype must NOT use clipboard-paste workaround",
+            )
 
-    @patch("vocalinux.text_injection.text_injector.time.sleep")
     @patch("vocalinux.text_injection.text_injector.shutil.which")
     @patch("vocalinux.text_injection.text_injector.subprocess.run")
-    def test_clipboard_paste_returns_false_on_paste_failure(self, mock_run, mock_which, mock_sleep):
+    def test_clipboard_paste_returns_false_on_paste_failure(self, mock_run, mock_which):
         """Test clipboard paste returns False when Ctrl+V simulation fails (#362)."""
         mock_which.side_effect = lambda x: x in ("wl-copy", "ydotool")
 
@@ -682,6 +694,40 @@ class TestTextInjector(unittest.TestCase):
             result = injector._inject_via_clipboard_paste("café")
 
             self.assertFalse(result)
+
+    @patch("vocalinux.text_injection.text_injector.is_ibus_active_input_method", return_value=False)
+    @patch("vocalinux.text_injection.text_injector.is_ibus_available", return_value=False)
+    @patch("vocalinux.text_injection.text_injector.shutil.which")
+    @patch("vocalinux.text_injection.text_injector.subprocess.run")
+    def test_inject_text_ydotool_non_ascii_end_to_end(
+        self, mock_run, mock_which, mock_ibus_avail, mock_ibus_active
+    ):
+        """inject_text routes accented text through clipboard-paste on Wayland+ydotool (#362)."""
+        mock_which.side_effect = lambda x: x in ("ydotool", "wl-copy")
+        mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
+
+        with patch.dict("os.environ", {"XDG_SESSION_TYPE": "wayland", "WAYLAND_DISPLAY": "w-1"}):
+            injector = TextInjector()
+            injector.wayland_tool = "ydotool"
+            injector.environment = DesktopEnvironment.WAYLAND
+
+            mock_run.reset_mock()
+            result = injector.inject_text("Esdrújula")
+
+            self.assertTrue(result)
+            calls = [c.args[0] for c in mock_run.call_args_list if c.args]
+            self.assertTrue(
+                any(c[0] == "wl-copy" for c in calls),
+                "Should copy to clipboard via wl-copy",
+            )
+            self.assertTrue(
+                any(c[:2] == ["ydotool", "key"] for c in calls),
+                "Should simulate Ctrl+V via ydotool key",
+            )
+            self.assertFalse(
+                any(c[:2] == ["ydotool", "type"] for c in calls),
+                "Should NOT call ydotool type for non-ASCII text",
+            )
 
 
 class TestDesktopEnvironmentEnum(unittest.TestCase):


### PR DESCRIPTION
## Problem

Users dictating accented or non-ASCII characters (á, é, í, ó, ú, ñ, CJK, etc.) on Wayland with **ydotool** would see those characters silently dropped. This affects setups like KDE Plasma / Debian / Wayland without IBus.

Root cause: ydotool simulates raw evdev keycodes, which only map to US ASCII. There is no evdev keycode for characters like `é` or `ñ`, so they are simply lost.

Fixes #362.

## Solution

When ydotool is the active Wayland tool **and** the text contains non-ASCII characters, inject via clipboard-paste instead:

1. Copy the full text to the clipboard (`wl-copy` → `xclip` → `xsel` in that preference order)
2. Simulate Ctrl+V via `ydotool key 29:1 47:1 47:0 29:0` (evdev keycodes for Ctrl+V)

Plain ASCII text continues to use `ydotool type` directly (no behavioral change for the common case). `wtype` is unaffected — it uses the Wayland virtual-keyboard protocol which supports Unicode natively.

> **Side-effect**: the user's clipboard is temporarily overwritten during injection. There is no safe race-free way to restore it on Wayland, so this is documented in the code and the debug log.

## Changes

### `src/vocalinux/text_injection/text_injector.py`

- Add `_inject_via_clipboard_paste(text)` — clipboard-based injection for ydotool + non-ASCII
- Add `_inject_with_wayland_tool(text)` routing: ASCII → `ydotool type`; non-ASCII → `_inject_via_clipboard_paste`; wtype always uses direct injection
- `_copy_to_clipboard` helper tries `wl-copy`, `xclip`, `xsel` in order (reused by the new path)

**Refactoring (post-review):**
- `_inject_via_clipboard_paste` now delegates to `_copy_to_clipboard` instead of reimplementing clipboard-tool selection — removes ~30 lines of duplication
- Removed unreachable `wtype` branch from `_inject_via_clipboard_paste` (wtype never calls this path)
- Dropped unnecessary `time.sleep(0.05)` after clipboard write (`subprocess.run` is synchronous)
- Added `logger.debug` noting clipboard will be temporarily overwritten

### `tests/test_text_injector.py`

- `test_ydotool_ascii_uses_type_directly` — fixed fragile string-repr assertion; now compares actual list slices and also asserts wl-copy is **not** called for ASCII text
- `test_wtype_injects_unicode_directly` — replaces old wtype test; actively asserts wtype injects directly **and** does not touch the clipboard
- `test_inject_text_ydotool_non_ascii_end_to_end` — new end-to-end test through `inject_text()` → `_inject_with_wayland_tool()` → `_inject_via_clipboard_paste()` for accented text on Wayland+ydotool
- Removed now-unnecessary `@patch('time.sleep')` decorators from three tests

## Testing

```
pytest tests/test_text_injector.py -v   # 64 passed
make lint                               # black + isort + flake8 all clean
```

## Compatibility

| Setup | Behaviour |
|---|---|
| Wayland + ydotool + ASCII text | Unchanged — `ydotool type` |
| Wayland + ydotool + non-ASCII | **Fixed** — clipboard-paste via Ctrl+V |
| Wayland + wtype (any text) | Unchanged — `wtype` direct |
| X11 (any tool) | Unchanged — xdotool path not touched |
| IBus active | Unchanged — IBus path takes priority |

## Notes

- Requires at least one of `wl-copy`, `xclip`, or `xsel` to be installed for non-ASCII injection. If none is found, the method returns `False` and logs a warning (graceful degradation — same behavior as before for that edge case).
- This PR was rebased onto current `main` (commit `45a69d5`) with no conflicts.
