### PR TITLE
test(tray): add missing AppIndicator coverage follow-up

### DIFF
--- a/tests/test_main_args_deps.py
+++ b/tests/test_main_args_deps.py
@@ -150,6 +150,19 @@ class TestCheckDependencies(unittest.TestCase):
                 result = check_dependencies()
                 assert result is False
 
+    def test_check_dependencies_logs_gnome_extension_guidance(self):
+        from vocalinux.main import check_dependencies
+
+        with patch("vocalinux.main.logger") as mock_logger:
+            with patch("builtins.__import__", side_effect=ImportError("No module")):
+                result = check_dependencies()
+
+        assert result is False
+        mock_logger.error.assert_any_call(
+            "  NOTE: On GNOME Shell (default on Debian), you also need:"
+        )
+        mock_logger.error.assert_any_call("    sudo apt install gnome-shell-extension-appindicator")
+
 
 class TestCheckDisplayAvailable(unittest.TestCase):
     """Tests for check_display_available() function."""
@@ -439,15 +452,15 @@ class TestMainFunction(unittest.TestCase):
             "general": {"first_run": False},
         }
 
+        mock_speech_manager_ctor = MagicMock(side_effect=Exception("stop"))
+
         with patch.dict(
             sys.modules,
             {
                 "vocalinux.single_instance": mock_single_instance,
                 "vocalinux.common_types": MagicMock(),
                 "vocalinux.speech_recognition": MagicMock(
-                    recognition_manager=MagicMock(
-                        SpeechRecognitionManager=MagicMock(side_effect=Exception("stop"))
-                    )
+                    recognition_manager=MagicMock(SpeechRecognitionManager=mock_speech_manager_ctor)
                 ),
                 "vocalinux.text_injection.text_injector": MagicMock(),
                 "vocalinux.ui.tray_indicator": MagicMock(),
@@ -467,6 +480,7 @@ class TestMainFunction(unittest.TestCase):
                     "No StatusNotifierWatcher found on D-Bus session bus."
                 )
                 mock_logger.warning.assert_any_call("The system tray icon may not appear.")
+                mock_speech_manager_ctor.assert_called_once()
 
     @patch("vocalinux.main.logging")
     @patch("vocalinux.main.check_dependencies")

--- a/tests/test_tray_indicator.py
+++ b/tests/test_tray_indicator.py
@@ -510,3 +510,40 @@ class TestTrayIndicator(unittest.TestCase):
                 result = self.tray_indicator._init_indicator()
                 self.assertEqual(result, False)
                 mock_error_dialog.assert_called_once_with("boom")
+
+    def test_init_indicator_creation_failure_without_prior_init_state(self):
+        from vocalinux.ui.tray_indicator import TrayIndicator
+
+        tray = TrayIndicator.__new__(TrayIndicator)
+        tray.icon_paths = {}
+        tray._show_appindicator_error_dialog = MagicMock(return_value=False)
+
+        with patch("vocalinux.ui.tray_indicator.os.path.exists", return_value=False):
+            with patch(
+                "vocalinux.ui.tray_indicator.AppIndicator3.Indicator.new_with_path",
+                side_effect=Exception("fresh-boom"),
+            ):
+                with patch(
+                    "vocalinux.ui.tray_indicator.GLib.idle_add",
+                    side_effect=lambda func, *args: func(*args),
+                ):
+                    result = TrayIndicator._init_indicator(tray)
+
+        self.assertEqual(result, False)
+        tray._show_appindicator_error_dialog.assert_called_once_with("fresh-boom")
+        self.assertFalse(hasattr(tray, "indicator"))
+
+    def test_update_ui_returns_false_when_indicator_missing(self):
+        from vocalinux.common_types import RecognitionState
+
+        if hasattr(self.tray_indicator, "indicator"):
+            delattr(self.tray_indicator, "indicator")
+
+        result = self.tray_indicator._update_ui(RecognitionState.IDLE)
+        self.assertEqual(result, False)
+
+    def test_set_menu_item_enabled_noop_when_menu_missing(self):
+        if hasattr(self.tray_indicator, "menu"):
+            delattr(self.tray_indicator, "menu")
+
+        self.tray_indicator._set_menu_item_enabled("Start Voice Typing", True)


### PR DESCRIPTION
## Summary
- Add the missing follow-up tests that were not included in `main` after PR #385 merged.
- Cover degraded-startup guard paths in tray logic and GNOME extension guidance assertions.

## Included Tests
- `tests/test_tray_indicator.py`
  - `test_init_indicator_creation_failure_without_prior_init_state`
  - `test_update_ui_returns_false_when_indicator_missing`
  - `test_set_menu_item_enabled_noop_when_menu_missing`
- `tests/test_main_args_deps.py`
  - `test_check_dependencies_logs_gnome_extension_guidance`
  - strengthened warning-path test to assert startup continues past warning branch

## Validation
- `python3 -m pytest -o addopts='' tests/test_main.py tests/test_main_args_deps.py tests/test_main_edge_cases.py tests/test_tray_indicator.py tests/test_tray_indicator_ext.py`
- Result: 99 passed

## Context
PR #385 was merged before this follow-up coverage commit landed, so these tests are being merged via a separate PR.