### PR TITLE
Add Moonshine STT support

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,6 +57,9 @@ whisper = [
     "torch>=2.0.0",
     "torchaudio>=2.0.0",
 ]
+moonshine = [
+    "moonshine-voice>=0.0.56",
+]
 dev = [
     "pytest>=7.0.0",
     "pytest-cov>=4.0.0",

--- a/src/vocalinux/main.py
+++ b/src/vocalinux/main.py
@@ -61,9 +61,7 @@ def parse_arguments():
         choices=["vosk", "whisper", "whisper_cpp", "moonshine"],
         help="Speech recognition engine to use (whisper_cpp recommended for best performance)",
     )
-    parser.add_argument(
-        "--wayland", action="store_true", help="Force Wayland compatibility mode"
-    )
+    parser.add_argument("--wayland", action="store_true", help="Force Wayland compatibility mode")
     parser.add_argument(
         "--start-minimized",
         action="store_true",
@@ -136,9 +134,7 @@ def check_dependencies():
             logger.error("  Then log out and back in. Ubuntu includes this by default.")
             logger.error("")
             logger.error("  Fedora:")
-            logger.error(
-                "    sudo dnf install python3-gobject gtk3 libappindicator-gtk3"
-            )
+            logger.error("    sudo dnf install python3-gobject gtk3 libappindicator-gtk3")
             logger.error("")
             logger.error("  Arch Linux:")
             logger.error("    sudo pacman -S python-gobject gtk3 libappindicator")
@@ -166,9 +162,7 @@ def check_display_available():
 
         display = Gdk.Display.get_default()
         if display is None:
-            logger.error(
-                "No display available. Vocalinux requires a graphical environment."
-            )
+            logger.error("No display available. Vocalinux requires a graphical environment.")
             logger.error("")
             logger.error("If running remotely, ensure DISPLAY is set:")
             logger.error("  export DISPLAY=:0")
@@ -259,16 +253,12 @@ def main():
         logger.warning("No StatusNotifierWatcher found on D-Bus session bus.")
         logger.warning("The system tray icon may not appear.")
         logger.warning("")
-        logger.warning(
-            "If you are using GNOME Shell, install the AppIndicator extension:"
-        )
+        logger.warning("If you are using GNOME Shell, install the AppIndicator extension:")
         logger.warning("  Debian:  sudo apt install gnome-shell-extension-appindicator")
         logger.warning("  Fedora:  sudo dnf install gnome-shell-extension-appindicator")
         logger.warning("  Arch:    sudo pacman -S gnome-shell-extension-appindicator")
         logger.warning("")
-        logger.warning(
-            "After installing, log out and back in (or restart GNOME Shell)."
-        )
+        logger.warning("After installing, log out and back in (or restart GNOME Shell).")
 
     # Now it's safe to import GTK-dependent modules
     from .common_types import RecognitionState
@@ -360,13 +350,9 @@ def main():
     voice_commands_enabled = saved_settings.get("voice_commands_enabled")  # None = auto
     audio_device_index = audio_settings.get("device_index", None)
 
-    logger.info(
-        f"Final settings: engine={engine}, language={language}, model={model_size}"
-    )
+    logger.info(f"Final settings: engine={engine}, language={language}, model={model_size}")
     if audio_device_index is not None:
-        logger.info(
-            f"Using audio device index={audio_device_index} (from saved config)"
-        )
+        logger.info(f"Using audio device index={audio_device_index} (from saved config)")
 
     # Initialize main components
     logger.info("Initializing Vocalinux...")
@@ -427,10 +413,7 @@ def main():
             # Add a separating space between consecutive dictation segments,
             # but never for the very first segment (avoids unwanted leading space
             # when starting dictation in an empty text field).
-            if (
-                action_handler.last_injected_text
-                and action_handler.last_injected_text.strip()
-            ):
+            if action_handler.last_injected_text and action_handler.last_injected_text.strip():
                 text_to_inject = " " + text_to_inject
                 logger.debug("Added space separator before new segment")
 

--- a/src/vocalinux/main.py
+++ b/src/vocalinux/main.py
@@ -61,7 +61,9 @@ def parse_arguments():
         choices=["vosk", "whisper", "whisper_cpp", "moonshine"],
         help="Speech recognition engine to use (whisper_cpp recommended for best performance)",
     )
-    parser.add_argument("--wayland", action="store_true", help="Force Wayland compatibility mode")
+    parser.add_argument(
+        "--wayland", action="store_true", help="Force Wayland compatibility mode"
+    )
     parser.add_argument(
         "--start-minimized",
         action="store_true",
@@ -134,7 +136,9 @@ def check_dependencies():
             logger.error("  Then log out and back in. Ubuntu includes this by default.")
             logger.error("")
             logger.error("  Fedora:")
-            logger.error("    sudo dnf install python3-gobject gtk3 libappindicator-gtk3")
+            logger.error(
+                "    sudo dnf install python3-gobject gtk3 libappindicator-gtk3"
+            )
             logger.error("")
             logger.error("  Arch Linux:")
             logger.error("    sudo pacman -S python-gobject gtk3 libappindicator")
@@ -162,7 +166,9 @@ def check_display_available():
 
         display = Gdk.Display.get_default()
         if display is None:
-            logger.error("No display available. Vocalinux requires a graphical environment.")
+            logger.error(
+                "No display available. Vocalinux requires a graphical environment."
+            )
             logger.error("")
             logger.error("If running remotely, ensure DISPLAY is set:")
             logger.error("  export DISPLAY=:0")
@@ -253,12 +259,16 @@ def main():
         logger.warning("No StatusNotifierWatcher found on D-Bus session bus.")
         logger.warning("The system tray icon may not appear.")
         logger.warning("")
-        logger.warning("If you are using GNOME Shell, install the AppIndicator extension:")
+        logger.warning(
+            "If you are using GNOME Shell, install the AppIndicator extension:"
+        )
         logger.warning("  Debian:  sudo apt install gnome-shell-extension-appindicator")
         logger.warning("  Fedora:  sudo dnf install gnome-shell-extension-appindicator")
         logger.warning("  Arch:    sudo pacman -S gnome-shell-extension-appindicator")
         logger.warning("")
-        logger.warning("After installing, log out and back in (or restart GNOME Shell).")
+        logger.warning(
+            "After installing, log out and back in (or restart GNOME Shell)."
+        )
 
     # Now it's safe to import GTK-dependent modules
     from .common_types import RecognitionState
@@ -350,9 +360,13 @@ def main():
     voice_commands_enabled = saved_settings.get("voice_commands_enabled")  # None = auto
     audio_device_index = audio_settings.get("device_index", None)
 
-    logger.info(f"Final settings: engine={engine}, language={language}, model={model_size}")
+    logger.info(
+        f"Final settings: engine={engine}, language={language}, model={model_size}"
+    )
     if audio_device_index is not None:
-        logger.info(f"Using audio device index={audio_device_index} (from saved config)")
+        logger.info(
+            f"Using audio device index={audio_device_index} (from saved config)"
+        )
 
     # Initialize main components
     logger.info("Initializing Vocalinux...")
@@ -413,7 +427,10 @@ def main():
             # Add a separating space between consecutive dictation segments,
             # but never for the very first segment (avoids unwanted leading space
             # when starting dictation in an empty text field).
-            if action_handler.last_injected_text and action_handler.last_injected_text.strip():
+            if (
+                action_handler.last_injected_text
+                and action_handler.last_injected_text.strip()
+            ):
                 text_to_inject = " " + text_to_inject
                 logger.debug("Added space separator before new segment")
 

--- a/src/vocalinux/main.py
+++ b/src/vocalinux/main.py
@@ -28,8 +28,8 @@ def parse_arguments():
     parser.add_argument(
         "--model",
         type=str,
-        choices=["small", "medium", "large"],
-        help="Speech recognition model size (small, medium, large)",
+        choices=["auto", "tiny", "base", "small", "medium", "large"],
+        help="Speech recognition model size (auto, tiny, base, small, medium, large)",
     )
     parser.add_argument(
         "--language",
@@ -58,7 +58,7 @@ def parse_arguments():
     parser.add_argument(
         "--engine",
         type=str,
-        choices=["vosk", "whisper", "whisper_cpp"],
+        choices=["vosk", "whisper", "whisper_cpp", "moonshine"],
         help="Speech recognition engine to use (whisper_cpp recommended for best performance)",
     )
     parser.add_argument("--wayland", action="store_true", help="Force Wayland compatibility mode")

--- a/src/vocalinux/speech_recognition/recognition_manager.py
+++ b/src/vocalinux/speech_recognition/recognition_manager.py
@@ -17,6 +17,12 @@ from typing import Callable, Optional
 
 from ..common_types import RecognitionState
 from ..ui.audio_feedback import play_error_sound, play_start_sound, play_stop_sound
+from ..utils.moonshine_model_info import (
+    get_moonshine_default_model_size,
+    get_moonshine_supported_model_sizes,
+    resolve_moonshine_language,
+    resolve_moonshine_model_arch_name,
+)
 from ..utils.vosk_model_info import VOSK_MODEL_INFO
 from ..utils.whispercpp_model_info import WHISPERCPP_MODEL_INFO, get_model_path, is_model_downloaded
 from .command_processor import CommandProcessor
@@ -591,6 +597,8 @@ class SpeechRecognitionManager:
             self._init_whisper()
         elif engine == "whisper_cpp":
             self._init_whispercpp()
+        elif engine == "moonshine":
+            self._init_moonshine()
         else:
             raise ValueError(f"Unsupported speech recognition engine: {engine}")
 
@@ -719,6 +727,79 @@ class SpeechRecognitionManager:
             logger.error(f"Failed to initialize Whisper engine: {e}")
             self.state = RecognitionState.ERROR
             raise
+
+    def _init_moonshine(self):
+        """Initialize the Moonshine speech recognition engine."""
+        try:
+            from moonshine_voice import Transcriber, get_model_for_language
+            from moonshine_voice.moonshine_api import ModelArch
+
+            moonshine_language, language_fallback = resolve_moonshine_language(self.language)
+            valid_models = get_moonshine_supported_model_sizes(self.language)
+            arch_name, model_fallback = resolve_moonshine_model_arch_name(
+                self.model_size, self.language
+            )
+
+            if self.language == "auto":
+                logger.info("Moonshine does not support auto language detection; using English.")
+            elif language_fallback:
+                logger.warning(
+                    f"Moonshine does not support Vocalinux language '{self.language}'. "
+                    "Falling back to English."
+                )
+
+            if self.model_size in ("", "auto", None):
+                logger.info(
+                    f"Moonshine model selection is auto for language '{moonshine_language}'. "
+                    "Using moonshine_voice default."
+                )
+            elif model_fallback:
+                fallback_model = get_moonshine_default_model_size(self.language)
+                logger.warning(
+                    f"Model size '{self.model_size}' is not directly supported by Moonshine "
+                    f"for language '{moonshine_language}'. Valid options: {valid_models}. "
+                    f"Using '{fallback_model}' instead."
+                )
+                self.model_size = fallback_model
+
+            logger.info(
+                f"Resolving Moonshine model for language '{moonshine_language}' "
+                f"with model selection '{self.model_size}'"
+            )
+
+            if arch_name is None:
+                model_path, model_arch = get_model_for_language(
+                    wanted_language=moonshine_language
+                )
+            else:
+                model_arch = getattr(ModelArch, arch_name)
+                model_path, model_arch = get_model_for_language(
+                    wanted_language=moonshine_language,
+                    wanted_model_arch=model_arch,
+                )
+
+            logger.info(
+                f"Loading Moonshine model from {model_path} "
+                f"(language={moonshine_language}, arch={model_arch})"
+            )
+
+            self.model = None
+            self.recognizer = None
+            self.model = Transcriber(model_path=model_path, model_arch=model_arch)
+
+            self._model_initialized = True
+            logger.info("Moonshine engine initialized successfully.")
+
+        except ImportError as e:
+            logger.error(f"Failed to import Moonshine: {e}")
+            logger.error("Please install with: pip install moonshine-voice")
+            self.state = RecognitionState.ERROR
+            raise
+        except (AttributeError, RuntimeError, OSError, ValueError) as e:
+            logger.error(f"Failed to initialize Moonshine engine: {e}", exc_info=True)
+            self.state = RecognitionState.ERROR
+            raise
+
 
     def _transcribe_with_whisper(self, audio_buffer: list[bytes]) -> str:
         """
@@ -1036,6 +1117,80 @@ class SpeechRecognitionManager:
             )
             logger.error(f"Error in whisper.cpp transcription: {e} ({audio_info})", exc_info=True)
             return ""
+
+    def _transcribe_with_moonshine(self, audio_buffer: list[bytes]) -> str:
+        """
+        Transcribe audio buffer using Moonshine.
+
+        Args:
+            audio_buffer: List of audio data chunks (16-bit PCM at 16kHz)
+
+        Returns:
+            Transcribed text
+        """
+        import time
+
+        try:
+            import numpy as np
+
+            if not audio_buffer:
+                return ""
+
+            # Convert audio buffer to normalized float audio for moonshine_voice
+            audio_data = np.frombuffer(b"".join(audio_buffer), dtype=np.int16)
+            audio_float = (audio_data.astype(np.float32) / 32768.0).tolist()
+
+            duration = len(audio_float) / 16000.0
+            num_chunks = len(audio_buffer)
+            logger.debug(
+                f"Moonshine audio preprocessing: {len(audio_float)} samples, "
+                f"{duration:.2f}s, {num_chunks} chunks"
+            )
+
+            with self._model_lock:
+                if self.model is None:
+                    logger.warning("Model is None during Moonshine transcription, returning empty result")
+                    return ""
+
+                transcribe_start = time.time()
+                transcript = self.model.transcribe_without_streaming(
+                    audio_float, sample_rate=16000
+                )
+                transcribe_duration = time.time() - transcribe_start
+
+            text_parts = []
+            for line in getattr(transcript, "lines", []) or []:
+                line_text = getattr(line, "text", "") or ""
+                filtered_text = _filter_non_speech(line_text.strip())
+                if filtered_text:
+                    text_parts.append(filtered_text)
+
+            text = " ".join(text_parts).strip()
+            num_lines = len(text_parts)
+            rtf = transcribe_duration / duration if duration > 0 else 0
+
+            if text:
+                logger.info(f"Moonshine transcribed: '{text}'")
+                logger.info(
+                    f"Moonshine transcription completed in {transcribe_duration:.3f}s "
+                    f"for {duration:.2f}s audio (RTF: {rtf:.2f}x) - {num_lines} lines"
+                )
+            else:
+                logger.debug(
+                    f"Moonshine returned empty transcription ({transcribe_duration:.3f}s)"
+                )
+
+            return text
+
+        except Exception as e:
+            audio_info = (
+                f"audio buffer: {len(audio_buffer)} chunks"
+                if audio_buffer
+                else "empty audio buffer"
+            )
+            logger.error(f"Error in Moonshine transcription: {e} ({audio_info})", exc_info=True)
+            return ""
+
 
     def _download_whispercpp_model(self):
         """Download a whisper.cpp model with progress tracking."""
@@ -1898,6 +2053,9 @@ class SpeechRecognitionManager:
         elif self.engine == "whisper_cpp":
             text = self._transcribe_with_whispercpp(audio_buffer)
 
+        elif self.engine == "moonshine":
+            text = self._transcribe_with_moonshine(audio_buffer)
+
         else:
             logger.error(f"Unknown engine: {self.engine}")
             return
@@ -2124,6 +2282,8 @@ class SpeechRecognitionManager:
                         self._init_whisper()
                     elif self.engine == "whisper_cpp":
                         self._init_whispercpp()
+                    elif self.engine == "moonshine":
+                        self._init_moonshine()
                     else:
                         raise ValueError(f"Unsupported engine during reconfigure: {self.engine}")
                     logger.info("Speech engine re-initialized successfully.")
@@ -2252,6 +2412,8 @@ class SpeechRecognitionManager:
                     self._init_whisper()
                 elif self.engine == "whisper_cpp":
                     self._init_whispercpp()
+                elif self.engine == "moonshine":
+                    self._init_moonshine()
                 else:
                     logger.error("Cannot reinitialize: unknown engine '%s'", self.engine)
                     return

--- a/src/vocalinux/speech_recognition/recognition_manager.py
+++ b/src/vocalinux/speech_recognition/recognition_manager.py
@@ -176,9 +176,7 @@ def _get_supported_channels(audio, device_index: Optional[int] = None) -> int:
             except (IOError, OSError) as e:
                 error_str = str(e).lower()
                 if "invalid number of channels" in error_str or "-9998" in error_str:
-                    logger.debug(
-                        f"Device rejected {channels} channel(s) at {rate}Hz: {e}"
-                    )
+                    logger.debug(f"Device rejected {channels} channel(s) at {rate}Hz: {e}")
                 else:
                     logger.debug(f"Channel test failed at {rate}Hz: {e}")
                 continue
@@ -187,9 +185,7 @@ def _get_supported_channels(audio, device_index: Optional[int] = None) -> int:
     return 1
 
 
-def _get_supported_sample_rate(
-    audio, device_index: Optional[int], channels: int = 1
-) -> int:
+def _get_supported_sample_rate(audio, device_index: Optional[int], channels: int = 1) -> int:
     """
     Get a supported sample rate for the audio device.
 
@@ -239,9 +235,7 @@ def _get_supported_sample_rate(
                 logger.debug(f"Using device default sample rate: {default_rate}Hz")
                 return default_rate
             except (IOError, OSError):
-                logger.debug(
-                    f"Device default rate {default_rate}Hz failed, trying common rates"
-                )
+                logger.debug(f"Device default rate {default_rate}Hz failed, trying common rates")
     except (IOError, OSError) as e:
         logger.debug(f"Could not get device default rate: {e}")
 
@@ -559,9 +553,7 @@ class SpeechRecognitionManager:
         self.action_callbacks: list[Callable[[str], None]] = []
 
         # Download progress tracking
-        self._download_progress_callback: Optional[
-            Callable[[float, float, str], None]
-        ] = None
+        self._download_progress_callback: Optional[Callable[[float, float, str], None]] = None
         self._download_cancelled = False
         self._defer_download = defer_download
         self._model_initialized = False
@@ -644,31 +636,18 @@ class SpeechRecognitionManager:
                     self._model_initialized = False
                     return  # Don't block startup
                 else:
-                    logger.info(
-                        f"VOSK model not found at {self.vosk_model_path}. Downloading..."
-                    )
+                    logger.info(f"VOSK model not found at {self.vosk_model_path}. Downloading...")
                     self._download_vosk_model()
                     # Update path after download
                     self.vosk_model_path = self._get_vosk_model_path()
             else:
                 # Check if this is a pre-installed model
-                if any(
-                    self.vosk_model_path.startswith(sys_dir)
-                    for sys_dir in SYSTEM_MODELS_DIRS
-                ):
-                    logger.info(
-                        f"Using pre-installed VOSK model from {self.vosk_model_path}"
-                    )
-                elif os.path.exists(
-                    os.path.join(self.vosk_model_path, ".vocalinux_preinstalled")
-                ):
-                    logger.info(
-                        f"Using installer-provided VOSK model from {self.vosk_model_path}"
-                    )
+                if any(self.vosk_model_path.startswith(sys_dir) for sys_dir in SYSTEM_MODELS_DIRS):
+                    logger.info(f"Using pre-installed VOSK model from {self.vosk_model_path}")
+                elif os.path.exists(os.path.join(self.vosk_model_path, ".vocalinux_preinstalled")):
+                    logger.info(f"Using installer-provided VOSK model from {self.vosk_model_path}")
                 else:
-                    logger.info(
-                        f"Using existing VOSK model from {self.vosk_model_path}"
-                    )
+                    logger.info(f"Using existing VOSK model from {self.vosk_model_path}")
 
             logger.info(f"Loading VOSK model from {self.vosk_model_path}")
             # Ensure previous model/recognizer are released if re-initializing
@@ -680,9 +659,7 @@ class SpeechRecognitionManager:
             logger.info("VOSK engine initialized successfully.")
 
         except ImportError:
-            logger.error(
-                "Failed to import VOSK. Please install it with 'pip install vosk'"
-            )
+            logger.error("Failed to import VOSK. Please install it with 'pip install vosk'")
             self.state = RecognitionState.ERROR
             raise
 
@@ -714,9 +691,7 @@ class SpeechRecognitionManager:
             default_cache = os.path.expanduser("~/.cache/whisper")
             default_model_file = os.path.join(default_cache, f"{self.model_size}.pt")
 
-            model_exists = os.path.exists(model_file) or os.path.exists(
-                default_model_file
-            )
+            model_exists = os.path.exists(model_file) or os.path.exists(default_model_file)
 
             if not model_exists and self._defer_download:
                 logger.info(
@@ -763,18 +738,14 @@ class SpeechRecognitionManager:
             from moonshine_voice import Transcriber, get_model_for_language
             from moonshine_voice.moonshine_api import ModelArch
 
-            moonshine_language, language_fallback = resolve_moonshine_language(
-                self.language
-            )
+            moonshine_language, language_fallback = resolve_moonshine_language(self.language)
             valid_models = get_moonshine_supported_model_sizes(self.language)
             arch_name, model_fallback = resolve_moonshine_model_arch_name(
                 self.model_size, self.language
             )
 
             if self.language == "auto":
-                logger.info(
-                    "Moonshine does not support auto language detection; using English."
-                )
+                logger.info("Moonshine does not support auto language detection; using English.")
             elif language_fallback:
                 logger.warning(
                     f"Moonshine does not support Vocalinux language '{self.language}'. "
@@ -801,9 +772,7 @@ class SpeechRecognitionManager:
             )
 
             if arch_name is None:
-                model_path, model_arch = get_model_for_language(
-                    wanted_language=moonshine_language
-                )
+                model_path, model_arch = get_model_for_language(wanted_language=moonshine_language)
             else:
                 model_arch = getattr(ModelArch, arch_name)
                 model_path, model_arch = get_model_for_language(
@@ -864,9 +833,7 @@ class SpeechRecognitionManager:
             with self._model_lock:
                 # Check if model is still valid
                 if self.model is None:
-                    logger.warning(
-                        "Model is None during transcription, returning empty result"
-                    )
+                    logger.warning("Model is None during transcription, returning empty result")
                     return ""
 
                 # Determine if we should use fp16 (only on CUDA)
@@ -980,16 +947,12 @@ class SpeechRecognitionManager:
         import psutil
 
         total_ram_gb = psutil.virtual_memory().total // (1024**3)
-        logger.info(
-            f"whisper.cpp hardware: {backend} | {backend_info} | RAM: {total_ram_gb}GB"
-        )
+        logger.info(f"whisper.cpp hardware: {backend} | {backend_info} | RAM: {total_ram_gb}GB")
 
         # Validate model file exists and get size
         if os.path.exists(model_path):
             model_size_mb = os.path.getsize(model_path) / (1024 * 1024)
-            logger.info(
-                f"whisper.cpp model file: {model_path} ({model_size_mb:.1f} MB)"
-            )
+            logger.info(f"whisper.cpp model file: {model_path} ({model_size_mb:.1f} MB)")
         else:
             raise FileNotFoundError(f"Model file not found: {model_path}")
 
@@ -1019,9 +982,7 @@ class SpeechRecognitionManager:
             f"whisper.cpp configured with n_threads={n_threads} "
             f"(detected {multiprocessing.cpu_count()} CPUs)"
         )
-        logger.info(
-            f"whisper.cpp model loaded in {load_duration:.2f}s ({loaded_backend} backend)"
-        )
+        logger.info(f"whisper.cpp model loaded in {load_duration:.2f}s ({loaded_backend} backend)")
 
         self._model_initialized = True
         logger.info("whisper.cpp engine initialized successfully.")
@@ -1052,13 +1013,10 @@ class SpeechRecognitionManager:
         if not gpu_incompatible:
             raise error
 
-        logger.warning(
-            f"Vulkan GPU initialization failed: {error}. Falling back to CPU backend."
-        )
+        logger.warning(f"Vulkan GPU initialization failed: {error}. Falling back to CPU backend.")
         _show_notification(
             "Vocalinux: GPU Fallback",
-            "Your GPU doesn't support whisper.cpp Vulkan.\n"
-            "Switched to CPU mode - still fast!",
+            "Your GPU doesn't support whisper.cpp Vulkan.\n" "Switched to CPU mode - still fast!",
             "dialog-information",
         )
         # Force CPU backend by disabling GPU backends
@@ -1119,9 +1077,7 @@ class SpeechRecognitionManager:
             with self._model_lock:
                 # Check if model is still valid
                 if self.model is None:
-                    logger.warning(
-                        "Model is None during transcription, returning empty result"
-                    )
+                    logger.warning("Model is None during transcription, returning empty result")
                     return ""
 
                 # Transcribe with whisper.cpp
@@ -1162,9 +1118,7 @@ class SpeechRecognitionManager:
                 if audio_buffer
                 else "empty audio buffer"
             )
-            logger.error(
-                f"Error in whisper.cpp transcription: {e} ({audio_info})", exc_info=True
-            )
+            logger.error(f"Error in whisper.cpp transcription: {e} ({audio_info})", exc_info=True)
             return ""
 
     def _transcribe_with_moonshine(self, audio_buffer: list[bytes]) -> str:
@@ -1204,9 +1158,7 @@ class SpeechRecognitionManager:
                     return ""
 
                 transcribe_start = time.time()
-                transcript = self.model.transcribe_without_streaming(
-                    audio_float, sample_rate=16000
-                )
+                transcript = self.model.transcribe_without_streaming(audio_float, sample_rate=16000)
                 transcribe_duration = time.time() - transcribe_start
 
             text_parts = []
@@ -1227,9 +1179,7 @@ class SpeechRecognitionManager:
                     f"for {duration:.2f}s audio (RTF: {rtf:.2f}x) - {num_lines} lines"
                 )
             else:
-                logger.debug(
-                    f"Moonshine returned empty transcription ({transcribe_duration:.3f}s)"
-                )
+                logger.debug(f"Moonshine returned empty transcription ({transcribe_duration:.3f}s)")
 
             return text
 
@@ -1239,9 +1189,7 @@ class SpeechRecognitionManager:
                 if audio_buffer
                 else "empty audio buffer"
             )
-            logger.error(
-                f"Error in Moonshine transcription: {e} ({audio_info})", exc_info=True
-            )
+            logger.error(f"Error in Moonshine transcription: {e} ({audio_info})", exc_info=True)
             return ""
 
     def _download_whispercpp_model(self):
@@ -1300,9 +1248,7 @@ class SpeechRecognitionManager:
 
                         if total_size > 0:
                             progress = downloaded_size / total_size
-                            remaining_mb = (total_size - downloaded_size) / (
-                                1024 * 1024
-                            )
+                            remaining_mb = (total_size - downloaded_size) / (1024 * 1024)
                             if speed_mbps > 0:
                                 eta_seconds = remaining_mb / speed_mbps
                                 eta_str = (
@@ -1315,14 +1261,14 @@ class SpeechRecognitionManager:
                             status = f"{downloaded_size / (1024 * 1024):.1f} / {total_size / (1024 * 1024):.1f} MB • {speed_mbps:.1f} MB/s • ETA: {eta_str}"
                         else:
                             progress = 0
-                            status = f"{downloaded_size / (1024 * 1024):.1f} MB • {speed_mbps:.1f} MB/s"
+                            status = (
+                                f"{downloaded_size / (1024 * 1024):.1f} MB • {speed_mbps:.1f} MB/s"
+                            )
 
                         self._download_progress_callback(progress, speed_mbps, status)
                         last_update_time = current_time
 
-                        logger.info(
-                            f"Download progress: {progress * 100:.1f}% - {status}"
-                        )
+                        logger.info(f"Download progress: {progress * 100:.1f}% - {status}")
 
             # Rename temp file to final
             os.rename(temp_file, model_path)
@@ -1344,9 +1290,7 @@ class SpeechRecognitionManager:
 
     def _get_vosk_model_path(self) -> str:
         """Get the path to the VOSK model based on the selected size and language."""
-        model_name = self.vosk_model_map.get(
-            self.model_size, self.vosk_model_map["small"]
-        )
+        model_name = self.vosk_model_map.get(self.model_size, self.vosk_model_map["small"])
 
         # First, check user's local models directory
         user_model_path = os.path.join(MODELS_DIR, model_name)
@@ -1409,9 +1353,7 @@ class SpeechRecognitionManager:
         # Create models directory if it doesn't exist
         os.makedirs(MODELS_DIR, exist_ok=True)
 
-        logger.info(
-            f"Downloading VOSK {self.model_size} model to user directory: {model_path}"
-        )
+        logger.info(f"Downloading VOSK {self.model_size} model to user directory: {model_path}")
 
         # Download the model
         logger.info(f"Downloading VOSK model from {url}")
@@ -1451,9 +1393,7 @@ class SpeechRecognitionManager:
 
                         if total_size > 0:
                             progress = downloaded_size / total_size
-                            remaining_mb = (total_size - downloaded_size) / (
-                                1024 * 1024
-                            )
+                            remaining_mb = (total_size - downloaded_size) / (1024 * 1024)
                             if speed_mbps > 0:
                                 eta_seconds = remaining_mb / speed_mbps
                                 eta_str = (
@@ -1466,15 +1406,15 @@ class SpeechRecognitionManager:
                             status = f"{downloaded_size / (1024 * 1024):.1f} / {total_size / (1024 * 1024):.1f} MB • {speed_mbps:.1f} MB/s • ETA: {eta_str}"
                         else:
                             progress = 0
-                            status = f"{downloaded_size / (1024 * 1024):.1f} MB • {speed_mbps:.1f} MB/s"
+                            status = (
+                                f"{downloaded_size / (1024 * 1024):.1f} MB • {speed_mbps:.1f} MB/s"
+                            )
 
                         self._download_progress_callback(progress, speed_mbps, status)
                         last_update_time = current_time
 
                         # Also log progress periodically
-                        logger.info(
-                            f"Download progress: {progress * 100:.1f}% - {status}"
-                        )
+                        logger.info(f"Download progress: {progress * 100:.1f}% - {status}")
 
             # Update status for extraction phase
             if self._download_progress_callback:
@@ -1506,9 +1446,7 @@ class SpeechRecognitionManager:
                 os.remove(zip_path)
             raise RuntimeError("Downloaded VOSK model file is corrupted.")
         except (OSError, RuntimeError, ValueError) as e:
-            logger.error(
-                f"An error occurred during VOSK model download/extraction: {e}"
-            )
+            logger.error(f"An error occurred during VOSK model download/extraction: {e}")
             # Clean up potentially corrupted extraction
             if os.path.exists(zip_path):
                 os.remove(zip_path)
@@ -1589,9 +1527,7 @@ class SpeechRecognitionManager:
 
                         if total_size > 0:
                             progress = downloaded_size / total_size
-                            remaining_mb = (total_size - downloaded_size) / (
-                                1024 * 1024
-                            )
+                            remaining_mb = (total_size - downloaded_size) / (1024 * 1024)
                             if speed_mbps > 0:
                                 eta_seconds = remaining_mb / speed_mbps
                                 eta_str = (
@@ -1604,14 +1540,14 @@ class SpeechRecognitionManager:
                             status = f"{downloaded_size / (1024 * 1024):.1f} / {total_size / (1024 * 1024):.1f} MB • {speed_mbps:.1f} MB/s • ETA: {eta_str}"
                         else:
                             progress = 0
-                            status = f"{downloaded_size / (1024 * 1024):.1f} MB • {speed_mbps:.1f} MB/s"
+                            status = (
+                                f"{downloaded_size / (1024 * 1024):.1f} MB • {speed_mbps:.1f} MB/s"
+                            )
 
                         self._download_progress_callback(progress, speed_mbps, status)
                         last_update_time = current_time
 
-                        logger.info(
-                            f"Download progress: {progress * 100:.1f}% - {status}"
-                        )
+                        logger.info(f"Download progress: {progress * 100:.1f}% - {status}")
 
             # Rename temp file to final
             os.rename(temp_file, model_file)
@@ -1708,9 +1644,7 @@ class SpeechRecognitionManager:
             device_index: The device index to use, or None for system default
         """
         if device_index != self.audio_device_index:
-            logger.info(
-                f"Audio device changed from {self.audio_device_index} to {device_index}"
-            )
+            logger.info(f"Audio device changed from {self.audio_device_index} to {device_index}")
             self.audio_device_index = device_index
 
     def get_audio_device(self) -> Optional[int]:
@@ -1746,14 +1680,12 @@ class SpeechRecognitionManager:
         # Check if model is ready
         if not self.model_ready:
             logger.warning(
-                "Cannot start recognition: model not downloaded. "
-                "Please download via Settings."
+                "Cannot start recognition: model not downloaded. " "Please download via Settings."
             )
             play_error_sound()
             _show_notification(
                 "No Speech Model",
-                "Please open Settings and download a speech recognition model "
-                "to use dictation.",
+                "Please open Settings and download a speech recognition model " "to use dictation.",
                 "dialog-warning",
             )
             return
@@ -1808,15 +1740,11 @@ class SpeechRecognitionManager:
                 )
             elif self.audio_buffer:
                 # If buffer is small, just clear it entirely to be safe
-                logger.debug(
-                    f"Clearing small audio buffer ({len(self.audio_buffer)} chunks)"
-                )
+                logger.debug(f"Clearing small audio buffer ({len(self.audio_buffer)} chunks)")
                 self.audio_buffer = []
 
             if self.audio_buffer:
-                logger.info(
-                    f"DEBUG: Enqueuing final buffer with {len(self.audio_buffer)} chunks"
-                )
+                logger.info(f"DEBUG: Enqueuing final buffer with {len(self.audio_buffer)} chunks")
                 self._enqueue_audio_segment(self.audio_buffer)
                 self.audio_buffer = []
 
@@ -1827,9 +1755,7 @@ class SpeechRecognitionManager:
         self._signal_recognition_stop()
 
         if self.recognition_thread and self.recognition_thread.is_alive():
-            self.recognition_thread.join(
-                timeout=5.0
-            )  # Increased timeout for transcription
+            self.recognition_thread.join(timeout=5.0)  # Increased timeout for transcription
         self._signal_recognition_stop()
 
         if self.recognition_thread and self.recognition_thread.is_alive():
@@ -1848,9 +1774,7 @@ class SpeechRecognitionManager:
             import pyaudio
         except ImportError as e:
             logger.error(f"Failed to import required audio libraries: {e}")
-            logger.error(
-                "Please install required dependencies: pip install pyaudio numpy"
-            )
+            logger.error("Please install required dependencies: pip install pyaudio numpy")
             play_error_sound()
             self._update_state(RecognitionState.ERROR)
             return
@@ -1898,16 +1822,12 @@ class SpeechRecognitionManager:
             if self.audio_device_index is not None:
                 stream_kwargs["input_device_index"] = self.audio_device_index
                 try:
-                    device_info = audio.get_device_info_by_index(
-                        self.audio_device_index
-                    )
+                    device_info = audio.get_device_info_by_index(self.audio_device_index)
                     logger.info(
                         f"Using audio device [{self.audio_device_index}]: {device_info.get('name')}"
                     )
                 except (IOError, OSError):
-                    logger.warning(
-                        f"Could not get info for device index {self.audio_device_index}"
-                    )
+                    logger.warning(f"Could not get info for device index {self.audio_device_index}")
             else:
                 try:
                     default_device = audio.get_default_input_device_info()
@@ -1922,9 +1842,7 @@ class SpeechRecognitionManager:
                 stream = self._audio_stream
             except (IOError, OSError) as e:
                 logger.error(f"Failed to open audio stream: {e}")
-                logger.error(
-                    "This may indicate a problem with the audio device or permissions."
-                )
+                logger.error("This may indicate a problem with the audio device or permissions.")
 
                 # Attempt reconnection
                 if self._attempt_audio_reconnection(audio):
@@ -2000,9 +1918,7 @@ class SpeechRecognitionManager:
 
                     # Log audio levels periodically for debugging
                     log_level_interval += 1
-                    if (
-                        log_level_interval >= 50
-                    ):  # Every ~3 seconds at 16kHz/1024 chunks
+                    if log_level_interval >= 50:  # Every ~3 seconds at 16kHz/1024 chunks
                         logger.debug(
                             f"Audio level: current={normalized_level:.1f}%, max_seen={max_level_seen:.1f}%, buffer_size={len(self.audio_buffer)}"
                         )
@@ -2012,9 +1928,7 @@ class SpeechRecognitionManager:
                     # Ensure vad_sensitivity is treated as integer for calculation
                     try:
                         vad_sens = int(self.vad_sensitivity)
-                        threshold = 500 / max(
-                            1, min(5, vad_sens)
-                        )  # Use self.vad_sensitivity
+                        threshold = 500 / max(1, min(5, vad_sens))  # Use self.vad_sensitivity
                     except ValueError:
                         logger.warning(
                             f"Invalid VAD sensitivity value: {self.vad_sensitivity}. Using default 3."
@@ -2023,9 +1937,7 @@ class SpeechRecognitionManager:
 
                     if volume < threshold:  # Silence
                         silence_counter += CHUNK / RATE  # Convert chunks to seconds
-                        if (
-                            silence_counter > self.silence_timeout
-                        ):  # Use self.silence_timeout
+                        if silence_counter > self.silence_timeout:  # Use self.silence_timeout
                             if len(self.audio_buffer) > 0:
                                 if self._recognition_mode == "push_to_talk":
                                     logger.debug(
@@ -2033,9 +1945,7 @@ class SpeechRecognitionManager:
                                         "deferring transcription until key release"
                                     )
                                 else:
-                                    logger.debug(
-                                        "Silence detected, queueing audio segment"
-                                    )
+                                    logger.debug("Silence detected, queueing audio segment")
                                     self._enqueue_audio_segment(self.audio_buffer)
                                     self.audio_buffer = []
                             silence_counter = 0
@@ -2058,15 +1968,11 @@ class SpeechRecognitionManager:
                         self._last_audio_error_time = current_time
 
                         if self._attempt_audio_reconnection(audio):
-                            logger.info(
-                                "Audio reconnection successful, continuing recording"
-                            )
+                            logger.info("Audio reconnection successful, continuing recording")
                             stream = self._audio_stream  # Update stream reference
                             continue  # Continue recording with new stream
                         else:
-                            logger.error(
-                                "Audio reconnection failed, stopping recording"
-                            )
+                            logger.error("Audio reconnection failed, stopping recording")
                             break
                     else:
                         logger.warning(
@@ -2133,9 +2039,7 @@ class SpeechRecognitionManager:
             with self._model_lock:
                 # Check if recognizer is still valid
                 if self.recognizer is None:
-                    logger.warning(
-                        "Recognizer is None during processing, returning empty result"
-                    )
+                    logger.warning("Recognizer is None during processing, returning empty result")
                     return
                 for data in audio_buffer:
                     self.recognizer.AcceptWaveform(data)
@@ -2229,9 +2133,7 @@ class SpeechRecognitionManager:
                 logger.info("DEBUG: Recognition loop - exiting after None signal")
                 break
 
-            logger.info(
-                f"DEBUG: Recognition loop - processing segment with {len(segment)} chunks"
-            )
+            logger.info(f"DEBUG: Recognition loop - processing segment with {len(segment)} chunks")
             self._update_state(RecognitionState.PROCESSING)
             self._process_audio_buffer(segment)
             if self.should_record:
@@ -2253,9 +2155,7 @@ class SpeechRecognitionManager:
                 logger.info("DEBUG: Recognition loop - got None signal, continuing")
                 continue
 
-            logger.info(
-                f"DEBUG: Recognition loop - processing segment with {len(segment)} chunks"
-            )
+            logger.info(f"DEBUG: Recognition loop - processing segment with {len(segment)} chunks")
             self._update_state(RecognitionState.PROCESSING)
             self._process_audio_buffer(segment)
             if self.should_record:
@@ -2275,16 +2175,12 @@ class SpeechRecognitionManager:
             self._segment_queue.put_nowait(segment)
             logger.info("DEBUG: Enqueued segment successfully")
         except queue.Full:
-            logger.warning(
-                "Transcription queue is full, dropping oldest pending segment"
-            )
+            logger.warning("Transcription queue is full, dropping oldest pending segment")
             try:
                 self._segment_queue.get_nowait()
                 self._segment_queue.put_nowait(segment)
             except queue.Empty:
-                logger.warning(
-                    "Could not recover queue space for transcription segment"
-                )
+                logger.warning("Could not recover queue space for transcription segment")
 
     def _signal_recognition_stop(self):
         """Signal recognition thread to wake up and stop cleanly."""
@@ -2389,14 +2285,10 @@ class SpeechRecognitionManager:
                     elif self.engine == "moonshine":
                         self._init_moonshine()
                     else:
-                        raise ValueError(
-                            f"Unsupported engine during reconfigure: {self.engine}"
-                        )
+                        raise ValueError(f"Unsupported engine during reconfigure: {self.engine}")
                     logger.info("Speech engine re-initialized successfully.")
                 except Exception as e:
-                    logger.error(
-                        f"Failed to re-initialize speech engine: {e}", exc_info=True
-                    )
+                    logger.error(f"Failed to re-initialize speech engine: {e}", exc_info=True)
                     self._update_state(RecognitionState.ERROR)
                     # Re-raise or handle appropriately
                     raise
@@ -2421,9 +2313,7 @@ class SpeechRecognitionManager:
         self._reconnection_attempts += 1
 
         if self._reconnection_attempts > self._max_reconnection_attempts:
-            logger.error(
-                f"Max reconnection attempts ({self._max_reconnection_attempts}) reached"
-            )
+            logger.error(f"Max reconnection attempts ({self._max_reconnection_attempts}) reached")
             return False
 
         # Calculate delay with exponential backoff
@@ -2455,9 +2345,7 @@ class SpeechRecognitionManager:
             logger.debug(f"Reconnecting with {CHANNELS} channel(s)")
 
             # Detect supported sample rate for the device
-            RATE = _get_supported_sample_rate(
-                audio_instance, self.audio_device_index, CHANNELS
-            )
+            RATE = _get_supported_sample_rate(audio_instance, self.audio_device_index, CHANNELS)
             self._capture_sample_rate = RATE
             logger.debug(f"Reconnecting with sample rate: {RATE}Hz")
 
@@ -2527,16 +2415,12 @@ class SpeechRecognitionManager:
                 elif self.engine == "moonshine":
                     self._init_moonshine()
                 else:
-                    logger.error(
-                        "Cannot reinitialize: unknown engine '%s'", self.engine
-                    )
+                    logger.error("Cannot reinitialize: unknown engine '%s'", self.engine)
                     return
 
                 logger.info("Speech engine reinitialized after resume")
             except Exception:
-                logger.error(
-                    "Failed to reinitialize speech engine after resume", exc_info=True
-                )
+                logger.error("Failed to reinitialize speech engine after resume", exc_info=True)
                 self._update_state(RecognitionState.ERROR)
 
         self._reconnection_attempts = 0
@@ -2574,8 +2458,6 @@ class SpeechRecognitionManager:
             "memory_usage_bytes": total_memory,
             "memory_usage_mb": total_memory / (1024 * 1024),
             "buffer_full_percentage": (
-                (buffer_size / self._max_buffer_size) * 100
-                if self._max_buffer_size > 0
-                else 0
+                (buffer_size / self._max_buffer_size) * 100 if self._max_buffer_size > 0 else 0
             ),
         }

--- a/src/vocalinux/speech_recognition/recognition_manager.py
+++ b/src/vocalinux/speech_recognition/recognition_manager.py
@@ -24,7 +24,11 @@ from ..utils.moonshine_model_info import (
     resolve_moonshine_model_arch_name,
 )
 from ..utils.vosk_model_info import VOSK_MODEL_INFO
-from ..utils.whispercpp_model_info import WHISPERCPP_MODEL_INFO, get_model_path, is_model_downloaded
+from ..utils.whispercpp_model_info import (
+    WHISPERCPP_MODEL_INFO,
+    get_model_path,
+    is_model_downloaded,
+)
 from .command_processor import CommandProcessor
 
 
@@ -172,7 +176,9 @@ def _get_supported_channels(audio, device_index: Optional[int] = None) -> int:
             except (IOError, OSError) as e:
                 error_str = str(e).lower()
                 if "invalid number of channels" in error_str or "-9998" in error_str:
-                    logger.debug(f"Device rejected {channels} channel(s) at {rate}Hz: {e}")
+                    logger.debug(
+                        f"Device rejected {channels} channel(s) at {rate}Hz: {e}"
+                    )
                 else:
                     logger.debug(f"Channel test failed at {rate}Hz: {e}")
                 continue
@@ -181,7 +187,9 @@ def _get_supported_channels(audio, device_index: Optional[int] = None) -> int:
     return 1
 
 
-def _get_supported_sample_rate(audio, device_index: Optional[int], channels: int = 1) -> int:
+def _get_supported_sample_rate(
+    audio, device_index: Optional[int], channels: int = 1
+) -> int:
     """
     Get a supported sample rate for the audio device.
 
@@ -231,7 +239,9 @@ def _get_supported_sample_rate(audio, device_index: Optional[int], channels: int
                 logger.debug(f"Using device default sample rate: {default_rate}Hz")
                 return default_rate
             except (IOError, OSError):
-                logger.debug(f"Device default rate {default_rate}Hz failed, trying common rates")
+                logger.debug(
+                    f"Device default rate {default_rate}Hz failed, trying common rates"
+                )
     except (IOError, OSError) as e:
         logger.debug(f"Could not get device default rate: {e}")
 
@@ -549,7 +559,9 @@ class SpeechRecognitionManager:
         self.action_callbacks: list[Callable[[str], None]] = []
 
         # Download progress tracking
-        self._download_progress_callback: Optional[Callable[[float, float, str], None]] = None
+        self._download_progress_callback: Optional[
+            Callable[[float, float, str], None]
+        ] = None
         self._download_cancelled = False
         self._defer_download = defer_download
         self._model_initialized = False
@@ -632,18 +644,31 @@ class SpeechRecognitionManager:
                     self._model_initialized = False
                     return  # Don't block startup
                 else:
-                    logger.info(f"VOSK model not found at {self.vosk_model_path}. Downloading...")
+                    logger.info(
+                        f"VOSK model not found at {self.vosk_model_path}. Downloading..."
+                    )
                     self._download_vosk_model()
                     # Update path after download
                     self.vosk_model_path = self._get_vosk_model_path()
             else:
                 # Check if this is a pre-installed model
-                if any(self.vosk_model_path.startswith(sys_dir) for sys_dir in SYSTEM_MODELS_DIRS):
-                    logger.info(f"Using pre-installed VOSK model from {self.vosk_model_path}")
-                elif os.path.exists(os.path.join(self.vosk_model_path, ".vocalinux_preinstalled")):
-                    logger.info(f"Using installer-provided VOSK model from {self.vosk_model_path}")
+                if any(
+                    self.vosk_model_path.startswith(sys_dir)
+                    for sys_dir in SYSTEM_MODELS_DIRS
+                ):
+                    logger.info(
+                        f"Using pre-installed VOSK model from {self.vosk_model_path}"
+                    )
+                elif os.path.exists(
+                    os.path.join(self.vosk_model_path, ".vocalinux_preinstalled")
+                ):
+                    logger.info(
+                        f"Using installer-provided VOSK model from {self.vosk_model_path}"
+                    )
                 else:
-                    logger.info(f"Using existing VOSK model from {self.vosk_model_path}")
+                    logger.info(
+                        f"Using existing VOSK model from {self.vosk_model_path}"
+                    )
 
             logger.info(f"Loading VOSK model from {self.vosk_model_path}")
             # Ensure previous model/recognizer are released if re-initializing
@@ -655,7 +680,9 @@ class SpeechRecognitionManager:
             logger.info("VOSK engine initialized successfully.")
 
         except ImportError:
-            logger.error("Failed to import VOSK. Please install it with 'pip install vosk'")
+            logger.error(
+                "Failed to import VOSK. Please install it with 'pip install vosk'"
+            )
             self.state = RecognitionState.ERROR
             raise
 
@@ -687,7 +714,9 @@ class SpeechRecognitionManager:
             default_cache = os.path.expanduser("~/.cache/whisper")
             default_model_file = os.path.join(default_cache, f"{self.model_size}.pt")
 
-            model_exists = os.path.exists(model_file) or os.path.exists(default_model_file)
+            model_exists = os.path.exists(model_file) or os.path.exists(
+                default_model_file
+            )
 
             if not model_exists and self._defer_download:
                 logger.info(
@@ -734,14 +763,18 @@ class SpeechRecognitionManager:
             from moonshine_voice import Transcriber, get_model_for_language
             from moonshine_voice.moonshine_api import ModelArch
 
-            moonshine_language, language_fallback = resolve_moonshine_language(self.language)
+            moonshine_language, language_fallback = resolve_moonshine_language(
+                self.language
+            )
             valid_models = get_moonshine_supported_model_sizes(self.language)
             arch_name, model_fallback = resolve_moonshine_model_arch_name(
                 self.model_size, self.language
             )
 
             if self.language == "auto":
-                logger.info("Moonshine does not support auto language detection; using English.")
+                logger.info(
+                    "Moonshine does not support auto language detection; using English."
+                )
             elif language_fallback:
                 logger.warning(
                     f"Moonshine does not support Vocalinux language '{self.language}'. "
@@ -768,7 +801,9 @@ class SpeechRecognitionManager:
             )
 
             if arch_name is None:
-                model_path, model_arch = get_model_for_language(wanted_language=moonshine_language)
+                model_path, model_arch = get_model_for_language(
+                    wanted_language=moonshine_language
+                )
             else:
                 model_arch = getattr(ModelArch, arch_name)
                 model_path, model_arch = get_model_for_language(
@@ -829,7 +864,9 @@ class SpeechRecognitionManager:
             with self._model_lock:
                 # Check if model is still valid
                 if self.model is None:
-                    logger.warning("Model is None during transcription, returning empty result")
+                    logger.warning(
+                        "Model is None during transcription, returning empty result"
+                    )
                     return ""
 
                 # Determine if we should use fp16 (only on CUDA)
@@ -871,7 +908,9 @@ class SpeechRecognitionManager:
     def _init_whispercpp(self):
         """Initialize the whisper.cpp speech recognition engine."""
         try:
-            from pywhispercpp.model import Model  # noqa: F401 — used in _load_whispercpp_model
+            from pywhispercpp.model import (  # noqa: F401 — used in _load_whispercpp_model
+                Model,
+            )
 
             # Validate model size for whisper.cpp
             valid_models = list(WHISPERCPP_MODEL_INFO.keys())
@@ -941,12 +980,16 @@ class SpeechRecognitionManager:
         import psutil
 
         total_ram_gb = psutil.virtual_memory().total // (1024**3)
-        logger.info(f"whisper.cpp hardware: {backend} | {backend_info} | RAM: {total_ram_gb}GB")
+        logger.info(
+            f"whisper.cpp hardware: {backend} | {backend_info} | RAM: {total_ram_gb}GB"
+        )
 
         # Validate model file exists and get size
         if os.path.exists(model_path):
             model_size_mb = os.path.getsize(model_path) / (1024 * 1024)
-            logger.info(f"whisper.cpp model file: {model_path} ({model_size_mb:.1f} MB)")
+            logger.info(
+                f"whisper.cpp model file: {model_path} ({model_size_mb:.1f} MB)"
+            )
         else:
             raise FileNotFoundError(f"Model file not found: {model_path}")
 
@@ -976,7 +1019,9 @@ class SpeechRecognitionManager:
             f"whisper.cpp configured with n_threads={n_threads} "
             f"(detected {multiprocessing.cpu_count()} CPUs)"
         )
-        logger.info(f"whisper.cpp model loaded in {load_duration:.2f}s ({loaded_backend} backend)")
+        logger.info(
+            f"whisper.cpp model loaded in {load_duration:.2f}s ({loaded_backend} backend)"
+        )
 
         self._model_initialized = True
         logger.info("whisper.cpp engine initialized successfully.")
@@ -1007,10 +1052,13 @@ class SpeechRecognitionManager:
         if not gpu_incompatible:
             raise error
 
-        logger.warning(f"Vulkan GPU initialization failed: {error}. Falling back to CPU backend.")
+        logger.warning(
+            f"Vulkan GPU initialization failed: {error}. Falling back to CPU backend."
+        )
         _show_notification(
             "Vocalinux: GPU Fallback",
-            "Your GPU doesn't support whisper.cpp Vulkan.\n" "Switched to CPU mode - still fast!",
+            "Your GPU doesn't support whisper.cpp Vulkan.\n"
+            "Switched to CPU mode - still fast!",
             "dialog-information",
         )
         # Force CPU backend by disabling GPU backends
@@ -1071,7 +1119,9 @@ class SpeechRecognitionManager:
             with self._model_lock:
                 # Check if model is still valid
                 if self.model is None:
-                    logger.warning("Model is None during transcription, returning empty result")
+                    logger.warning(
+                        "Model is None during transcription, returning empty result"
+                    )
                     return ""
 
                 # Transcribe with whisper.cpp
@@ -1112,7 +1162,9 @@ class SpeechRecognitionManager:
                 if audio_buffer
                 else "empty audio buffer"
             )
-            logger.error(f"Error in whisper.cpp transcription: {e} ({audio_info})", exc_info=True)
+            logger.error(
+                f"Error in whisper.cpp transcription: {e} ({audio_info})", exc_info=True
+            )
             return ""
 
     def _transcribe_with_moonshine(self, audio_buffer: list[bytes]) -> str:
@@ -1152,7 +1204,9 @@ class SpeechRecognitionManager:
                     return ""
 
                 transcribe_start = time.time()
-                transcript = self.model.transcribe_without_streaming(audio_float, sample_rate=16000)
+                transcript = self.model.transcribe_without_streaming(
+                    audio_float, sample_rate=16000
+                )
                 transcribe_duration = time.time() - transcribe_start
 
             text_parts = []
@@ -1173,7 +1227,9 @@ class SpeechRecognitionManager:
                     f"for {duration:.2f}s audio (RTF: {rtf:.2f}x) - {num_lines} lines"
                 )
             else:
-                logger.debug(f"Moonshine returned empty transcription ({transcribe_duration:.3f}s)")
+                logger.debug(
+                    f"Moonshine returned empty transcription ({transcribe_duration:.3f}s)"
+                )
 
             return text
 
@@ -1183,7 +1239,9 @@ class SpeechRecognitionManager:
                 if audio_buffer
                 else "empty audio buffer"
             )
-            logger.error(f"Error in Moonshine transcription: {e} ({audio_info})", exc_info=True)
+            logger.error(
+                f"Error in Moonshine transcription: {e} ({audio_info})", exc_info=True
+            )
             return ""
 
     def _download_whispercpp_model(self):
@@ -1242,7 +1300,9 @@ class SpeechRecognitionManager:
 
                         if total_size > 0:
                             progress = downloaded_size / total_size
-                            remaining_mb = (total_size - downloaded_size) / (1024 * 1024)
+                            remaining_mb = (total_size - downloaded_size) / (
+                                1024 * 1024
+                            )
                             if speed_mbps > 0:
                                 eta_seconds = remaining_mb / speed_mbps
                                 eta_str = (
@@ -1255,14 +1315,14 @@ class SpeechRecognitionManager:
                             status = f"{downloaded_size / (1024 * 1024):.1f} / {total_size / (1024 * 1024):.1f} MB • {speed_mbps:.1f} MB/s • ETA: {eta_str}"
                         else:
                             progress = 0
-                            status = (
-                                f"{downloaded_size / (1024 * 1024):.1f} MB • {speed_mbps:.1f} MB/s"
-                            )
+                            status = f"{downloaded_size / (1024 * 1024):.1f} MB • {speed_mbps:.1f} MB/s"
 
                         self._download_progress_callback(progress, speed_mbps, status)
                         last_update_time = current_time
 
-                        logger.info(f"Download progress: {progress * 100:.1f}% - {status}")
+                        logger.info(
+                            f"Download progress: {progress * 100:.1f}% - {status}"
+                        )
 
             # Rename temp file to final
             os.rename(temp_file, model_path)
@@ -1284,7 +1344,9 @@ class SpeechRecognitionManager:
 
     def _get_vosk_model_path(self) -> str:
         """Get the path to the VOSK model based on the selected size and language."""
-        model_name = self.vosk_model_map.get(self.model_size, self.vosk_model_map["small"])
+        model_name = self.vosk_model_map.get(
+            self.model_size, self.vosk_model_map["small"]
+        )
 
         # First, check user's local models directory
         user_model_path = os.path.join(MODELS_DIR, model_name)
@@ -1347,7 +1409,9 @@ class SpeechRecognitionManager:
         # Create models directory if it doesn't exist
         os.makedirs(MODELS_DIR, exist_ok=True)
 
-        logger.info(f"Downloading VOSK {self.model_size} model to user directory: {model_path}")
+        logger.info(
+            f"Downloading VOSK {self.model_size} model to user directory: {model_path}"
+        )
 
         # Download the model
         logger.info(f"Downloading VOSK model from {url}")
@@ -1387,7 +1451,9 @@ class SpeechRecognitionManager:
 
                         if total_size > 0:
                             progress = downloaded_size / total_size
-                            remaining_mb = (total_size - downloaded_size) / (1024 * 1024)
+                            remaining_mb = (total_size - downloaded_size) / (
+                                1024 * 1024
+                            )
                             if speed_mbps > 0:
                                 eta_seconds = remaining_mb / speed_mbps
                                 eta_str = (
@@ -1400,15 +1466,15 @@ class SpeechRecognitionManager:
                             status = f"{downloaded_size / (1024 * 1024):.1f} / {total_size / (1024 * 1024):.1f} MB • {speed_mbps:.1f} MB/s • ETA: {eta_str}"
                         else:
                             progress = 0
-                            status = (
-                                f"{downloaded_size / (1024 * 1024):.1f} MB • {speed_mbps:.1f} MB/s"
-                            )
+                            status = f"{downloaded_size / (1024 * 1024):.1f} MB • {speed_mbps:.1f} MB/s"
 
                         self._download_progress_callback(progress, speed_mbps, status)
                         last_update_time = current_time
 
                         # Also log progress periodically
-                        logger.info(f"Download progress: {progress * 100:.1f}% - {status}")
+                        logger.info(
+                            f"Download progress: {progress * 100:.1f}% - {status}"
+                        )
 
             # Update status for extraction phase
             if self._download_progress_callback:
@@ -1440,7 +1506,9 @@ class SpeechRecognitionManager:
                 os.remove(zip_path)
             raise RuntimeError("Downloaded VOSK model file is corrupted.")
         except (OSError, RuntimeError, ValueError) as e:
-            logger.error(f"An error occurred during VOSK model download/extraction: {e}")
+            logger.error(
+                f"An error occurred during VOSK model download/extraction: {e}"
+            )
             # Clean up potentially corrupted extraction
             if os.path.exists(zip_path):
                 os.remove(zip_path)
@@ -1521,7 +1589,9 @@ class SpeechRecognitionManager:
 
                         if total_size > 0:
                             progress = downloaded_size / total_size
-                            remaining_mb = (total_size - downloaded_size) / (1024 * 1024)
+                            remaining_mb = (total_size - downloaded_size) / (
+                                1024 * 1024
+                            )
                             if speed_mbps > 0:
                                 eta_seconds = remaining_mb / speed_mbps
                                 eta_str = (
@@ -1534,14 +1604,14 @@ class SpeechRecognitionManager:
                             status = f"{downloaded_size / (1024 * 1024):.1f} / {total_size / (1024 * 1024):.1f} MB • {speed_mbps:.1f} MB/s • ETA: {eta_str}"
                         else:
                             progress = 0
-                            status = (
-                                f"{downloaded_size / (1024 * 1024):.1f} MB • {speed_mbps:.1f} MB/s"
-                            )
+                            status = f"{downloaded_size / (1024 * 1024):.1f} MB • {speed_mbps:.1f} MB/s"
 
                         self._download_progress_callback(progress, speed_mbps, status)
                         last_update_time = current_time
 
-                        logger.info(f"Download progress: {progress * 100:.1f}% - {status}")
+                        logger.info(
+                            f"Download progress: {progress * 100:.1f}% - {status}"
+                        )
 
             # Rename temp file to final
             os.rename(temp_file, model_file)
@@ -1638,7 +1708,9 @@ class SpeechRecognitionManager:
             device_index: The device index to use, or None for system default
         """
         if device_index != self.audio_device_index:
-            logger.info(f"Audio device changed from {self.audio_device_index} to {device_index}")
+            logger.info(
+                f"Audio device changed from {self.audio_device_index} to {device_index}"
+            )
             self.audio_device_index = device_index
 
     def get_audio_device(self) -> Optional[int]:
@@ -1674,12 +1746,14 @@ class SpeechRecognitionManager:
         # Check if model is ready
         if not self.model_ready:
             logger.warning(
-                "Cannot start recognition: model not downloaded. " "Please download via Settings."
+                "Cannot start recognition: model not downloaded. "
+                "Please download via Settings."
             )
             play_error_sound()
             _show_notification(
                 "No Speech Model",
-                "Please open Settings and download a speech recognition model " "to use dictation.",
+                "Please open Settings and download a speech recognition model "
+                "to use dictation.",
                 "dialog-warning",
             )
             return
@@ -1734,11 +1808,15 @@ class SpeechRecognitionManager:
                 )
             elif self.audio_buffer:
                 # If buffer is small, just clear it entirely to be safe
-                logger.debug(f"Clearing small audio buffer ({len(self.audio_buffer)} chunks)")
+                logger.debug(
+                    f"Clearing small audio buffer ({len(self.audio_buffer)} chunks)"
+                )
                 self.audio_buffer = []
 
             if self.audio_buffer:
-                logger.info(f"DEBUG: Enqueuing final buffer with {len(self.audio_buffer)} chunks")
+                logger.info(
+                    f"DEBUG: Enqueuing final buffer with {len(self.audio_buffer)} chunks"
+                )
                 self._enqueue_audio_segment(self.audio_buffer)
                 self.audio_buffer = []
 
@@ -1749,7 +1827,9 @@ class SpeechRecognitionManager:
         self._signal_recognition_stop()
 
         if self.recognition_thread and self.recognition_thread.is_alive():
-            self.recognition_thread.join(timeout=5.0)  # Increased timeout for transcription
+            self.recognition_thread.join(
+                timeout=5.0
+            )  # Increased timeout for transcription
         self._signal_recognition_stop()
 
         if self.recognition_thread and self.recognition_thread.is_alive():
@@ -1768,7 +1848,9 @@ class SpeechRecognitionManager:
             import pyaudio
         except ImportError as e:
             logger.error(f"Failed to import required audio libraries: {e}")
-            logger.error("Please install required dependencies: pip install pyaudio numpy")
+            logger.error(
+                "Please install required dependencies: pip install pyaudio numpy"
+            )
             play_error_sound()
             self._update_state(RecognitionState.ERROR)
             return
@@ -1816,12 +1898,16 @@ class SpeechRecognitionManager:
             if self.audio_device_index is not None:
                 stream_kwargs["input_device_index"] = self.audio_device_index
                 try:
-                    device_info = audio.get_device_info_by_index(self.audio_device_index)
+                    device_info = audio.get_device_info_by_index(
+                        self.audio_device_index
+                    )
                     logger.info(
                         f"Using audio device [{self.audio_device_index}]: {device_info.get('name')}"
                     )
                 except (IOError, OSError):
-                    logger.warning(f"Could not get info for device index {self.audio_device_index}")
+                    logger.warning(
+                        f"Could not get info for device index {self.audio_device_index}"
+                    )
             else:
                 try:
                     default_device = audio.get_default_input_device_info()
@@ -1836,7 +1922,9 @@ class SpeechRecognitionManager:
                 stream = self._audio_stream
             except (IOError, OSError) as e:
                 logger.error(f"Failed to open audio stream: {e}")
-                logger.error("This may indicate a problem with the audio device or permissions.")
+                logger.error(
+                    "This may indicate a problem with the audio device or permissions."
+                )
 
                 # Attempt reconnection
                 if self._attempt_audio_reconnection(audio):
@@ -1912,7 +2000,9 @@ class SpeechRecognitionManager:
 
                     # Log audio levels periodically for debugging
                     log_level_interval += 1
-                    if log_level_interval >= 50:  # Every ~3 seconds at 16kHz/1024 chunks
+                    if (
+                        log_level_interval >= 50
+                    ):  # Every ~3 seconds at 16kHz/1024 chunks
                         logger.debug(
                             f"Audio level: current={normalized_level:.1f}%, max_seen={max_level_seen:.1f}%, buffer_size={len(self.audio_buffer)}"
                         )
@@ -1922,7 +2012,9 @@ class SpeechRecognitionManager:
                     # Ensure vad_sensitivity is treated as integer for calculation
                     try:
                         vad_sens = int(self.vad_sensitivity)
-                        threshold = 500 / max(1, min(5, vad_sens))  # Use self.vad_sensitivity
+                        threshold = 500 / max(
+                            1, min(5, vad_sens)
+                        )  # Use self.vad_sensitivity
                     except ValueError:
                         logger.warning(
                             f"Invalid VAD sensitivity value: {self.vad_sensitivity}. Using default 3."
@@ -1931,7 +2023,9 @@ class SpeechRecognitionManager:
 
                     if volume < threshold:  # Silence
                         silence_counter += CHUNK / RATE  # Convert chunks to seconds
-                        if silence_counter > self.silence_timeout:  # Use self.silence_timeout
+                        if (
+                            silence_counter > self.silence_timeout
+                        ):  # Use self.silence_timeout
                             if len(self.audio_buffer) > 0:
                                 if self._recognition_mode == "push_to_talk":
                                     logger.debug(
@@ -1939,7 +2033,9 @@ class SpeechRecognitionManager:
                                         "deferring transcription until key release"
                                     )
                                 else:
-                                    logger.debug("Silence detected, queueing audio segment")
+                                    logger.debug(
+                                        "Silence detected, queueing audio segment"
+                                    )
                                     self._enqueue_audio_segment(self.audio_buffer)
                                     self.audio_buffer = []
                             silence_counter = 0
@@ -1962,11 +2058,15 @@ class SpeechRecognitionManager:
                         self._last_audio_error_time = current_time
 
                         if self._attempt_audio_reconnection(audio):
-                            logger.info("Audio reconnection successful, continuing recording")
+                            logger.info(
+                                "Audio reconnection successful, continuing recording"
+                            )
                             stream = self._audio_stream  # Update stream reference
                             continue  # Continue recording with new stream
                         else:
-                            logger.error("Audio reconnection failed, stopping recording")
+                            logger.error(
+                                "Audio reconnection failed, stopping recording"
+                            )
                             break
                     else:
                         logger.warning(
@@ -2033,7 +2133,9 @@ class SpeechRecognitionManager:
             with self._model_lock:
                 # Check if recognizer is still valid
                 if self.recognizer is None:
-                    logger.warning("Recognizer is None during processing, returning empty result")
+                    logger.warning(
+                        "Recognizer is None during processing, returning empty result"
+                    )
                     return
                 for data in audio_buffer:
                     self.recognizer.AcceptWaveform(data)
@@ -2127,7 +2229,9 @@ class SpeechRecognitionManager:
                 logger.info("DEBUG: Recognition loop - exiting after None signal")
                 break
 
-            logger.info(f"DEBUG: Recognition loop - processing segment with {len(segment)} chunks")
+            logger.info(
+                f"DEBUG: Recognition loop - processing segment with {len(segment)} chunks"
+            )
             self._update_state(RecognitionState.PROCESSING)
             self._process_audio_buffer(segment)
             if self.should_record:
@@ -2149,7 +2253,9 @@ class SpeechRecognitionManager:
                 logger.info("DEBUG: Recognition loop - got None signal, continuing")
                 continue
 
-            logger.info(f"DEBUG: Recognition loop - processing segment with {len(segment)} chunks")
+            logger.info(
+                f"DEBUG: Recognition loop - processing segment with {len(segment)} chunks"
+            )
             self._update_state(RecognitionState.PROCESSING)
             self._process_audio_buffer(segment)
             if self.should_record:
@@ -2169,12 +2275,16 @@ class SpeechRecognitionManager:
             self._segment_queue.put_nowait(segment)
             logger.info("DEBUG: Enqueued segment successfully")
         except queue.Full:
-            logger.warning("Transcription queue is full, dropping oldest pending segment")
+            logger.warning(
+                "Transcription queue is full, dropping oldest pending segment"
+            )
             try:
                 self._segment_queue.get_nowait()
                 self._segment_queue.put_nowait(segment)
             except queue.Empty:
-                logger.warning("Could not recover queue space for transcription segment")
+                logger.warning(
+                    "Could not recover queue space for transcription segment"
+                )
 
     def _signal_recognition_stop(self):
         """Signal recognition thread to wake up and stop cleanly."""
@@ -2279,10 +2389,14 @@ class SpeechRecognitionManager:
                     elif self.engine == "moonshine":
                         self._init_moonshine()
                     else:
-                        raise ValueError(f"Unsupported engine during reconfigure: {self.engine}")
+                        raise ValueError(
+                            f"Unsupported engine during reconfigure: {self.engine}"
+                        )
                     logger.info("Speech engine re-initialized successfully.")
                 except Exception as e:
-                    logger.error(f"Failed to re-initialize speech engine: {e}", exc_info=True)
+                    logger.error(
+                        f"Failed to re-initialize speech engine: {e}", exc_info=True
+                    )
                     self._update_state(RecognitionState.ERROR)
                     # Re-raise or handle appropriately
                     raise
@@ -2307,7 +2421,9 @@ class SpeechRecognitionManager:
         self._reconnection_attempts += 1
 
         if self._reconnection_attempts > self._max_reconnection_attempts:
-            logger.error(f"Max reconnection attempts ({self._max_reconnection_attempts}) reached")
+            logger.error(
+                f"Max reconnection attempts ({self._max_reconnection_attempts}) reached"
+            )
             return False
 
         # Calculate delay with exponential backoff
@@ -2339,7 +2455,9 @@ class SpeechRecognitionManager:
             logger.debug(f"Reconnecting with {CHANNELS} channel(s)")
 
             # Detect supported sample rate for the device
-            RATE = _get_supported_sample_rate(audio_instance, self.audio_device_index, CHANNELS)
+            RATE = _get_supported_sample_rate(
+                audio_instance, self.audio_device_index, CHANNELS
+            )
             self._capture_sample_rate = RATE
             logger.debug(f"Reconnecting with sample rate: {RATE}Hz")
 
@@ -2409,12 +2527,16 @@ class SpeechRecognitionManager:
                 elif self.engine == "moonshine":
                     self._init_moonshine()
                 else:
-                    logger.error("Cannot reinitialize: unknown engine '%s'", self.engine)
+                    logger.error(
+                        "Cannot reinitialize: unknown engine '%s'", self.engine
+                    )
                     return
 
                 logger.info("Speech engine reinitialized after resume")
             except Exception:
-                logger.error("Failed to reinitialize speech engine after resume", exc_info=True)
+                logger.error(
+                    "Failed to reinitialize speech engine after resume", exc_info=True
+                )
                 self._update_state(RecognitionState.ERROR)
 
         self._reconnection_attempts = 0
@@ -2452,6 +2574,8 @@ class SpeechRecognitionManager:
             "memory_usage_bytes": total_memory,
             "memory_usage_mb": total_memory / (1024 * 1024),
             "buffer_full_percentage": (
-                (buffer_size / self._max_buffer_size) * 100 if self._max_buffer_size > 0 else 0
+                (buffer_size / self._max_buffer_size) * 100
+                if self._max_buffer_size > 0
+                else 0
             ),
         }

--- a/src/vocalinux/speech_recognition/recognition_manager.py
+++ b/src/vocalinux/speech_recognition/recognition_manager.py
@@ -768,9 +768,7 @@ class SpeechRecognitionManager:
             )
 
             if arch_name is None:
-                model_path, model_arch = get_model_for_language(
-                    wanted_language=moonshine_language
-                )
+                model_path, model_arch = get_model_for_language(wanted_language=moonshine_language)
             else:
                 model_arch = getattr(ModelArch, arch_name)
                 model_path, model_arch = get_model_for_language(
@@ -799,7 +797,6 @@ class SpeechRecognitionManager:
             logger.error(f"Failed to initialize Moonshine engine: {e}", exc_info=True)
             self.state = RecognitionState.ERROR
             raise
-
 
     def _transcribe_with_whisper(self, audio_buffer: list[bytes]) -> str:
         """
@@ -1149,13 +1146,13 @@ class SpeechRecognitionManager:
 
             with self._model_lock:
                 if self.model is None:
-                    logger.warning("Model is None during Moonshine transcription, returning empty result")
+                    logger.warning(
+                        "Model is None during Moonshine transcription, returning empty result"
+                    )
                     return ""
 
                 transcribe_start = time.time()
-                transcript = self.model.transcribe_without_streaming(
-                    audio_float, sample_rate=16000
-                )
+                transcript = self.model.transcribe_without_streaming(audio_float, sample_rate=16000)
                 transcribe_duration = time.time() - transcribe_start
 
             text_parts = []
@@ -1176,9 +1173,7 @@ class SpeechRecognitionManager:
                     f"for {duration:.2f}s audio (RTF: {rtf:.2f}x) - {num_lines} lines"
                 )
             else:
-                logger.debug(
-                    f"Moonshine returned empty transcription ({transcribe_duration:.3f}s)"
-                )
+                logger.debug(f"Moonshine returned empty transcription ({transcribe_duration:.3f}s)")
 
             return text
 
@@ -1190,7 +1185,6 @@ class SpeechRecognitionManager:
             )
             logger.error(f"Error in Moonshine transcription: {e} ({audio_info})", exc_info=True)
             return ""
-
 
     def _download_whispercpp_model(self):
         """Download a whisper.cpp model with progress tracking."""

--- a/src/vocalinux/ui/config_manager.py
+++ b/src/vocalinux/ui/config_manager.py
@@ -19,12 +19,13 @@ CONFIG_FILE = os.path.join(CONFIG_DIR, "config.json")
 # Default configuration
 DEFAULT_CONFIG = {
     "speech_recognition": {  # Changed section name
-        "engine": "whisper_cpp",  # "vosk", "whisper", or "whisper_cpp" - whisper_cpp is default for best performance
+        "engine": "whisper_cpp",  # "vosk", "whisper", "whisper_cpp", or "moonshine"
         "language": "auto",  # Auto-detect language (Whisper/whisper.cpp only)
         "model_size": "tiny",  # Current model size (for backward compatibility)
         "vosk_model_size": "small",  # Default model for VOSK engine
         "whisper_model_size": "tiny",  # Default model for Whisper engine
         "whisper_cpp_model_size": "tiny",  # Default model for whisper.cpp engine
+        "moonshine_model_size": "auto",  # Default model selection for Moonshine engine
         "vad_sensitivity": 3,  # Voice Activity Detection sensitivity (1-5)
         "silence_timeout": 2.0,  # Seconds of silence before stopping
         "voice_commands_enabled": None,  # None = auto (enabled for VOSK, disabled for Whisper)
@@ -117,7 +118,10 @@ class ConfigManager:
         sr_config = user_config.get("speech_recognition", {})
         # Need migration if we have model_size but not the per-engine keys
         return "model_size" in sr_config and (
-            "vosk_model_size" not in sr_config or "whisper_model_size" not in sr_config
+            "vosk_model_size" not in sr_config
+            or "whisper_model_size" not in sr_config
+            or "whisper_cpp_model_size" not in sr_config
+            or "moonshine_model_size" not in sr_config
         )
 
     def _migrate_config(self, user_config: dict):
@@ -141,6 +145,22 @@ class ConfigManager:
                 current_model if current_engine == "whisper" else "tiny"
             )
             logger.info(f"Migrated whisper_model_size to: {sr_config['whisper_model_size']}")
+
+        if "whisper_cpp_model_size" not in user_sr_config:
+            sr_config["whisper_cpp_model_size"] = (
+                current_model if current_engine == "whisper_cpp" else "tiny"
+            )
+            logger.info(
+                f"Migrated whisper_cpp_model_size to: {sr_config['whisper_cpp_model_size']}"
+            )
+
+        if "moonshine_model_size" not in user_sr_config:
+            sr_config["moonshine_model_size"] = (
+                current_model if current_engine == "moonshine" else "auto"
+            )
+            logger.info(
+                f"Migrated moonshine_model_size to: {sr_config['moonshine_model_size']}"
+            )
 
         self.save_config()
         logger.info("Config migrated to new per-engine model format")
@@ -278,7 +298,7 @@ class ConfigManager:
         """Get the saved model size for a specific engine.
 
         Args:
-            engine: The engine name ("vosk", "whisper", or "whisper_cpp")
+            engine: The engine name ("vosk", "whisper", "whisper_cpp", or "moonshine")
 
         Returns:
             The model size for the engine, or the default if not found
@@ -297,7 +317,7 @@ class ConfigManager:
         """Set the model size for a specific engine.
 
         Args:
-            engine: The engine name ("vosk" or "whisper")
+            engine: The engine name ("vosk", "whisper", "whisper_cpp", or "moonshine")
             model_size: The model size to save
         """
         if "speech_recognition" not in self.config:

--- a/src/vocalinux/ui/config_manager.py
+++ b/src/vocalinux/ui/config_manager.py
@@ -158,9 +158,7 @@ class ConfigManager:
             sr_config["moonshine_model_size"] = (
                 current_model if current_engine == "moonshine" else "auto"
             )
-            logger.info(
-                f"Migrated moonshine_model_size to: {sr_config['moonshine_model_size']}"
-            )
+            logger.info(f"Migrated moonshine_model_size to: {sr_config['moonshine_model_size']}")
 
         self.save_config()
         logger.info("Config migrated to new per-engine model format")

--- a/src/vocalinux/ui/config_manager.py
+++ b/src/vocalinux/ui/config_manager.py
@@ -136,7 +136,9 @@ class ConfigManager:
         # Set the per-engine model sizes based on the user's original config
         if "vosk_model_size" not in user_sr_config:
             # If current engine is vosk, use the current model; otherwise use default
-            sr_config["vosk_model_size"] = current_model if current_engine == "vosk" else "small"
+            sr_config["vosk_model_size"] = (
+                current_model if current_engine == "vosk" else "small"
+            )
             logger.info(f"Migrated vosk_model_size to: {sr_config['vosk_model_size']}")
 
         if "whisper_model_size" not in user_sr_config:
@@ -144,7 +146,9 @@ class ConfigManager:
             sr_config["whisper_model_size"] = (
                 current_model if current_engine == "whisper" else "tiny"
             )
-            logger.info(f"Migrated whisper_model_size to: {sr_config['whisper_model_size']}")
+            logger.info(
+                f"Migrated whisper_model_size to: {sr_config['whisper_model_size']}"
+            )
 
         if "whisper_cpp_model_size" not in user_sr_config:
             sr_config["whisper_cpp_model_size"] = (
@@ -158,7 +162,9 @@ class ConfigManager:
             sr_config["moonshine_model_size"] = (
                 current_model if current_engine == "moonshine" else "auto"
             )
-            logger.info(f"Migrated moonshine_model_size to: {sr_config['moonshine_model_size']}")
+            logger.info(
+                f"Migrated moonshine_model_size to: {sr_config['moonshine_model_size']}"
+            )
 
         self.save_config()
         logger.info("Config migrated to new per-engine model format")
@@ -380,7 +386,11 @@ class ConfigManager:
             source: The source dictionary with updates
         """
         for key, value in source.items():
-            if key in target and isinstance(target[key], dict) and isinstance(value, dict):
+            if (
+                key in target
+                and isinstance(target[key], dict)
+                and isinstance(value, dict)
+            ):
                 self._update_dict_recursive(target[key], value)
             else:
                 target[key] = value

--- a/src/vocalinux/ui/config_manager.py
+++ b/src/vocalinux/ui/config_manager.py
@@ -136,9 +136,7 @@ class ConfigManager:
         # Set the per-engine model sizes based on the user's original config
         if "vosk_model_size" not in user_sr_config:
             # If current engine is vosk, use the current model; otherwise use default
-            sr_config["vosk_model_size"] = (
-                current_model if current_engine == "vosk" else "small"
-            )
+            sr_config["vosk_model_size"] = current_model if current_engine == "vosk" else "small"
             logger.info(f"Migrated vosk_model_size to: {sr_config['vosk_model_size']}")
 
         if "whisper_model_size" not in user_sr_config:
@@ -146,9 +144,7 @@ class ConfigManager:
             sr_config["whisper_model_size"] = (
                 current_model if current_engine == "whisper" else "tiny"
             )
-            logger.info(
-                f"Migrated whisper_model_size to: {sr_config['whisper_model_size']}"
-            )
+            logger.info(f"Migrated whisper_model_size to: {sr_config['whisper_model_size']}")
 
         if "whisper_cpp_model_size" not in user_sr_config:
             sr_config["whisper_cpp_model_size"] = (
@@ -162,9 +158,7 @@ class ConfigManager:
             sr_config["moonshine_model_size"] = (
                 current_model if current_engine == "moonshine" else "auto"
             )
-            logger.info(
-                f"Migrated moonshine_model_size to: {sr_config['moonshine_model_size']}"
-            )
+            logger.info(f"Migrated moonshine_model_size to: {sr_config['moonshine_model_size']}")
 
         self.save_config()
         logger.info("Config migrated to new per-engine model format")
@@ -386,11 +380,7 @@ class ConfigManager:
             source: The source dictionary with updates
         """
         for key, value in source.items():
-            if (
-                key in target
-                and isinstance(target[key], dict)
-                and isinstance(value, dict)
-            ):
+            if key in target and isinstance(target[key], dict) and isinstance(value, dict):
                 self._update_dict_recursive(target[key], value)
             else:
                 target[key] = value

--- a/src/vocalinux/ui/settings_dialog.py
+++ b/src/vocalinux/ui/settings_dialog.py
@@ -40,12 +40,8 @@ from ..utils.whispercpp_model_info import (
     detect_compute_backend,
     get_backend_display_name,
 )
-from ..utils.whispercpp_model_info import (
-    get_recommended_model as get_recommended_whispercpp_model,
-)
-from ..utils.whispercpp_model_info import (
-    is_model_downloaded as is_whispercpp_model_downloaded,
-)
+from ..utils.whispercpp_model_info import get_recommended_model as get_recommended_whispercpp_model
+from ..utils.whispercpp_model_info import is_model_downloaded as is_whispercpp_model_downloaded
 from .keyboard_backends import (  # noqa: E402
     SHORTCUT_DISPLAY_NAMES,
     SHORTCUT_GROUPS,
@@ -469,9 +465,7 @@ def _get_recommended_whisper_model() -> tuple:
 
                 if torch.cuda.is_available():
                     has_cuda = True
-                    cuda_memory_gb = torch.cuda.get_device_properties(
-                        0
-                    ).total_memory // (1024**3)
+                    cuda_memory_gb = torch.cuda.get_device_properties(0).total_memory // (1024**3)
         except Exception:
             pass
 
@@ -738,9 +732,7 @@ class ModelDownloadDialog(Gtk.Dialog):
                     "<span foreground='#e5a50a'>✗ Download cancelled</span>"
                 )
             else:
-                self.status_label.set_markup(
-                    f"<span foreground='#c01c28'>✗ {message}</span>"
-                )
+                self.status_label.set_markup(f"<span foreground='#c01c28'>✗ {message}</span>")
 
         # Allow closing now
         self.set_deletable(True)
@@ -770,15 +762,11 @@ class SettingsDialog(Gtk.Dialog):
         self._test_active = False
         self._test_result = ""
         self._initializing = True  # Flag to prevent auto-apply during initialization
-        self._populating_models = (
-            False  # Flag to prevent model change handler during population
-        )
+        self._populating_models = False  # Flag to prevent model change handler during population
         self._processing_language_change = (
             False  # Flag to prevent recursive language change handling
         )
-        self._applying_settings = (
-            False  # Flag to prevent recursive settings application
-        )
+        self._applying_settings = False  # Flag to prevent recursive settings application
 
         # Setup CSS styling
         _setup_css()
@@ -813,18 +801,14 @@ class SettingsDialog(Gtk.Dialog):
 
         # Create tab content boxes
         # Speech Engine tab (Engine, Model, Language)
-        self.speech_engine_tab = Gtk.Box(
-            orientation=Gtk.Orientation.VERTICAL, spacing=12
-        )
+        self.speech_engine_tab = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=12)
         self.speech_engine_tab.set_margin_top(16)
         self.speech_engine_tab.set_margin_bottom(16)
         self.speech_engine_tab.set_margin_start(16)
         self.speech_engine_tab.set_margin_end(16)
 
         # Recognition Settings tab (VAD, Silence, Test)
-        self.recognition_settings_tab = Gtk.Box(
-            orientation=Gtk.Orientation.VERTICAL, spacing=12
-        )
+        self.recognition_settings_tab = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=12)
         self.recognition_settings_tab.set_margin_top(16)
         self.recognition_settings_tab.set_margin_bottom(16)
         self.recognition_settings_tab.set_margin_start(16)
@@ -852,9 +836,7 @@ class SettingsDialog(Gtk.Dialog):
         # Add tabs to notebook (ordered by importance)
         # Speech Engine tab - most important (what model/language to use)
         speech_engine_label = Gtk.Label(label="Speech Engine")
-        speech_engine_label.set_tooltip_text(
-            "Speech recognition engine and model settings"
-        )
+        speech_engine_label.set_tooltip_text("Speech recognition engine and model settings")
         notebook.append_page(self.speech_engine_tab, speech_engine_label)
 
         # Recognition Settings tab - second most important (how to recognize)
@@ -922,9 +904,7 @@ class SettingsDialog(Gtk.Dialog):
         _prevent_scroll_on_hover(self.audio_device_combo)
         device_box.pack_start(self.audio_device_combo, True, True, 0)
 
-        refresh_btn = Gtk.Button.new_from_icon_name(
-            "view-refresh-symbolic", Gtk.IconSize.BUTTON
-        )
+        refresh_btn = Gtk.Button.new_from_icon_name("view-refresh-symbolic", Gtk.IconSize.BUTTON)
         refresh_btn.set_tooltip_text("Refresh device list")
         refresh_btn.get_style_context().add_class("flat-button")
         refresh_btn.connect("clicked", self._on_refresh_audio_devices)
@@ -991,9 +971,7 @@ class SettingsDialog(Gtk.Dialog):
         group = PreferencesGroup(title="General")
 
         self.autostart_switch = Gtk.Switch()
-        self.autostart_switch.set_tooltip_text(
-            "Start Vocalinux automatically when you log in"
-        )
+        self.autostart_switch.set_tooltip_text("Start Vocalinux automatically when you log in")
         autostart_row = PreferenceRow(
             title="Start on Login",
             subtitle="Automatically start Vocalinux when you log in",
@@ -1025,12 +1003,8 @@ class SettingsDialog(Gtk.Dialog):
         self.general_tab.pack_start(group, False, False, 0)
 
         self.autostart_switch.connect("state-set", self._on_autostart_toggled)
-        self.start_minimized_switch.connect(
-            "state-set", self._on_start_minimized_toggled
-        )
-        self.copy_to_clipboard_switch.connect(
-            "state-set", self._on_copy_to_clipboard_toggled
-        )
+        self.start_minimized_switch.connect("state-set", self._on_start_minimized_toggled)
+        self.copy_to_clipboard_switch.connect("state-set", self._on_copy_to_clipboard_toggled)
 
     def _on_autostart_toggled(self, widget, state):
         """Handle toggle of the autostart switch."""
@@ -1191,9 +1165,7 @@ class SettingsDialog(Gtk.Dialog):
         # Silence Timeout
         self.silence_spin = Gtk.SpinButton.new_with_range(0.5, 5.0, 0.1)
         self.silence_spin.set_digits(1)
-        self.silence_spin.set_tooltip_text(
-            "Wait time after silence before processing speech"
-        )
+        self.silence_spin.set_tooltip_text("Wait time after silence before processing speech")
         _prevent_scroll_on_hover(self.silence_spin)
         silence_row = PreferenceRow(
             title="Silence Timeout",
@@ -1256,9 +1228,7 @@ class SettingsDialog(Gtk.Dialog):
         # Shortcut selection combo
         self.shortcut_combo = Gtk.ComboBoxText()
         self.shortcut_combo.set_size_request(200, -1)
-        self.shortcut_combo.set_tooltip_text(
-            "Select the keyboard shortcut for voice typing"
-        )
+        self.shortcut_combo.set_tooltip_text("Select the keyboard shortcut for voice typing")
         _prevent_scroll_on_hover(self.shortcut_combo)
 
         # Populate shortcut options grouped by side
@@ -1293,9 +1263,7 @@ class SettingsDialog(Gtk.Dialog):
         info_box.set_margin_end(4)
         info_box.set_margin_top(4)
 
-        info_icon = Gtk.Image.new_from_icon_name(
-            "dialog-information-symbolic", Gtk.IconSize.MENU
-        )
+        info_icon = Gtk.Image.new_from_icon_name("dialog-information-symbolic", Gtk.IconSize.MENU)
         info_box.pack_start(info_icon, False, False, 0)
 
         self.shortcut_info_label = Gtk.Label(
@@ -1318,9 +1286,7 @@ class SettingsDialog(Gtk.Dialog):
     def _update_shortcut_ui_for_mode(self, mode: str):
         """Update the shortcut UI based on the selected mode."""
         if mode == "toggle":
-            self.shortcut_row.set_subtitle(
-                "Double-tap this key to start/stop voice typing"
-            )
+            self.shortcut_row.set_subtitle("Double-tap this key to start/stop voice typing")
             self.shortcut_info_label.set_text(
                 "In Toggle mode: Double-tap the key to start voice typing, double-tap again to stop."
             )
@@ -1381,9 +1347,7 @@ class SettingsDialog(Gtk.Dialog):
         # Ignore separator entries (used for grouped display)
         if shortcut_id.startswith("__separator_"):
             # Revert to the previously saved shortcut
-            current = self.config_manager.get_str(
-                "shortcuts", "toggle_recognition", "ctrl+ctrl"
-            )
+            current = self.config_manager.get_str("shortcuts", "toggle_recognition", "ctrl+ctrl")
             self.shortcut_combo.set_active_id(current)
             return
 
@@ -1494,9 +1458,7 @@ class SettingsDialog(Gtk.Dialog):
         self.progress_info_label = Gtk.Label(label="", use_markup=True, xalign=0)
         self.progress_info_label.set_margin_start(16)
         self.progress_info_label.set_margin_bottom(8)
-        self.recognition_settings_tab.pack_start(
-            self.progress_info_label, False, False, 0
-        )
+        self.recognition_settings_tab.pack_start(self.progress_info_label, False, False, 0)
 
     def _load_and_apply_settings(self):
         """Load current settings and populate the UI."""
@@ -1513,9 +1475,7 @@ class SettingsDialog(Gtk.Dialog):
 
         general_settings = self.config_manager.get_settings().get("general", {})
         ui_settings = self.config_manager.get_settings().get("ui", {})
-        text_injection_settings = self.config_manager.get_settings().get(
-            "text_injection", {}
-        )
+        text_injection_settings = self.config_manager.get_settings().get("text_injection", {})
 
         autostart_enabled = general_settings.get("autostart", False)
         start_minimized = ui_settings.get("start_minimized", False)
@@ -1524,9 +1484,7 @@ class SettingsDialog(Gtk.Dialog):
         self.autostart_switch.set_active(autostart_enabled)
         self.start_minimized_switch.set_active(start_minimized)
         self.copy_to_clipboard_switch.set_active(copy_to_clipboard)
-        self.sound_effects_switch.set_active(
-            self.config_manager.is_sound_effects_enabled()
-        )
+        self.sound_effects_switch.set_active(self.config_manager.is_sound_effects_enabled())
 
         # Populate engine combo with only available engines
         available_engines = get_available_engines()
@@ -1545,9 +1503,7 @@ class SettingsDialog(Gtk.Dialog):
                 capitalized_engine = engine.capitalize()
                 self.engine_combo.append(capitalized_engine, capitalized_engine)
         else:
-            logger.info(
-                f"Populated {available_count} available engines: {available_engines}"
-            )
+            logger.info(f"Populated {available_count} available engines: {available_engines}")
 
         # Set engine active - check if current engine is available
         if not available_engines.get(self.current_engine, False):
@@ -1582,9 +1538,7 @@ class SettingsDialog(Gtk.Dialog):
         self._populate_language_options()
         if self.language:
             if not self.language_combo.set_active_id(self.language):
-                logger.warning(
-                    f"Language '{self.language}' not found in options, using auto"
-                )
+                logger.warning(f"Language '{self.language}' not found in options, using auto")
                 self.language_combo.set_active_id("auto")
                 self.language = "auto"
 
@@ -1635,9 +1589,7 @@ class SettingsDialog(Gtk.Dialog):
             engine = engine_text.lower()
             logger.info(f"Populating model options for engine: {engine}")
 
-            saved_model_for_engine = self.config_manager.get_model_size_for_engine(
-                engine
-            )
+            saved_model_for_engine = self.config_manager.get_model_size_for_engine(engine)
             logger.info(f"Saved model for {engine}: {saved_model_for_engine}")
 
             downloaded_models = []
@@ -1699,9 +1651,7 @@ class SettingsDialog(Gtk.Dialog):
             elif downloaded_models:
                 model_to_set = downloaded_models[0].capitalize()
             else:
-                model_to_set = (
-                    smallest_model.capitalize() if smallest_model else "Small"
-                )
+                model_to_set = smallest_model.capitalize() if smallest_model else "Small"
 
             logger.info(f"Setting active model to: {model_to_set}")
 
@@ -1731,15 +1681,12 @@ class SettingsDialog(Gtk.Dialog):
         current_lang = self.language_combo.get_active_id()
         if current_lang:
             if engine == "vosk" and (
-                current_lang == "auto"
-                or not SUPPORTED_LANGUAGES.get(current_lang, {}).get("vosk")
+                current_lang == "auto" or not SUPPORTED_LANGUAGES.get(current_lang, {}).get("vosk")
             ):
                 self.language = "en-us"
             elif engine in ["whisper", "whisper_cpp"] and not current_lang:
                 self.language = "auto"
-            elif engine == "moonshine" and not is_moonshine_language_supported(
-                current_lang
-            ):
+            elif engine == "moonshine" and not is_moonshine_language_supported(current_lang):
                 self.language = "auto"
 
         self._populate_model_options()
@@ -1755,11 +1702,7 @@ class SettingsDialog(Gtk.Dialog):
         voice_commands_enabled = sr_config.get("voice_commands_enabled")
 
         engine_text = self.engine_combo.get_active_text()
-        engine = (
-            engine_text.lower()
-            if engine_text
-            else sr_config.get("engine", "whisper_cpp")
-        )
+        engine = engine_text.lower() if engine_text else sr_config.get("engine", "whisper_cpp")
 
         if engine == "moonshine":
             self.voice_commands_switch.set_sensitive(False)
@@ -1799,9 +1742,7 @@ class SettingsDialog(Gtk.Dialog):
         self.config_manager.set("speech_recognition", "voice_commands_enabled", enabled)
         self.config_manager.save_settings()
         try:
-            self.speech_engine.reconfigure(
-                voice_commands_enabled=enabled, force_download=False
-            )
+            self.speech_engine.reconfigure(voice_commands_enabled=enabled, force_download=False)
         except Exception as e:
             logger.warning(f"Failed to apply voice commands toggle immediately: {e}")
         logger.info(f"Voice commands {'enabled' if enabled else 'disabled'}")
@@ -1830,9 +1771,7 @@ class SettingsDialog(Gtk.Dialog):
                 if lang_code == "auto":
                     display_text += " ⚠"
             elif engine == "moonshine":
-                if lang_code != "auto" and not is_moonshine_language_supported(
-                    lang_code
-                ):
+                if lang_code != "auto" and not is_moonshine_language_supported(lang_code):
                     continue
                 if lang_code == "auto":
                     display_text += " (English fallback)"
@@ -1909,7 +1848,9 @@ class SettingsDialog(Gtk.Dialog):
             is_downloaded = is_whispercpp_model_downloaded(model_name)
             recommended, reason = get_recommended_whispercpp_model()
             backend, backend_info = detect_compute_backend()
-            extra_info = f"Parameters: {info['params']} • Backend: {get_backend_display_name(backend)}"
+            extra_info = (
+                f"Parameters: {info['params']} • Backend: {get_backend_display_name(backend)}"
+            )
         elif engine == "vosk":
             if model_name not in VOSK_MODEL_INFO:
                 self.model_info_card.hide()
@@ -1923,16 +1864,12 @@ class SettingsDialog(Gtk.Dialog):
             info = {
                 "desc": "Moonshine ONNX backend",
                 "params": (
-                    "Auto-selected by moonshine_voice"
-                    if model_name == "auto"
-                    else model_name
+                    "Auto-selected by moonshine_voice" if model_name == "auto" else model_name
                 ),
             }
             package_available = is_moonshine_available()
             recommended = "auto"
-            reason = (
-                "Moonshine chooses the best available model for the selected language"
-            )
+            reason = "Moonshine chooses the best available model for the selected language"
             extra_info = (
                 "Backend: moonshine_voice"
                 if model_name == "auto"
@@ -1942,17 +1879,11 @@ class SettingsDialog(Gtk.Dialog):
                 self.model_info_card.hide()
                 return
 
-            self.model_info_title.set_markup(
-                f"<b>{model_name.capitalize()}</b>: {info['desc']}"
-            )
+            self.model_info_title.set_markup(f"<b>{model_name.capitalize()}</b>: {info['desc']}")
             if package_available:
-                status = (
-                    "<span foreground='#26a269'>✓ Managed by moonshine_voice</span>"
-                )
+                status = "<span foreground='#26a269'>✓ Managed by moonshine_voice</span>"
             else:
-                status = (
-                    "<span foreground='#c01c28'>Moonshine package not installed</span>"
-                )
+                status = "<span foreground='#c01c28'>Moonshine package not installed</span>"
             self.model_info_subtitle.set_markup(f"{extra_info} • {status}")
 
             if model_name == recommended:
@@ -1971,9 +1902,7 @@ class SettingsDialog(Gtk.Dialog):
             return
 
         # Update title
-        self.model_info_title.set_markup(
-            f"<b>{model_name.capitalize()}</b>: {info['desc']}"
-        )
+        self.model_info_title.set_markup(f"<b>{model_name.capitalize()}</b>: {info['desc']}")
 
         # Update subtitle with status
         if is_downloaded:
@@ -2020,21 +1949,15 @@ class SettingsDialog(Gtk.Dialog):
             if engine == "whisper" and not _is_whisper_model_downloaded(model_name):
                 needs_download = True
                 model_info = WHISPER_MODEL_INFO.get(model_name, {"size_mb": 500})
-            elif engine == "whisper_cpp" and not is_whispercpp_model_downloaded(
-                model_name
-            ):
+            elif engine == "whisper_cpp" and not is_whispercpp_model_downloaded(model_name):
                 needs_download = True
                 model_info = WHISPERCPP_MODEL_INFO.get(model_name, {"size_mb": 39})
-            elif engine == "vosk" and not _is_vosk_model_downloaded(
-                model_name, self.language
-            ):
+            elif engine == "vosk" and not _is_vosk_model_downloaded(model_name, self.language):
                 needs_download = True
                 model_info = VOSK_MODEL_INFO.get(model_name, {"size_mb": 50})
 
             if needs_download:
-                logger.info(
-                    f"Model {model_name} needs download, showing progress dialog"
-                )
+                logger.info(f"Model {model_name} needs download, showing progress dialog")
                 download_dialog = ModelDownloadDialog(
                     self,
                     model_name,
@@ -2044,15 +1967,11 @@ class SettingsDialog(Gtk.Dialog):
                 )
 
                 def progress_callback(fraction, speed, status):
-                    GLib.idle_add(
-                        download_dialog.update_progress, fraction, speed, status
-                    )
+                    GLib.idle_add(download_dialog.update_progress, fraction, speed, status)
 
                 def download_and_apply():
                     try:
-                        self.speech_engine.set_download_progress_callback(
-                            progress_callback
-                        )
+                        self.speech_engine.set_download_progress_callback(progress_callback)
 
                         def check_cancelled():
                             if download_dialog.cancelled:
@@ -2077,10 +1996,7 @@ class SettingsDialog(Gtk.Dialog):
                                 False,
                                 "Download cancelled",
                             )
-                        elif (
-                            engine == "whisper"
-                            and "no module named" in error_msg.lower()
-                        ):
+                        elif engine == "whisper" and "no module named" in error_msg.lower():
                             GLib.idle_add(
                                 download_dialog.set_complete,
                                 False,
@@ -2088,9 +2004,7 @@ class SettingsDialog(Gtk.Dialog):
                             )
                             GLib.idle_add(self._show_whisper_install_dialog)
                         else:
-                            GLib.idle_add(
-                                download_dialog.set_complete, False, error_msg[:100]
-                            )
+                            GLib.idle_add(download_dialog.set_complete, False, error_msg[:100])
 
                 threading.Thread(target=download_and_apply, daemon=True).start()
                 download_dialog.run()
@@ -2147,22 +2061,18 @@ class SettingsDialog(Gtk.Dialog):
             logger.warning("Test already in progress.")
             return
 
-        current_config = self.config_manager.get_settings().get(
-            "speech_recognition", {}
-        )
+        current_config = self.config_manager.get_settings().get("speech_recognition", {})
         selected_settings = self.get_selected_settings()
 
         settings_differ = False
-        if current_config.get("engine") != selected_settings.get(
-            "engine"
-        ) or current_config.get("model_size") != selected_settings.get("model_size"):
+        if current_config.get("engine") != selected_settings.get("engine") or current_config.get(
+            "model_size"
+        ) != selected_settings.get("model_size"):
             settings_differ = True
         elif selected_settings.get("engine") == "vosk":
             if current_config.get("vad_sensitivity") != selected_settings.get(
                 "vad_sensitivity"
-            ) or current_config.get("silence_timeout") != selected_settings.get(
-                "silence_timeout"
-            ):
+            ) or current_config.get("silence_timeout") != selected_settings.get("silence_timeout"):
                 settings_differ = True
 
         if settings_differ:
@@ -2179,9 +2089,7 @@ class SettingsDialog(Gtk.Dialog):
         self._test_result = ""
 
         self.connect_to_recognition_manager()
-        self.update_recognition_progress(
-            "Listening", info="Starting recognition test..."
-        )
+        self.update_recognition_progress("Listening", info="Starting recognition test...")
 
         self._saved_text_callbacks = self.speech_engine.get_text_callbacks()
         self.speech_engine.set_text_callbacks([self._test_text_callback])
@@ -2296,9 +2204,7 @@ For now, the engine has been reverted to VOSK."""
         if engine == "whisper" and not _is_whisper_model_downloaded(model_name):
             needs_download = True
             model_info = WHISPER_MODEL_INFO.get(model_name, {"size_mb": 500})
-        elif engine == "vosk" and not _is_vosk_model_downloaded(
-            model_name, self.language
-        ):
+        elif engine == "vosk" and not _is_vosk_model_downloaded(model_name, self.language):
             needs_download = True
             model_info = VOSK_MODEL_INFO.get(model_name, {"size_mb": 50})
 
@@ -2335,18 +2241,12 @@ For now, the engine has been reverted to VOSK."""
                 except Exception as e:
                     error_msg = str(e)
                     if "cancelled" in error_msg.lower():
-                        GLib.idle_add(
-                            download_dialog.set_complete, False, "Download cancelled"
-                        )
+                        GLib.idle_add(download_dialog.set_complete, False, "Download cancelled")
                     elif engine == "whisper" and "no module named" in error_msg.lower():
-                        GLib.idle_add(
-                            download_dialog.set_complete, False, "Whisper not installed"
-                        )
+                        GLib.idle_add(download_dialog.set_complete, False, "Whisper not installed")
                         GLib.idle_add(self._show_whisper_install_dialog)
                     else:
-                        GLib.idle_add(
-                            download_dialog.set_complete, False, error_msg[:100]
-                        )
+                        GLib.idle_add(download_dialog.set_complete, False, error_msg[:100])
 
             threading.Thread(target=download_and_apply, daemon=True).start()
             download_dialog.run()
@@ -2406,9 +2306,7 @@ For now, the engine has been reverted to VOSK."""
                 label += " (default)"
             self.audio_device_combo.append(str(device_index), label)
 
-        saved_device = self.config_manager.get_optional_int(
-            "audio", "device_index", None
-        )
+        saved_device = self.config_manager.get_optional_int("audio", "device_index", None)
 
         if saved_device is None:
             self.audio_device_combo.set_active_id("-1")
@@ -2457,9 +2355,7 @@ For now, the engine has been reverted to VOSK."""
         """Handle test audio button click."""
         self.test_audio_btn.set_sensitive(False)
         self.test_audio_btn.set_label("Testing...")
-        self.audio_test_status.set_markup(
-            "<i>Recording... speak into your microphone</i>"
-        )
+        self.audio_test_status.set_markup("<i>Recording... speak into your microphone</i>")
         self.audio_level_bar.set_value(0)
 
         device_id = self.audio_device_combo.get_active_id()
@@ -2511,9 +2407,7 @@ For now, the engine has been reverted to VOSK."""
 
         return False
 
-    def update_recognition_progress(
-        self, state: str, audio_level: float = 0.0, info: str = ""
-    ):
+    def update_recognition_progress(self, state: str, audio_level: float = 0.0, info: str = ""):
         """Update the recognition progress feedback UI."""
         self.recognition_status_label.set_text(state)
 
@@ -2528,31 +2422,21 @@ For now, the engine has been reverted to VOSK."""
 
         if state == "Listening":
             self.recognition_indicator.set_opacity(1.0)
-            self.recognition_status_label.get_style_context().add_class(
-                "recognition-listening"
-            )
-            self.progress_info_label.set_markup(
-                "<span foreground='#26a269'>● Listening...</span>"
-            )
+            self.recognition_status_label.get_style_context().add_class("recognition-listening")
+            self.progress_info_label.set_markup("<span foreground='#26a269'>● Listening...</span>")
         elif state == "Processing":
             self.recognition_indicator.set_opacity(1.0)
-            self.recognition_status_label.get_style_context().add_class(
-                "recognition-processing"
-            )
+            self.recognition_status_label.get_style_context().add_class("recognition-processing")
             self.progress_info_label.set_markup(
                 "<span foreground='#e5a50a'>● Processing speech...</span>"
             )
         elif state == "Idle":
             self.recognition_indicator.set_opacity(0.3)
-            self.recognition_status_label.get_style_context().add_class(
-                "recognition-idle"
-            )
+            self.recognition_status_label.get_style_context().add_class("recognition-idle")
             self.progress_info_label.set_text("")
         elif state == "Error":
             self.recognition_indicator.set_opacity(0.3)
-            self.recognition_status_label.get_style_context().add_class(
-                "recognition-error"
-            )
+            self.recognition_status_label.get_style_context().add_class("recognition-error")
             self.progress_info_label.set_markup(
                 f"<span foreground='#c01c28'>✗ Error: {info}</span>"
             )
@@ -2571,12 +2455,8 @@ For now, the engine has been reverted to VOSK."""
         """Connect to speech recognition manager for progress updates."""
         if hasattr(self, "speech_engine") and self.speech_engine:
             if not hasattr(self, "_callbacks_registered"):
-                self.speech_engine.state_callbacks.append(
-                    self._on_recognition_state_changed
-                )
-                self.speech_engine.register_audio_level_callback(
-                    self._on_audio_level_changed
-                )
+                self.speech_engine.state_callbacks.append(self._on_recognition_state_changed)
+                self.speech_engine.register_audio_level_callback(self._on_audio_level_changed)
                 self._callbacks_registered = True
                 self.connect("destroy", self._on_dialog_destroy)
 
@@ -2584,12 +2464,8 @@ For now, the engine has been reverted to VOSK."""
         """Clean up callbacks when dialog is destroyed."""
         if hasattr(self, "speech_engine") and self.speech_engine:
             if self._on_recognition_state_changed in self.speech_engine.state_callbacks:
-                self.speech_engine.state_callbacks.remove(
-                    self._on_recognition_state_changed
-                )
-            self.speech_engine.unregister_audio_level_callback(
-                self._on_audio_level_changed
-            )
+                self.speech_engine.state_callbacks.remove(self._on_recognition_state_changed)
+            self.speech_engine.unregister_audio_level_callback(self._on_audio_level_changed)
 
     def _on_recognition_state_changed(self, state):
         """Handle recognition state changes."""

--- a/src/vocalinux/ui/settings_dialog.py
+++ b/src/vocalinux/ui/settings_dialog.py
@@ -1848,7 +1848,9 @@ class SettingsDialog(Gtk.Dialog):
             info = {
                 "desc": "Moonshine ONNX backend",
                 "size_mb": 0,
-                "params": "Auto-selected by moonshine_voice" if model_name == "auto" else model_name,
+                "params": (
+                    "Auto-selected by moonshine_voice" if model_name == "auto" else model_name
+                ),
             }
             is_downloaded = is_moonshine_available()
             recommended = "auto"

--- a/src/vocalinux/ui/settings_dialog.py
+++ b/src/vocalinux/ui/settings_dialog.py
@@ -28,6 +28,12 @@ gi.require_version("Gdk", "3.0")
 from gi.repository import Gdk, GLib, Gtk, Pango  # noqa: E402
 
 from ..common_types import RecognitionState  # noqa: E402
+from ..utils.moonshine_model_info import (  # noqa: E402
+    get_moonshine_default_model_size,
+    get_moonshine_supported_model_sizes,
+    is_moonshine_available,
+    is_moonshine_language_supported,
+)
 from ..utils.vosk_model_info import SUPPORTED_LANGUAGES, VOSK_MODEL_INFO  # noqa: E402
 from ..utils.whispercpp_model_info import (
     WHISPERCPP_MODEL_INFO,
@@ -71,6 +77,13 @@ ENGINE_MODELS = {
         "medium",
         "large",
     ],  # whisper.cpp models (ggml format)
+    "moonshine": [
+        "auto",
+        "tiny",
+        "base",
+        "small",
+        "medium",
+    ],
 }
 
 # Whisper model metadata for display
@@ -88,7 +101,7 @@ def get_available_engines():
     Detect which speech recognition engines are available/installed.
     Returns a dictionary of engine_name -> availability (bool).
     """
-    engines = {"vosk": False, "whisper": False, "whisper_cpp": False}
+    engines = {"vosk": False, "whisper": False, "whisper_cpp": False, "moonshine": False}
 
     # Check VOSK
     try:
@@ -113,6 +126,10 @@ def get_available_engines():
         engines["whisper_cpp"] = True
     except ImportError:
         pass
+
+    # Check Moonshine
+    if is_moonshine_available():
+        engines["moonshine"] = True
 
     logger.debug(f"Available engines: {engines}")
     return engines
@@ -1570,15 +1587,21 @@ class SettingsDialog(Gtk.Dialog):
 
             downloaded_models = []
             smallest_model = None
+            available_models = ENGINE_MODELS.get(engine, [])
             if engine == "whisper":
                 recommended_model, _ = _get_recommended_whisper_model()
             elif engine == "whisper_cpp":
                 recommended_model, _ = get_recommended_whispercpp_model()
+            elif engine == "moonshine":
+                available_models = get_moonshine_supported_model_sizes(self.language)
+                if "auto" not in available_models:
+                    available_models = ["auto"] + available_models
+                recommended_model = "auto"
             else:
                 recommended_model, _ = _get_recommended_vosk_model()
 
-            if engine in ENGINE_MODELS:
-                for size in ENGINE_MODELS[engine]:
+            if available_models:
+                for size in available_models:
                     if engine == "whisper" and size in WHISPER_MODEL_INFO:
                         info = WHISPER_MODEL_INFO[size]
                         is_downloaded = _is_whisper_model_downloaded(size)
@@ -1605,7 +1628,7 @@ class SettingsDialog(Gtk.Dialog):
 
             # Determine which model to select
             saved_model = saved_model_for_engine.lower()
-            valid_models = [m.lower() for m in ENGINE_MODELS.get(engine, [])]
+            valid_models = [m.lower() for m in available_models]
 
             if saved_model in valid_models:
                 model_to_set = saved_model.capitalize()
@@ -1624,7 +1647,7 @@ class SettingsDialog(Gtk.Dialog):
                         self.model_combo.set_active(i)
                         break
                 else:
-                    if len(ENGINE_MODELS.get(engine, [])) > 0:
+                    if len(available_models) > 0:
                         self.model_combo.set_active(0)
 
             logger.info(f"Final selected model: {self.model_combo.get_active_text()}")
@@ -1647,6 +1670,8 @@ class SettingsDialog(Gtk.Dialog):
                 self.language = "en-us"
             elif engine in ["whisper", "whisper_cpp"] and not current_lang:
                 self.language = "auto"
+            elif engine == "moonshine" and not is_moonshine_language_supported(current_lang):
+                self.language = "auto"
 
         self._populate_model_options()
         self._populate_language_options()
@@ -1660,9 +1685,17 @@ class SettingsDialog(Gtk.Dialog):
         sr_config = self.config_manager.get_settings().get("speech_recognition", {})
         voice_commands_enabled = sr_config.get("voice_commands_enabled")
 
+        engine_text = self.engine_combo.get_active_text()
+        engine = engine_text.lower() if engine_text else sr_config.get("engine", "whisper_cpp")
+
+        if engine == "moonshine":
+            self.voice_commands_switch.set_sensitive(False)
+            self.voice_commands_switch.set_active(False)
+            return
+
+        self.voice_commands_switch.set_sensitive(True)
+
         if voice_commands_enabled is None:
-            engine_text = self.engine_combo.get_active_text()
-            engine = engine_text.lower() if engine_text else sr_config.get("engine", "whisper_cpp")
             auto_enabled = engine == "vosk"
             self.voice_commands_switch.set_active(auto_enabled)
 
@@ -1721,6 +1754,11 @@ class SettingsDialog(Gtk.Dialog):
                 # Both Whisper and whisper.cpp support auto-detect
                 if lang_code == "auto":
                     display_text += " ⚠"
+            elif engine == "moonshine":
+                if lang_code != "auto" and not is_moonshine_language_supported(lang_code):
+                    continue
+                if lang_code == "auto":
+                    display_text += " (English fallback)"
             else:
                 continue
 
@@ -1805,6 +1843,24 @@ class SettingsDialog(Gtk.Dialog):
             is_downloaded = _is_vosk_model_downloaded(model_name, self.language)
             recommended, reason = _get_recommended_vosk_model()
             extra_info = f"Size: {_format_size(info['size_mb'])}"
+        elif engine == "moonshine":
+            supported = get_moonshine_supported_model_sizes(self.language)
+            info = {
+                "desc": "Moonshine ONNX backend",
+                "size_mb": 0,
+                "params": "Auto-selected by moonshine_voice" if model_name == "auto" else model_name,
+            }
+            is_downloaded = is_moonshine_available()
+            recommended = "auto"
+            reason = "Moonshine chooses the best available model for the selected language"
+            extra_info = (
+                "Backend: moonshine_voice"
+                if model_name == "auto"
+                else f"Model selection: {model_name}"
+            )
+            if model_name != "auto" and model_name not in supported:
+                self.model_info_card.hide()
+                return
         else:
             self.model_info_card.hide()
             return
@@ -1950,13 +2006,18 @@ class SettingsDialog(Gtk.Dialog):
         vad = int(self.vad_spin.get_value())
         silence = self.silence_spin.get_value()
 
-        return {
+        settings = {
             "engine": engine,
             "model_size": model_size,
             "language": language,
             "vad_sensitivity": vad,
             "silence_timeout": silence,
         }
+
+        if engine == "moonshine":
+            settings["voice_commands_enabled"] = False
+
+        return settings
 
     def _on_test_clicked(self, widget):
         """Handle click on the test button."""

--- a/src/vocalinux/ui/settings_dialog.py
+++ b/src/vocalinux/ui/settings_dialog.py
@@ -1615,9 +1615,18 @@ class SettingsDialog(Gtk.Dialog):
                         is_downloaded = False
                         info = {"size_mb": 0}
 
-                    status = "✓" if is_downloaded else "↓"
                     star = " ★" if size == recommended_model else ""
-                    display_text = f"{size.capitalize()} ({_format_size(info.get('size_mb', 0))}) {status}{star}"
+                    if engine == "moonshine":
+                        if size == "auto":
+                            display_text = f"{size.capitalize()} (managed){star}"
+                        else:
+                            display_text = f"{size.capitalize()}{star}"
+                    else:
+                        status = "✓" if is_downloaded else "↓"
+                        display_text = (
+                            f"{size.capitalize()} ({_format_size(info.get('size_mb', 0))}) "
+                            f"{status}{star}"
+                        )
 
                     if is_downloaded:
                         downloaded_models.append(size)
@@ -1847,12 +1856,11 @@ class SettingsDialog(Gtk.Dialog):
             supported = get_moonshine_supported_model_sizes(self.language)
             info = {
                 "desc": "Moonshine ONNX backend",
-                "size_mb": 0,
                 "params": (
                     "Auto-selected by moonshine_voice" if model_name == "auto" else model_name
                 ),
             }
-            is_downloaded = is_moonshine_available()
+            package_available = is_moonshine_available()
             recommended = "auto"
             reason = "Moonshine chooses the best available model for the selected language"
             extra_info = (
@@ -1863,6 +1871,25 @@ class SettingsDialog(Gtk.Dialog):
             if model_name != "auto" and model_name not in supported:
                 self.model_info_card.hide()
                 return
+
+            self.model_info_title.set_markup(f"<b>{model_name.capitalize()}</b>: {info['desc']}")
+            if package_available:
+                status = "<span foreground='#26a269'>✓ Managed by moonshine_voice</span>"
+            else:
+                status = "<span foreground='#c01c28'>Moonshine package not installed</span>"
+            self.model_info_subtitle.set_markup(f"{extra_info} • {status}")
+
+            if model_name == recommended:
+                self.model_recommendation.set_markup(
+                    f"<span foreground='#26a269'>★ Recommended for your system ({reason})</span>"
+                )
+            else:
+                self.model_recommendation.set_markup(
+                    f"Tip: <b>{recommended.capitalize()}</b> is recommended for your system ({reason})"
+                )
+
+            self.model_info_card.show_all()
+            return
         else:
             self.model_info_card.hide()
             return

--- a/src/vocalinux/ui/settings_dialog.py
+++ b/src/vocalinux/ui/settings_dialog.py
@@ -40,8 +40,12 @@ from ..utils.whispercpp_model_info import (
     detect_compute_backend,
     get_backend_display_name,
 )
-from ..utils.whispercpp_model_info import get_recommended_model as get_recommended_whispercpp_model
-from ..utils.whispercpp_model_info import is_model_downloaded as is_whispercpp_model_downloaded
+from ..utils.whispercpp_model_info import (
+    get_recommended_model as get_recommended_whispercpp_model,
+)
+from ..utils.whispercpp_model_info import (
+    is_model_downloaded as is_whispercpp_model_downloaded,
+)
 from .keyboard_backends import (  # noqa: E402
     SHORTCUT_DISPLAY_NAMES,
     SHORTCUT_GROUPS,
@@ -51,7 +55,9 @@ from .keyboard_backends import (  # noqa: E402
 
 # Avoid circular imports for type checking
 if TYPE_CHECKING:
-    from ..speech_recognition.recognition_manager import SpeechRecognitionManager  # noqa: E402
+    from ..speech_recognition.recognition_manager import (  # noqa: E402
+        SpeechRecognitionManager,
+    )
     from .config_manager import ConfigManager  # noqa: E402
 
 logger = logging.getLogger(__name__)
@@ -101,7 +107,12 @@ def get_available_engines():
     Detect which speech recognition engines are available/installed.
     Returns a dictionary of engine_name -> availability (bool).
     """
-    engines = {"vosk": False, "whisper": False, "whisper_cpp": False, "moonshine": False}
+    engines = {
+        "vosk": False,
+        "whisper": False,
+        "whisper_cpp": False,
+        "moonshine": False,
+    }
 
     # Check VOSK
     try:
@@ -458,7 +469,9 @@ def _get_recommended_whisper_model() -> tuple:
 
                 if torch.cuda.is_available():
                     has_cuda = True
-                    cuda_memory_gb = torch.cuda.get_device_properties(0).total_memory // (1024**3)
+                    cuda_memory_gb = torch.cuda.get_device_properties(
+                        0
+                    ).total_memory // (1024**3)
         except Exception:
             pass
 
@@ -725,7 +738,9 @@ class ModelDownloadDialog(Gtk.Dialog):
                     "<span foreground='#e5a50a'>✗ Download cancelled</span>"
                 )
             else:
-                self.status_label.set_markup(f"<span foreground='#c01c28'>✗ {message}</span>")
+                self.status_label.set_markup(
+                    f"<span foreground='#c01c28'>✗ {message}</span>"
+                )
 
         # Allow closing now
         self.set_deletable(True)
@@ -755,11 +770,15 @@ class SettingsDialog(Gtk.Dialog):
         self._test_active = False
         self._test_result = ""
         self._initializing = True  # Flag to prevent auto-apply during initialization
-        self._populating_models = False  # Flag to prevent model change handler during population
+        self._populating_models = (
+            False  # Flag to prevent model change handler during population
+        )
         self._processing_language_change = (
             False  # Flag to prevent recursive language change handling
         )
-        self._applying_settings = False  # Flag to prevent recursive settings application
+        self._applying_settings = (
+            False  # Flag to prevent recursive settings application
+        )
 
         # Setup CSS styling
         _setup_css()
@@ -794,14 +813,18 @@ class SettingsDialog(Gtk.Dialog):
 
         # Create tab content boxes
         # Speech Engine tab (Engine, Model, Language)
-        self.speech_engine_tab = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=12)
+        self.speech_engine_tab = Gtk.Box(
+            orientation=Gtk.Orientation.VERTICAL, spacing=12
+        )
         self.speech_engine_tab.set_margin_top(16)
         self.speech_engine_tab.set_margin_bottom(16)
         self.speech_engine_tab.set_margin_start(16)
         self.speech_engine_tab.set_margin_end(16)
 
         # Recognition Settings tab (VAD, Silence, Test)
-        self.recognition_settings_tab = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=12)
+        self.recognition_settings_tab = Gtk.Box(
+            orientation=Gtk.Orientation.VERTICAL, spacing=12
+        )
         self.recognition_settings_tab.set_margin_top(16)
         self.recognition_settings_tab.set_margin_bottom(16)
         self.recognition_settings_tab.set_margin_start(16)
@@ -829,7 +852,9 @@ class SettingsDialog(Gtk.Dialog):
         # Add tabs to notebook (ordered by importance)
         # Speech Engine tab - most important (what model/language to use)
         speech_engine_label = Gtk.Label(label="Speech Engine")
-        speech_engine_label.set_tooltip_text("Speech recognition engine and model settings")
+        speech_engine_label.set_tooltip_text(
+            "Speech recognition engine and model settings"
+        )
         notebook.append_page(self.speech_engine_tab, speech_engine_label)
 
         # Recognition Settings tab - second most important (how to recognize)
@@ -897,7 +922,9 @@ class SettingsDialog(Gtk.Dialog):
         _prevent_scroll_on_hover(self.audio_device_combo)
         device_box.pack_start(self.audio_device_combo, True, True, 0)
 
-        refresh_btn = Gtk.Button.new_from_icon_name("view-refresh-symbolic", Gtk.IconSize.BUTTON)
+        refresh_btn = Gtk.Button.new_from_icon_name(
+            "view-refresh-symbolic", Gtk.IconSize.BUTTON
+        )
         refresh_btn.set_tooltip_text("Refresh device list")
         refresh_btn.get_style_context().add_class("flat-button")
         refresh_btn.connect("clicked", self._on_refresh_audio_devices)
@@ -964,7 +991,9 @@ class SettingsDialog(Gtk.Dialog):
         group = PreferencesGroup(title="General")
 
         self.autostart_switch = Gtk.Switch()
-        self.autostart_switch.set_tooltip_text("Start Vocalinux automatically when you log in")
+        self.autostart_switch.set_tooltip_text(
+            "Start Vocalinux automatically when you log in"
+        )
         autostart_row = PreferenceRow(
             title="Start on Login",
             subtitle="Automatically start Vocalinux when you log in",
@@ -996,8 +1025,12 @@ class SettingsDialog(Gtk.Dialog):
         self.general_tab.pack_start(group, False, False, 0)
 
         self.autostart_switch.connect("state-set", self._on_autostart_toggled)
-        self.start_minimized_switch.connect("state-set", self._on_start_minimized_toggled)
-        self.copy_to_clipboard_switch.connect("state-set", self._on_copy_to_clipboard_toggled)
+        self.start_minimized_switch.connect(
+            "state-set", self._on_start_minimized_toggled
+        )
+        self.copy_to_clipboard_switch.connect(
+            "state-set", self._on_copy_to_clipboard_toggled
+        )
 
     def _on_autostart_toggled(self, widget, state):
         """Handle toggle of the autostart switch."""
@@ -1158,7 +1191,9 @@ class SettingsDialog(Gtk.Dialog):
         # Silence Timeout
         self.silence_spin = Gtk.SpinButton.new_with_range(0.5, 5.0, 0.1)
         self.silence_spin.set_digits(1)
-        self.silence_spin.set_tooltip_text("Wait time after silence before processing speech")
+        self.silence_spin.set_tooltip_text(
+            "Wait time after silence before processing speech"
+        )
         _prevent_scroll_on_hover(self.silence_spin)
         silence_row = PreferenceRow(
             title="Silence Timeout",
@@ -1221,7 +1256,9 @@ class SettingsDialog(Gtk.Dialog):
         # Shortcut selection combo
         self.shortcut_combo = Gtk.ComboBoxText()
         self.shortcut_combo.set_size_request(200, -1)
-        self.shortcut_combo.set_tooltip_text("Select the keyboard shortcut for voice typing")
+        self.shortcut_combo.set_tooltip_text(
+            "Select the keyboard shortcut for voice typing"
+        )
         _prevent_scroll_on_hover(self.shortcut_combo)
 
         # Populate shortcut options grouped by side
@@ -1256,7 +1293,9 @@ class SettingsDialog(Gtk.Dialog):
         info_box.set_margin_end(4)
         info_box.set_margin_top(4)
 
-        info_icon = Gtk.Image.new_from_icon_name("dialog-information-symbolic", Gtk.IconSize.MENU)
+        info_icon = Gtk.Image.new_from_icon_name(
+            "dialog-information-symbolic", Gtk.IconSize.MENU
+        )
         info_box.pack_start(info_icon, False, False, 0)
 
         self.shortcut_info_label = Gtk.Label(
@@ -1279,7 +1318,9 @@ class SettingsDialog(Gtk.Dialog):
     def _update_shortcut_ui_for_mode(self, mode: str):
         """Update the shortcut UI based on the selected mode."""
         if mode == "toggle":
-            self.shortcut_row.set_subtitle("Double-tap this key to start/stop voice typing")
+            self.shortcut_row.set_subtitle(
+                "Double-tap this key to start/stop voice typing"
+            )
             self.shortcut_info_label.set_text(
                 "In Toggle mode: Double-tap the key to start voice typing, double-tap again to stop."
             )
@@ -1340,7 +1381,9 @@ class SettingsDialog(Gtk.Dialog):
         # Ignore separator entries (used for grouped display)
         if shortcut_id.startswith("__separator_"):
             # Revert to the previously saved shortcut
-            current = self.config_manager.get_str("shortcuts", "toggle_recognition", "ctrl+ctrl")
+            current = self.config_manager.get_str(
+                "shortcuts", "toggle_recognition", "ctrl+ctrl"
+            )
             self.shortcut_combo.set_active_id(current)
             return
 
@@ -1451,7 +1494,9 @@ class SettingsDialog(Gtk.Dialog):
         self.progress_info_label = Gtk.Label(label="", use_markup=True, xalign=0)
         self.progress_info_label.set_margin_start(16)
         self.progress_info_label.set_margin_bottom(8)
-        self.recognition_settings_tab.pack_start(self.progress_info_label, False, False, 0)
+        self.recognition_settings_tab.pack_start(
+            self.progress_info_label, False, False, 0
+        )
 
     def _load_and_apply_settings(self):
         """Load current settings and populate the UI."""
@@ -1468,7 +1513,9 @@ class SettingsDialog(Gtk.Dialog):
 
         general_settings = self.config_manager.get_settings().get("general", {})
         ui_settings = self.config_manager.get_settings().get("ui", {})
-        text_injection_settings = self.config_manager.get_settings().get("text_injection", {})
+        text_injection_settings = self.config_manager.get_settings().get(
+            "text_injection", {}
+        )
 
         autostart_enabled = general_settings.get("autostart", False)
         start_minimized = ui_settings.get("start_minimized", False)
@@ -1477,7 +1524,9 @@ class SettingsDialog(Gtk.Dialog):
         self.autostart_switch.set_active(autostart_enabled)
         self.start_minimized_switch.set_active(start_minimized)
         self.copy_to_clipboard_switch.set_active(copy_to_clipboard)
-        self.sound_effects_switch.set_active(self.config_manager.is_sound_effects_enabled())
+        self.sound_effects_switch.set_active(
+            self.config_manager.is_sound_effects_enabled()
+        )
 
         # Populate engine combo with only available engines
         available_engines = get_available_engines()
@@ -1496,7 +1545,9 @@ class SettingsDialog(Gtk.Dialog):
                 capitalized_engine = engine.capitalize()
                 self.engine_combo.append(capitalized_engine, capitalized_engine)
         else:
-            logger.info(f"Populated {available_count} available engines: {available_engines}")
+            logger.info(
+                f"Populated {available_count} available engines: {available_engines}"
+            )
 
         # Set engine active - check if current engine is available
         if not available_engines.get(self.current_engine, False):
@@ -1531,7 +1582,9 @@ class SettingsDialog(Gtk.Dialog):
         self._populate_language_options()
         if self.language:
             if not self.language_combo.set_active_id(self.language):
-                logger.warning(f"Language '{self.language}' not found in options, using auto")
+                logger.warning(
+                    f"Language '{self.language}' not found in options, using auto"
+                )
                 self.language_combo.set_active_id("auto")
                 self.language = "auto"
 
@@ -1582,7 +1635,9 @@ class SettingsDialog(Gtk.Dialog):
             engine = engine_text.lower()
             logger.info(f"Populating model options for engine: {engine}")
 
-            saved_model_for_engine = self.config_manager.get_model_size_for_engine(engine)
+            saved_model_for_engine = self.config_manager.get_model_size_for_engine(
+                engine
+            )
             logger.info(f"Saved model for {engine}: {saved_model_for_engine}")
 
             downloaded_models = []
@@ -1644,7 +1699,9 @@ class SettingsDialog(Gtk.Dialog):
             elif downloaded_models:
                 model_to_set = downloaded_models[0].capitalize()
             else:
-                model_to_set = smallest_model.capitalize() if smallest_model else "Small"
+                model_to_set = (
+                    smallest_model.capitalize() if smallest_model else "Small"
+                )
 
             logger.info(f"Setting active model to: {model_to_set}")
 
@@ -1674,12 +1731,15 @@ class SettingsDialog(Gtk.Dialog):
         current_lang = self.language_combo.get_active_id()
         if current_lang:
             if engine == "vosk" and (
-                current_lang == "auto" or not SUPPORTED_LANGUAGES.get(current_lang, {}).get("vosk")
+                current_lang == "auto"
+                or not SUPPORTED_LANGUAGES.get(current_lang, {}).get("vosk")
             ):
                 self.language = "en-us"
             elif engine in ["whisper", "whisper_cpp"] and not current_lang:
                 self.language = "auto"
-            elif engine == "moonshine" and not is_moonshine_language_supported(current_lang):
+            elif engine == "moonshine" and not is_moonshine_language_supported(
+                current_lang
+            ):
                 self.language = "auto"
 
         self._populate_model_options()
@@ -1695,7 +1755,11 @@ class SettingsDialog(Gtk.Dialog):
         voice_commands_enabled = sr_config.get("voice_commands_enabled")
 
         engine_text = self.engine_combo.get_active_text()
-        engine = engine_text.lower() if engine_text else sr_config.get("engine", "whisper_cpp")
+        engine = (
+            engine_text.lower()
+            if engine_text
+            else sr_config.get("engine", "whisper_cpp")
+        )
 
         if engine == "moonshine":
             self.voice_commands_switch.set_sensitive(False)
@@ -1735,7 +1799,9 @@ class SettingsDialog(Gtk.Dialog):
         self.config_manager.set("speech_recognition", "voice_commands_enabled", enabled)
         self.config_manager.save_settings()
         try:
-            self.speech_engine.reconfigure(voice_commands_enabled=enabled, force_download=False)
+            self.speech_engine.reconfigure(
+                voice_commands_enabled=enabled, force_download=False
+            )
         except Exception as e:
             logger.warning(f"Failed to apply voice commands toggle immediately: {e}")
         logger.info(f"Voice commands {'enabled' if enabled else 'disabled'}")
@@ -1764,7 +1830,9 @@ class SettingsDialog(Gtk.Dialog):
                 if lang_code == "auto":
                     display_text += " ⚠"
             elif engine == "moonshine":
-                if lang_code != "auto" and not is_moonshine_language_supported(lang_code):
+                if lang_code != "auto" and not is_moonshine_language_supported(
+                    lang_code
+                ):
                     continue
                 if lang_code == "auto":
                     display_text += " (English fallback)"
@@ -1841,9 +1909,7 @@ class SettingsDialog(Gtk.Dialog):
             is_downloaded = is_whispercpp_model_downloaded(model_name)
             recommended, reason = get_recommended_whispercpp_model()
             backend, backend_info = detect_compute_backend()
-            extra_info = (
-                f"Parameters: {info['params']} • Backend: {get_backend_display_name(backend)}"
-            )
+            extra_info = f"Parameters: {info['params']} • Backend: {get_backend_display_name(backend)}"
         elif engine == "vosk":
             if model_name not in VOSK_MODEL_INFO:
                 self.model_info_card.hide()
@@ -1857,12 +1923,16 @@ class SettingsDialog(Gtk.Dialog):
             info = {
                 "desc": "Moonshine ONNX backend",
                 "params": (
-                    "Auto-selected by moonshine_voice" if model_name == "auto" else model_name
+                    "Auto-selected by moonshine_voice"
+                    if model_name == "auto"
+                    else model_name
                 ),
             }
             package_available = is_moonshine_available()
             recommended = "auto"
-            reason = "Moonshine chooses the best available model for the selected language"
+            reason = (
+                "Moonshine chooses the best available model for the selected language"
+            )
             extra_info = (
                 "Backend: moonshine_voice"
                 if model_name == "auto"
@@ -1872,11 +1942,17 @@ class SettingsDialog(Gtk.Dialog):
                 self.model_info_card.hide()
                 return
 
-            self.model_info_title.set_markup(f"<b>{model_name.capitalize()}</b>: {info['desc']}")
+            self.model_info_title.set_markup(
+                f"<b>{model_name.capitalize()}</b>: {info['desc']}"
+            )
             if package_available:
-                status = "<span foreground='#26a269'>✓ Managed by moonshine_voice</span>"
+                status = (
+                    "<span foreground='#26a269'>✓ Managed by moonshine_voice</span>"
+                )
             else:
-                status = "<span foreground='#c01c28'>Moonshine package not installed</span>"
+                status = (
+                    "<span foreground='#c01c28'>Moonshine package not installed</span>"
+                )
             self.model_info_subtitle.set_markup(f"{extra_info} • {status}")
 
             if model_name == recommended:
@@ -1895,7 +1971,9 @@ class SettingsDialog(Gtk.Dialog):
             return
 
         # Update title
-        self.model_info_title.set_markup(f"<b>{model_name.capitalize()}</b>: {info['desc']}")
+        self.model_info_title.set_markup(
+            f"<b>{model_name.capitalize()}</b>: {info['desc']}"
+        )
 
         # Update subtitle with status
         if is_downloaded:
@@ -1942,15 +2020,21 @@ class SettingsDialog(Gtk.Dialog):
             if engine == "whisper" and not _is_whisper_model_downloaded(model_name):
                 needs_download = True
                 model_info = WHISPER_MODEL_INFO.get(model_name, {"size_mb": 500})
-            elif engine == "whisper_cpp" and not is_whispercpp_model_downloaded(model_name):
+            elif engine == "whisper_cpp" and not is_whispercpp_model_downloaded(
+                model_name
+            ):
                 needs_download = True
                 model_info = WHISPERCPP_MODEL_INFO.get(model_name, {"size_mb": 39})
-            elif engine == "vosk" and not _is_vosk_model_downloaded(model_name, self.language):
+            elif engine == "vosk" and not _is_vosk_model_downloaded(
+                model_name, self.language
+            ):
                 needs_download = True
                 model_info = VOSK_MODEL_INFO.get(model_name, {"size_mb": 50})
 
             if needs_download:
-                logger.info(f"Model {model_name} needs download, showing progress dialog")
+                logger.info(
+                    f"Model {model_name} needs download, showing progress dialog"
+                )
                 download_dialog = ModelDownloadDialog(
                     self,
                     model_name,
@@ -1960,11 +2044,15 @@ class SettingsDialog(Gtk.Dialog):
                 )
 
                 def progress_callback(fraction, speed, status):
-                    GLib.idle_add(download_dialog.update_progress, fraction, speed, status)
+                    GLib.idle_add(
+                        download_dialog.update_progress, fraction, speed, status
+                    )
 
                 def download_and_apply():
                     try:
-                        self.speech_engine.set_download_progress_callback(progress_callback)
+                        self.speech_engine.set_download_progress_callback(
+                            progress_callback
+                        )
 
                         def check_cancelled():
                             if download_dialog.cancelled:
@@ -1989,7 +2077,10 @@ class SettingsDialog(Gtk.Dialog):
                                 False,
                                 "Download cancelled",
                             )
-                        elif engine == "whisper" and "no module named" in error_msg.lower():
+                        elif (
+                            engine == "whisper"
+                            and "no module named" in error_msg.lower()
+                        ):
                             GLib.idle_add(
                                 download_dialog.set_complete,
                                 False,
@@ -1997,7 +2088,9 @@ class SettingsDialog(Gtk.Dialog):
                             )
                             GLib.idle_add(self._show_whisper_install_dialog)
                         else:
-                            GLib.idle_add(download_dialog.set_complete, False, error_msg[:100])
+                            GLib.idle_add(
+                                download_dialog.set_complete, False, error_msg[:100]
+                            )
 
                 threading.Thread(target=download_and_apply, daemon=True).start()
                 download_dialog.run()
@@ -2054,18 +2147,22 @@ class SettingsDialog(Gtk.Dialog):
             logger.warning("Test already in progress.")
             return
 
-        current_config = self.config_manager.get_settings().get("speech_recognition", {})
+        current_config = self.config_manager.get_settings().get(
+            "speech_recognition", {}
+        )
         selected_settings = self.get_selected_settings()
 
         settings_differ = False
-        if current_config.get("engine") != selected_settings.get("engine") or current_config.get(
-            "model_size"
-        ) != selected_settings.get("model_size"):
+        if current_config.get("engine") != selected_settings.get(
+            "engine"
+        ) or current_config.get("model_size") != selected_settings.get("model_size"):
             settings_differ = True
         elif selected_settings.get("engine") == "vosk":
             if current_config.get("vad_sensitivity") != selected_settings.get(
                 "vad_sensitivity"
-            ) or current_config.get("silence_timeout") != selected_settings.get("silence_timeout"):
+            ) or current_config.get("silence_timeout") != selected_settings.get(
+                "silence_timeout"
+            ):
                 settings_differ = True
 
         if settings_differ:
@@ -2082,7 +2179,9 @@ class SettingsDialog(Gtk.Dialog):
         self._test_result = ""
 
         self.connect_to_recognition_manager()
-        self.update_recognition_progress("Listening", info="Starting recognition test...")
+        self.update_recognition_progress(
+            "Listening", info="Starting recognition test..."
+        )
 
         self._saved_text_callbacks = self.speech_engine.get_text_callbacks()
         self.speech_engine.set_text_callbacks([self._test_text_callback])
@@ -2197,7 +2296,9 @@ For now, the engine has been reverted to VOSK."""
         if engine == "whisper" and not _is_whisper_model_downloaded(model_name):
             needs_download = True
             model_info = WHISPER_MODEL_INFO.get(model_name, {"size_mb": 500})
-        elif engine == "vosk" and not _is_vosk_model_downloaded(model_name, self.language):
+        elif engine == "vosk" and not _is_vosk_model_downloaded(
+            model_name, self.language
+        ):
             needs_download = True
             model_info = VOSK_MODEL_INFO.get(model_name, {"size_mb": 50})
 
@@ -2234,12 +2335,18 @@ For now, the engine has been reverted to VOSK."""
                 except Exception as e:
                     error_msg = str(e)
                     if "cancelled" in error_msg.lower():
-                        GLib.idle_add(download_dialog.set_complete, False, "Download cancelled")
+                        GLib.idle_add(
+                            download_dialog.set_complete, False, "Download cancelled"
+                        )
                     elif engine == "whisper" and "no module named" in error_msg.lower():
-                        GLib.idle_add(download_dialog.set_complete, False, "Whisper not installed")
+                        GLib.idle_add(
+                            download_dialog.set_complete, False, "Whisper not installed"
+                        )
                         GLib.idle_add(self._show_whisper_install_dialog)
                     else:
-                        GLib.idle_add(download_dialog.set_complete, False, error_msg[:100])
+                        GLib.idle_add(
+                            download_dialog.set_complete, False, error_msg[:100]
+                        )
 
             threading.Thread(target=download_and_apply, daemon=True).start()
             download_dialog.run()
@@ -2299,7 +2406,9 @@ For now, the engine has been reverted to VOSK."""
                 label += " (default)"
             self.audio_device_combo.append(str(device_index), label)
 
-        saved_device = self.config_manager.get_optional_int("audio", "device_index", None)
+        saved_device = self.config_manager.get_optional_int(
+            "audio", "device_index", None
+        )
 
         if saved_device is None:
             self.audio_device_combo.set_active_id("-1")
@@ -2348,7 +2457,9 @@ For now, the engine has been reverted to VOSK."""
         """Handle test audio button click."""
         self.test_audio_btn.set_sensitive(False)
         self.test_audio_btn.set_label("Testing...")
-        self.audio_test_status.set_markup("<i>Recording... speak into your microphone</i>")
+        self.audio_test_status.set_markup(
+            "<i>Recording... speak into your microphone</i>"
+        )
         self.audio_level_bar.set_value(0)
 
         device_id = self.audio_device_combo.get_active_id()
@@ -2400,7 +2511,9 @@ For now, the engine has been reverted to VOSK."""
 
         return False
 
-    def update_recognition_progress(self, state: str, audio_level: float = 0.0, info: str = ""):
+    def update_recognition_progress(
+        self, state: str, audio_level: float = 0.0, info: str = ""
+    ):
         """Update the recognition progress feedback UI."""
         self.recognition_status_label.set_text(state)
 
@@ -2415,21 +2528,31 @@ For now, the engine has been reverted to VOSK."""
 
         if state == "Listening":
             self.recognition_indicator.set_opacity(1.0)
-            self.recognition_status_label.get_style_context().add_class("recognition-listening")
-            self.progress_info_label.set_markup("<span foreground='#26a269'>● Listening...</span>")
+            self.recognition_status_label.get_style_context().add_class(
+                "recognition-listening"
+            )
+            self.progress_info_label.set_markup(
+                "<span foreground='#26a269'>● Listening...</span>"
+            )
         elif state == "Processing":
             self.recognition_indicator.set_opacity(1.0)
-            self.recognition_status_label.get_style_context().add_class("recognition-processing")
+            self.recognition_status_label.get_style_context().add_class(
+                "recognition-processing"
+            )
             self.progress_info_label.set_markup(
                 "<span foreground='#e5a50a'>● Processing speech...</span>"
             )
         elif state == "Idle":
             self.recognition_indicator.set_opacity(0.3)
-            self.recognition_status_label.get_style_context().add_class("recognition-idle")
+            self.recognition_status_label.get_style_context().add_class(
+                "recognition-idle"
+            )
             self.progress_info_label.set_text("")
         elif state == "Error":
             self.recognition_indicator.set_opacity(0.3)
-            self.recognition_status_label.get_style_context().add_class("recognition-error")
+            self.recognition_status_label.get_style_context().add_class(
+                "recognition-error"
+            )
             self.progress_info_label.set_markup(
                 f"<span foreground='#c01c28'>✗ Error: {info}</span>"
             )
@@ -2448,8 +2571,12 @@ For now, the engine has been reverted to VOSK."""
         """Connect to speech recognition manager for progress updates."""
         if hasattr(self, "speech_engine") and self.speech_engine:
             if not hasattr(self, "_callbacks_registered"):
-                self.speech_engine.state_callbacks.append(self._on_recognition_state_changed)
-                self.speech_engine.register_audio_level_callback(self._on_audio_level_changed)
+                self.speech_engine.state_callbacks.append(
+                    self._on_recognition_state_changed
+                )
+                self.speech_engine.register_audio_level_callback(
+                    self._on_audio_level_changed
+                )
                 self._callbacks_registered = True
                 self.connect("destroy", self._on_dialog_destroy)
 
@@ -2457,8 +2584,12 @@ For now, the engine has been reverted to VOSK."""
         """Clean up callbacks when dialog is destroyed."""
         if hasattr(self, "speech_engine") and self.speech_engine:
             if self._on_recognition_state_changed in self.speech_engine.state_callbacks:
-                self.speech_engine.state_callbacks.remove(self._on_recognition_state_changed)
-            self.speech_engine.unregister_audio_level_callback(self._on_audio_level_changed)
+                self.speech_engine.state_callbacks.remove(
+                    self._on_recognition_state_changed
+                )
+            self.speech_engine.unregister_audio_level_callback(
+                self._on_audio_level_changed
+            )
 
     def _on_recognition_state_changed(self, state):
         """Handle recognition state changes."""

--- a/src/vocalinux/utils/moonshine_model_info.py
+++ b/src/vocalinux/utils/moonshine_model_info.py
@@ -1,0 +1,121 @@
+"""Moonshine language and model compatibility helpers for Vocalinux."""
+
+from __future__ import annotations
+
+from typing import Optional
+
+MOONSHINE_LANGUAGE_MAP = {
+    "auto": "en",
+    "en": "en",
+    "en-us": "en",
+    "en-in": "en",
+    "es": "es",
+    "zh": "zh",
+    "ja": "ja",
+    "ko": "ko",
+    "ar": "ar",
+}
+
+_LANGUAGE_MODEL_ARCHES = {
+    "en": {
+        "tiny": "TINY_STREAMING",
+        "base": "BASE",
+        "small": "SMALL_STREAMING",
+        "medium": "MEDIUM_STREAMING",
+    },
+    "es": {
+        "base": "BASE",
+    },
+    "zh": {
+        "base": "BASE",
+    },
+    "ja": {
+        "tiny": "TINY",
+        "base": "BASE",
+    },
+    "ko": {
+        "tiny": "TINY",
+    },
+    "ar": {
+        "base": "BASE",
+    },
+}
+
+_DEFAULT_MODEL_SIZE = {
+    "en": "medium",
+    "es": "base",
+    "zh": "base",
+    "ja": "base",
+    "ko": "tiny",
+    "ar": "base",
+}
+
+
+def is_moonshine_available() -> bool:
+    """Return True when moonshine_voice is importable."""
+    try:
+        import moonshine_voice  # noqa: F401
+    except ImportError:
+        return False
+    return True
+
+
+def resolve_moonshine_language(language: Optional[str]) -> tuple[str, bool]:
+    """Map Vocalinux language values to Moonshine-compatible language codes."""
+    normalized = (language or "auto").strip().lower()
+    resolved = MOONSHINE_LANGUAGE_MAP.get(normalized)
+    if resolved is None:
+        return "en", True
+    return resolved, normalized == "auto"
+
+
+def is_moonshine_language_supported(language: Optional[str]) -> bool:
+    """Return True if the provided Vocalinux language can be used without fallback."""
+    normalized = (language or "auto").strip().lower()
+    return normalized in MOONSHINE_LANGUAGE_MAP
+
+
+def get_moonshine_supported_model_sizes(language: Optional[str]) -> list[str]:
+    """Return valid Moonshine model-size labels for the resolved language."""
+    resolved_language, _ = resolve_moonshine_language(language)
+    arches = _LANGUAGE_MODEL_ARCHES.get(resolved_language, _LANGUAGE_MODEL_ARCHES["en"])
+    return list(arches.keys())
+
+
+def get_moonshine_default_model_size(language: Optional[str]) -> str:
+    """Return the safest default model-size label for the resolved language."""
+    resolved_language, _ = resolve_moonshine_language(language)
+    return _DEFAULT_MODEL_SIZE.get(resolved_language, "medium")
+
+
+def resolve_moonshine_model_arch_name(
+    model_size: Optional[str], language: Optional[str]
+) -> tuple[Optional[str], bool]:
+    """Resolve a Vocalinux model-size label to a Moonshine ModelArch enum name.
+
+    Returns:
+        (arch_name, used_fallback)
+
+        arch_name is None when Moonshine should choose the default arch itself.
+    """
+    resolved_language, _ = resolve_moonshine_language(language)
+    valid_arches = _LANGUAGE_MODEL_ARCHES.get(
+        resolved_language, _LANGUAGE_MODEL_ARCHES["en"]
+    )
+
+    normalized = (model_size or "auto").strip().lower()
+    if normalized in ("", "auto"):
+        return None, False
+
+    if normalized in valid_arches:
+        return valid_arches[normalized], False
+
+    fallback_aliases = {
+        "large": "medium",
+    }
+    aliased = fallback_aliases.get(normalized)
+    if aliased and aliased in valid_arches:
+        return valid_arches[aliased], True
+
+    default_size = get_moonshine_default_model_size(language)
+    return valid_arches[default_size], True

--- a/src/vocalinux/utils/moonshine_model_info.py
+++ b/src/vocalinux/utils/moonshine_model_info.py
@@ -99,9 +99,7 @@ def resolve_moonshine_model_arch_name(
         arch_name is None when Moonshine should choose the default arch itself.
     """
     resolved_language, _ = resolve_moonshine_language(language)
-    valid_arches = _LANGUAGE_MODEL_ARCHES.get(
-        resolved_language, _LANGUAGE_MODEL_ARCHES["en"]
-    )
+    valid_arches = _LANGUAGE_MODEL_ARCHES.get(resolved_language, _LANGUAGE_MODEL_ARCHES["en"])
 
     normalized = (model_size or "auto").strip().lower()
     if normalized in ("", "auto"):

--- a/src/vocalinux/utils/moonshine_model_info.py
+++ b/src/vocalinux/utils/moonshine_model_info.py
@@ -99,7 +99,9 @@ def resolve_moonshine_model_arch_name(
         arch_name is None when Moonshine should choose the default arch itself.
     """
     resolved_language, _ = resolve_moonshine_language(language)
-    valid_arches = _LANGUAGE_MODEL_ARCHES.get(resolved_language, _LANGUAGE_MODEL_ARCHES["en"])
+    valid_arches = _LANGUAGE_MODEL_ARCHES.get(
+        resolved_language, _LANGUAGE_MODEL_ARCHES["en"]
+    )
 
     normalized = (model_size or "auto").strip().lower()
     if normalized in ("", "auto"):

--- a/tests/test_config_manager.py
+++ b/tests/test_config_manager.py
@@ -84,19 +84,13 @@ class TestConfigManager(unittest.TestCase):
         config_manager = ConfigManager()
 
         # Verify it merged with defaults correctly
-        self.assertEqual(
-            config_manager.config["speech_recognition"]["engine"], "whisper"
-        )
-        self.assertEqual(
-            config_manager.config["speech_recognition"]["model_size"], "large"
-        )
+        self.assertEqual(config_manager.config["speech_recognition"]["engine"], "whisper")
+        self.assertEqual(config_manager.config["speech_recognition"]["model_size"], "large")
         self.assertEqual(
             config_manager.config["speech_recognition"]["vad_sensitivity"], 3
         )  # From defaults
         self.assertEqual(config_manager.config["ui"]["start_minimized"], True)
-        self.assertEqual(
-            config_manager.config["ui"]["show_notifications"], True
-        )  # From defaults
+        self.assertEqual(config_manager.config["ui"]["show_notifications"], True)  # From defaults
 
     def test_load_config_file_error(self):
         """Test handling of errors when loading config file."""
@@ -231,21 +225,15 @@ class TestConfigManager(unittest.TestCase):
 
         # Set model size for vosk
         config_manager.set_model_size_for_engine("vosk", "large")
-        self.assertEqual(
-            config_manager.config["speech_recognition"]["vosk_model_size"], "large"
-        )
-        self.assertEqual(
-            config_manager.config["speech_recognition"]["model_size"], "large"
-        )
+        self.assertEqual(config_manager.config["speech_recognition"]["vosk_model_size"], "large")
+        self.assertEqual(config_manager.config["speech_recognition"]["model_size"], "large")
 
         # Set model size for whisper
         config_manager.set_model_size_for_engine("whisper", "medium")
         self.assertEqual(
             config_manager.config["speech_recognition"]["whisper_model_size"], "medium"
         )
-        self.assertEqual(
-            config_manager.config["speech_recognition"]["model_size"], "medium"
-        )
+        self.assertEqual(config_manager.config["speech_recognition"]["model_size"], "medium")
 
     def test_migrate_old_config(self):
         """Test migration of old config format without per-engine model sizes."""
@@ -266,39 +254,27 @@ class TestConfigManager(unittest.TestCase):
         config_manager = ConfigManager()
 
         # Verify migration added per-engine model sizes
-        self.assertEqual(
-            config_manager.config["speech_recognition"]["vosk_model_size"], "medium"
-        )
-        self.assertEqual(
-            config_manager.config["speech_recognition"]["whisper_model_size"], "tiny"
-        )
+        self.assertEqual(config_manager.config["speech_recognition"]["vosk_model_size"], "medium")
+        self.assertEqual(config_manager.config["speech_recognition"]["whisper_model_size"], "tiny")
 
     def test_update_speech_recognition_settings_per_engine(self):
         """Test that update_speech_recognition_settings saves per-engine model sizes."""
         config_manager = ConfigManager()
 
         # Update settings for vosk
-        config_manager.update_speech_recognition_settings(
-            {"engine": "vosk", "model_size": "large"}
-        )
+        config_manager.update_speech_recognition_settings({"engine": "vosk", "model_size": "large"})
 
-        self.assertEqual(
-            config_manager.config["speech_recognition"]["vosk_model_size"], "large"
-        )
+        self.assertEqual(config_manager.config["speech_recognition"]["vosk_model_size"], "large")
 
         # Update settings for whisper
         config_manager.update_speech_recognition_settings(
             {"engine": "whisper", "model_size": "small"}
         )
 
-        self.assertEqual(
-            config_manager.config["speech_recognition"]["whisper_model_size"], "small"
-        )
+        self.assertEqual(config_manager.config["speech_recognition"]["whisper_model_size"], "small")
 
         # Verify the vosk setting wasn't changed
-        self.assertEqual(
-            config_manager.config["speech_recognition"]["vosk_model_size"], "large"
-        )
+        self.assertEqual(config_manager.config["speech_recognition"]["vosk_model_size"], "large")
 
     def test_save_settings(self):
         """Test the save_settings method (alias for save_config)."""
@@ -362,9 +338,7 @@ class TestConfigManager(unittest.TestCase):
 
         # Verify section was created and value was set
         self.assertIn("speech_recognition", config_manager.config)
-        self.assertEqual(
-            config_manager.config["speech_recognition"]["vosk_model_size"], "large"
-        )
+        self.assertEqual(config_manager.config["speech_recognition"]["vosk_model_size"], "large")
 
     def test_get_model_size_for_engine_fallback_to_generic(self):
         """Test fallback to generic model_size when no engine-specific key exists."""
@@ -404,12 +378,8 @@ class TestConfigManager(unittest.TestCase):
 
         # Verify section was created
         self.assertIn("speech_recognition", config_manager.config)
-        self.assertEqual(
-            config_manager.config["speech_recognition"]["engine"], "whisper"
-        )
-        self.assertEqual(
-            config_manager.config["speech_recognition"]["vad_sensitivity"], 5
-        )
+        self.assertEqual(config_manager.config["speech_recognition"]["engine"], "whisper")
+        self.assertEqual(config_manager.config["speech_recognition"]["vad_sensitivity"], 5)
 
     def test_migrate_super_shortcut_to_ctrl(self):
         test_config = {
@@ -423,9 +393,7 @@ class TestConfigManager(unittest.TestCase):
             json.dump(test_config, f)
 
         config_manager = ConfigManager()
-        self.assertEqual(
-            config_manager.config["shortcuts"]["toggle_recognition"], "ctrl+ctrl"
-        )
+        self.assertEqual(config_manager.config["shortcuts"]["toggle_recognition"], "ctrl+ctrl")
 
     def test_non_super_shortcut_unchanged(self):
         test_config = {
@@ -439,9 +407,7 @@ class TestConfigManager(unittest.TestCase):
             json.dump(test_config, f)
 
         config_manager = ConfigManager()
-        self.assertEqual(
-            config_manager.config["shortcuts"]["toggle_recognition"], "alt+alt"
-        )
+        self.assertEqual(config_manager.config["shortcuts"]["toggle_recognition"], "alt+alt")
         self.assertEqual(config_manager.config["shortcuts"]["mode"], "push_to_talk")
 
     def test_sound_effects_enabled_by_default(self):

--- a/tests/test_config_manager.py
+++ b/tests/test_config_manager.py
@@ -155,7 +155,9 @@ class TestConfigManager(unittest.TestCase):
         # Also test the get method works - it should return a valid engine value
         config_manager = ConfigManager()
         value = config_manager.get("speech_recognition", "engine")
-        self.assertIn(value, ["vosk", "whisper", "whisper_cpp", "moonshine"])  # Should be one of valid engines
+        self.assertIn(
+            value, ["vosk", "whisper", "whisper_cpp", "moonshine"]
+        )  # Should be one of valid engines
 
     def test_get_nonexistent_value(self):
         """Test getting a nonexistent configuration value."""

--- a/tests/test_config_manager.py
+++ b/tests/test_config_manager.py
@@ -155,7 +155,7 @@ class TestConfigManager(unittest.TestCase):
         # Also test the get method works - it should return a valid engine value
         config_manager = ConfigManager()
         value = config_manager.get("speech_recognition", "engine")
-        self.assertIn(value, ["vosk", "whisper", "whisper_cpp"])  # Should be one of valid engines
+        self.assertIn(value, ["vosk", "whisper", "whisper_cpp", "moonshine"])  # Should be one of valid engines
 
     def test_get_nonexistent_value(self):
         """Test getting a nonexistent configuration value."""

--- a/tests/test_config_manager.py
+++ b/tests/test_config_manager.py
@@ -84,13 +84,19 @@ class TestConfigManager(unittest.TestCase):
         config_manager = ConfigManager()
 
         # Verify it merged with defaults correctly
-        self.assertEqual(config_manager.config["speech_recognition"]["engine"], "whisper")
-        self.assertEqual(config_manager.config["speech_recognition"]["model_size"], "large")
+        self.assertEqual(
+            config_manager.config["speech_recognition"]["engine"], "whisper"
+        )
+        self.assertEqual(
+            config_manager.config["speech_recognition"]["model_size"], "large"
+        )
         self.assertEqual(
             config_manager.config["speech_recognition"]["vad_sensitivity"], 3
         )  # From defaults
         self.assertEqual(config_manager.config["ui"]["start_minimized"], True)
-        self.assertEqual(config_manager.config["ui"]["show_notifications"], True)  # From defaults
+        self.assertEqual(
+            config_manager.config["ui"]["show_notifications"], True
+        )  # From defaults
 
     def test_load_config_file_error(self):
         """Test handling of errors when loading config file."""
@@ -225,15 +231,21 @@ class TestConfigManager(unittest.TestCase):
 
         # Set model size for vosk
         config_manager.set_model_size_for_engine("vosk", "large")
-        self.assertEqual(config_manager.config["speech_recognition"]["vosk_model_size"], "large")
-        self.assertEqual(config_manager.config["speech_recognition"]["model_size"], "large")
+        self.assertEqual(
+            config_manager.config["speech_recognition"]["vosk_model_size"], "large"
+        )
+        self.assertEqual(
+            config_manager.config["speech_recognition"]["model_size"], "large"
+        )
 
         # Set model size for whisper
         config_manager.set_model_size_for_engine("whisper", "medium")
         self.assertEqual(
             config_manager.config["speech_recognition"]["whisper_model_size"], "medium"
         )
-        self.assertEqual(config_manager.config["speech_recognition"]["model_size"], "medium")
+        self.assertEqual(
+            config_manager.config["speech_recognition"]["model_size"], "medium"
+        )
 
     def test_migrate_old_config(self):
         """Test migration of old config format without per-engine model sizes."""
@@ -254,27 +266,39 @@ class TestConfigManager(unittest.TestCase):
         config_manager = ConfigManager()
 
         # Verify migration added per-engine model sizes
-        self.assertEqual(config_manager.config["speech_recognition"]["vosk_model_size"], "medium")
-        self.assertEqual(config_manager.config["speech_recognition"]["whisper_model_size"], "tiny")
+        self.assertEqual(
+            config_manager.config["speech_recognition"]["vosk_model_size"], "medium"
+        )
+        self.assertEqual(
+            config_manager.config["speech_recognition"]["whisper_model_size"], "tiny"
+        )
 
     def test_update_speech_recognition_settings_per_engine(self):
         """Test that update_speech_recognition_settings saves per-engine model sizes."""
         config_manager = ConfigManager()
 
         # Update settings for vosk
-        config_manager.update_speech_recognition_settings({"engine": "vosk", "model_size": "large"})
+        config_manager.update_speech_recognition_settings(
+            {"engine": "vosk", "model_size": "large"}
+        )
 
-        self.assertEqual(config_manager.config["speech_recognition"]["vosk_model_size"], "large")
+        self.assertEqual(
+            config_manager.config["speech_recognition"]["vosk_model_size"], "large"
+        )
 
         # Update settings for whisper
         config_manager.update_speech_recognition_settings(
             {"engine": "whisper", "model_size": "small"}
         )
 
-        self.assertEqual(config_manager.config["speech_recognition"]["whisper_model_size"], "small")
+        self.assertEqual(
+            config_manager.config["speech_recognition"]["whisper_model_size"], "small"
+        )
 
         # Verify the vosk setting wasn't changed
-        self.assertEqual(config_manager.config["speech_recognition"]["vosk_model_size"], "large")
+        self.assertEqual(
+            config_manager.config["speech_recognition"]["vosk_model_size"], "large"
+        )
 
     def test_save_settings(self):
         """Test the save_settings method (alias for save_config)."""
@@ -338,7 +362,9 @@ class TestConfigManager(unittest.TestCase):
 
         # Verify section was created and value was set
         self.assertIn("speech_recognition", config_manager.config)
-        self.assertEqual(config_manager.config["speech_recognition"]["vosk_model_size"], "large")
+        self.assertEqual(
+            config_manager.config["speech_recognition"]["vosk_model_size"], "large"
+        )
 
     def test_get_model_size_for_engine_fallback_to_generic(self):
         """Test fallback to generic model_size when no engine-specific key exists."""
@@ -378,8 +404,12 @@ class TestConfigManager(unittest.TestCase):
 
         # Verify section was created
         self.assertIn("speech_recognition", config_manager.config)
-        self.assertEqual(config_manager.config["speech_recognition"]["engine"], "whisper")
-        self.assertEqual(config_manager.config["speech_recognition"]["vad_sensitivity"], 5)
+        self.assertEqual(
+            config_manager.config["speech_recognition"]["engine"], "whisper"
+        )
+        self.assertEqual(
+            config_manager.config["speech_recognition"]["vad_sensitivity"], 5
+        )
 
     def test_migrate_super_shortcut_to_ctrl(self):
         test_config = {
@@ -393,7 +423,9 @@ class TestConfigManager(unittest.TestCase):
             json.dump(test_config, f)
 
         config_manager = ConfigManager()
-        self.assertEqual(config_manager.config["shortcuts"]["toggle_recognition"], "ctrl+ctrl")
+        self.assertEqual(
+            config_manager.config["shortcuts"]["toggle_recognition"], "ctrl+ctrl"
+        )
 
     def test_non_super_shortcut_unchanged(self):
         test_config = {
@@ -407,7 +439,9 @@ class TestConfigManager(unittest.TestCase):
             json.dump(test_config, f)
 
         config_manager = ConfigManager()
-        self.assertEqual(config_manager.config["shortcuts"]["toggle_recognition"], "alt+alt")
+        self.assertEqual(
+            config_manager.config["shortcuts"]["toggle_recognition"], "alt+alt"
+        )
         self.assertEqual(config_manager.config["shortcuts"]["mode"], "push_to_talk")
 
     def test_sound_effects_enabled_by_default(self):

--- a/tests/test_moonshine_support.py
+++ b/tests/test_moonshine_support.py
@@ -1,0 +1,56 @@
+"""Focused tests for Moonshine helper/config support."""
+
+from vocalinux.ui.config_manager import DEFAULT_CONFIG
+from vocalinux.utils.moonshine_model_info import (
+    get_moonshine_default_model_size,
+    get_moonshine_supported_model_sizes,
+    is_moonshine_language_supported,
+    resolve_moonshine_language,
+    resolve_moonshine_model_arch_name,
+)
+
+
+def test_default_config_has_moonshine_model_size():
+    sr = DEFAULT_CONFIG["speech_recognition"]
+    assert sr["moonshine_model_size"] == "auto"
+
+
+def test_moonshine_language_mapping():
+    assert resolve_moonshine_language("auto") == ("en", True)
+    assert resolve_moonshine_language("en-us") == ("en", False)
+    assert resolve_moonshine_language("en-in") == ("en", False)
+    assert resolve_moonshine_language("es") == ("es", False)
+    assert resolve_moonshine_language("fr") == ("en", True)
+
+
+def test_moonshine_language_support():
+    assert is_moonshine_language_supported("auto") is True
+    assert is_moonshine_language_supported("en-us") is True
+    assert is_moonshine_language_supported("ja") is True
+    assert is_moonshine_language_supported("fr") is False
+
+
+def test_moonshine_supported_model_sizes():
+    assert get_moonshine_supported_model_sizes("en-us") == ["tiny", "base", "small", "medium"]
+    assert get_moonshine_supported_model_sizes("es") == ["base"]
+    assert get_moonshine_supported_model_sizes("ko") == ["tiny"]
+
+
+def test_moonshine_default_model_size():
+    assert get_moonshine_default_model_size("en-us") == "medium"
+    assert get_moonshine_default_model_size("es") == "base"
+    assert get_moonshine_default_model_size("ko") == "tiny"
+
+
+def test_moonshine_model_arch_auto():
+    assert resolve_moonshine_model_arch_name("auto", "en-us") == (None, False)
+
+
+def test_moonshine_model_arch_direct():
+    assert resolve_moonshine_model_arch_name("medium", "en-us") == ("MEDIUM_STREAMING", False)
+    assert resolve_moonshine_model_arch_name("tiny", "ja") == ("TINY", False)
+
+
+def test_moonshine_model_arch_fallback():
+    assert resolve_moonshine_model_arch_name("large", "en-us") == ("MEDIUM_STREAMING", True)
+    assert resolve_moonshine_model_arch_name("tiny", "es") == ("BASE", True)

--- a/tests/test_moonshine_support.py
+++ b/tests/test_moonshine_support.py
@@ -31,7 +31,12 @@ def test_moonshine_language_support():
 
 
 def test_moonshine_supported_model_sizes():
-    assert get_moonshine_supported_model_sizes("en-us") == ["tiny", "base", "small", "medium"]
+    assert get_moonshine_supported_model_sizes("en-us") == [
+        "tiny",
+        "base",
+        "small",
+        "medium",
+    ]
     assert get_moonshine_supported_model_sizes("es") == ["base"]
     assert get_moonshine_supported_model_sizes("ko") == ["tiny"]
 
@@ -47,10 +52,16 @@ def test_moonshine_model_arch_auto():
 
 
 def test_moonshine_model_arch_direct():
-    assert resolve_moonshine_model_arch_name("medium", "en-us") == ("MEDIUM_STREAMING", False)
+    assert resolve_moonshine_model_arch_name("medium", "en-us") == (
+        "MEDIUM_STREAMING",
+        False,
+    )
     assert resolve_moonshine_model_arch_name("tiny", "ja") == ("TINY", False)
 
 
 def test_moonshine_model_arch_fallback():
-    assert resolve_moonshine_model_arch_name("large", "en-us") == ("MEDIUM_STREAMING", True)
+    assert resolve_moonshine_model_arch_name("large", "en-us") == (
+        "MEDIUM_STREAMING",
+        True,
+    )
     assert resolve_moonshine_model_arch_name("tiny", "es") == ("BASE", True)

--- a/tests/test_recognition_manager_core.py
+++ b/tests/test_recognition_manager_core.py
@@ -995,3 +995,188 @@ class TestDownloadModels(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+class _FakeMoonshineIntArray:
+    def __init__(self, values):
+        self._values = values
+
+    def astype(self, _dtype):
+        return _FakeMoonshineFloatArray(self._values)
+
+
+class _FakeMoonshineFloatArray:
+    def __init__(self, values):
+        self._values = values
+
+    def __len__(self):
+        return len(self._values)
+
+    def __truediv__(self, divisor):
+        return _FakeMoonshineListArray([value / divisor for value in self._values])
+
+
+class _FakeMoonshineListArray:
+    def __init__(self, values):
+        self._values = values
+
+    def tolist(self):
+        return list(self._values)
+
+
+class TestMoonshineRecognitionManager(unittest.TestCase):
+    """Targeted coverage tests for Moonshine recognition-manager paths."""
+
+    def setUp(self):
+        self.mockKaldi = patch.object(sys.modules["vosk"], "KaldiRecognizer")
+        self.mockModel = patch.object(sys.modules["vosk"], "Model")
+        self.mockMakeDirs = patch("os.makedirs")
+        self.mockThread = patch("threading.Thread")
+        self.mockPath = patch.object(SpeechRecognitionManager, "_get_vosk_model_path")
+        self.mockDownload = patch.object(SpeechRecognitionManager, "_download_vosk_model")
+
+        self.kaldiMock = self.mockKaldi.start()
+        self.modelMock = self.mockModel.start()
+        self.makeDirsMock = self.mockMakeDirs.start()
+        self.threadMock = self.mockThread.start()
+        self.pathMock = self.mockPath.start()
+        self.downloadMock = self.mockDownload.start()
+
+        self.pathMock.return_value = "/mock/path/vosk-model"
+        self.recognizerMock = MagicMock()
+        self.kaldiMock.return_value = self.recognizerMock
+        self.recognizerMock.FinalResult.return_value = '{"text": ""}'
+        self.threadInstance = MagicMock()
+        self.threadMock.return_value = self.threadInstance
+
+        self.patcher_exists = patch("os.path.exists", return_value=True)
+        self.mock_exists = self.patcher_exists.start()
+
+        mock_audio_feedback.play_start_sound.reset_mock()
+        mock_audio_feedback.play_stop_sound.reset_mock()
+        mock_audio_feedback.play_error_sound.reset_mock()
+
+    def tearDown(self):
+        self.mockKaldi.stop()
+        self.mockModel.stop()
+        self.mockMakeDirs.stop()
+        self.mockThread.stop()
+        self.mockPath.stop()
+        self.mockDownload.stop()
+        self.patcher_exists.stop()
+
+    def test_init_moonshine_auto_model_success(self):
+        manager = SpeechRecognitionManager(engine="vosk")
+        manager.engine = "moonshine"
+        manager.language = "auto"
+        manager.model_size = "auto"
+
+        transcriber_cls = MagicMock()
+        transcriber_instance = MagicMock()
+        transcriber_cls.return_value = transcriber_instance
+
+        moonshine_module = MagicMock()
+        moonshine_module.Transcriber = transcriber_cls
+        moonshine_module.get_model_for_language = MagicMock(
+            return_value=("/mock/moonshine-model", 5)
+        )
+
+        moonshine_api_module = MagicMock()
+        moonshine_api_module.ModelArch = MagicMock()
+
+        with patch.dict(
+            sys.modules,
+            {
+                "moonshine_voice": moonshine_module,
+                "moonshine_voice.moonshine_api": moonshine_api_module,
+            },
+        ):
+            manager._init_moonshine()
+
+        moonshine_module.get_model_for_language.assert_called_once_with(wanted_language="en")
+        transcriber_cls.assert_called_once_with(
+            model_path="/mock/moonshine-model",
+            model_arch=5,
+        )
+        self.assertTrue(manager._model_initialized)
+        self.assertIs(manager.model, transcriber_instance)
+
+    def test_init_moonshine_import_error_sets_error_state(self):
+        manager = SpeechRecognitionManager(engine="vosk")
+        manager.engine = "moonshine"
+
+        original_import = __import__
+
+        def raising_import(name, globals=None, locals=None, fromlist=(), level=0):
+            if name == "moonshine_voice":
+                raise ImportError("moonshine missing")
+            return original_import(name, globals, locals, fromlist, level)
+
+        with patch("builtins.__import__", side_effect=raising_import):
+            with self.assertRaises(ImportError):
+                manager._init_moonshine()
+
+        self.assertEqual(manager.state, RecognitionState.ERROR)
+
+    def test_transcribe_with_moonshine_returns_empty_for_no_buffer(self):
+        manager = SpeechRecognitionManager(engine="vosk")
+        manager.model = MagicMock()
+
+        text = manager._transcribe_with_moonshine([])
+
+        self.assertEqual(text, "")
+
+    def test_transcribe_with_moonshine_returns_empty_when_model_missing(self):
+        manager = SpeechRecognitionManager(engine="vosk")
+        manager.model = None
+
+        fake_numpy = MagicMock()
+        fake_numpy.int16 = object()
+        fake_numpy.float32 = object()
+        fake_numpy.frombuffer.return_value = _FakeMoonshineIntArray([0.0, 1.0, -1.0])
+
+        with patch.dict(sys.modules, {"numpy": fake_numpy}):
+            text = manager._transcribe_with_moonshine([b"\x00\x00" * 4])
+
+        self.assertEqual(text, "")
+
+    def test_transcribe_with_moonshine_joins_filtered_lines(self):
+        manager = SpeechRecognitionManager(engine="vosk")
+
+        transcript = MagicMock()
+        transcript.lines = [
+            MagicMock(text="hello"),
+            MagicMock(text="[BLANK_AUDIO]"),
+            MagicMock(text="world"),
+        ]
+
+        manager.model = MagicMock()
+        manager.model.transcribe_without_streaming.return_value = transcript
+
+        fake_numpy = MagicMock()
+        fake_numpy.int16 = object()
+        fake_numpy.float32 = object()
+        fake_numpy.frombuffer.return_value = _FakeMoonshineIntArray(
+            [0.0, 16384.0, -16384.0, 8192.0]
+        )
+
+        with patch.dict(sys.modules, {"numpy": fake_numpy}):
+            text = manager._transcribe_with_moonshine([b"\x00\x00" * 8])
+
+        self.assertEqual(text, "hello world")
+        manager.model.transcribe_without_streaming.assert_called_once()
+
+    def test_transcribe_with_moonshine_handles_backend_exception(self):
+        manager = SpeechRecognitionManager(engine="vosk")
+        manager.model = MagicMock()
+        manager.model.transcribe_without_streaming.side_effect = RuntimeError("boom")
+
+        fake_numpy = MagicMock()
+        fake_numpy.int16 = object()
+        fake_numpy.float32 = object()
+        fake_numpy.frombuffer.return_value = _FakeMoonshineIntArray([0.0, 1.0, -1.0])
+
+        with patch.dict(sys.modules, {"numpy": fake_numpy}):
+            text = manager._transcribe_with_moonshine([b"\x00\x00" * 4])
+
+        self.assertEqual(text, "")

--- a/tests/test_recognition_manager_core.py
+++ b/tests/test_recognition_manager_core.py
@@ -83,9 +83,7 @@ class TestGetAudioInputDevices(unittest.TestCase):
             "name": "Microphone",
             "maxInputChannels": 1,
         }
-        mock_pyaudio_instance.get_default_input_device_info.side_effect = IOError(
-            "No default"
-        )
+        mock_pyaudio_instance.get_default_input_device_info.side_effect = IOError("No default")
 
         mock_pyaudio = MagicMock()
         mock_pyaudio.PyAudio.return_value = mock_pyaudio_instance
@@ -267,9 +265,7 @@ class TestBufferManagement(unittest.TestCase):
         self.mockMakeDirs = patch("os.makedirs")
         self.mockThread = patch("threading.Thread")
         self.mockPath = patch.object(SpeechRecognitionManager, "_get_vosk_model_path")
-        self.mockDownload = patch.object(
-            SpeechRecognitionManager, "_download_vosk_model"
-        )
+        self.mockDownload = patch.object(SpeechRecognitionManager, "_download_vosk_model")
 
         self.kaldiMock = self.mockKaldi.start()
         self.modelMock = self.mockModel.start()
@@ -353,9 +349,7 @@ class TestProcessPartialResult(unittest.TestCase):
         self.mockMakeDirs = patch("os.makedirs")
         self.mockThread = patch("threading.Thread")
         self.mockPath = patch.object(SpeechRecognitionManager, "_get_vosk_model_path")
-        self.mockDownload = patch.object(
-            SpeechRecognitionManager, "_download_vosk_model"
-        )
+        self.mockDownload = patch.object(SpeechRecognitionManager, "_download_vosk_model")
 
         self.kaldiMock = self.mockKaldi.start()
         self.modelMock = self.mockModel.start()
@@ -445,9 +439,7 @@ class TestStartStopRecognition(unittest.TestCase):
         self.mockMakeDirs = patch("os.makedirs")
         self.mockThread = patch("threading.Thread")
         self.mockPath = patch.object(SpeechRecognitionManager, "_get_vosk_model_path")
-        self.mockDownload = patch.object(
-            SpeechRecognitionManager, "_download_vosk_model"
-        )
+        self.mockDownload = patch.object(SpeechRecognitionManager, "_download_vosk_model")
 
         self.kaldiMock = self.mockKaldi.start()
         self.modelMock = self.mockModel.start()
@@ -544,9 +536,7 @@ class TestPushToTalkMode(unittest.TestCase):
         self.mockMakeDirs = patch("os.makedirs")
         self.mockThread = patch("threading.Thread")
         self.mockPath = patch.object(SpeechRecognitionManager, "_get_vosk_model_path")
-        self.mockDownload = patch.object(
-            SpeechRecognitionManager, "_download_vosk_model"
-        )
+        self.mockDownload = patch.object(SpeechRecognitionManager, "_download_vosk_model")
 
         self.kaldiMock = self.mockKaldi.start()
         self.modelMock = self.mockModel.start()
@@ -613,9 +603,7 @@ class TestWhisperInitialization(unittest.TestCase):
         self.mockMakeDirs = patch("os.makedirs")
         self.mockThread = patch("threading.Thread")
         self.mockPath = patch.object(SpeechRecognitionManager, "_get_vosk_model_path")
-        self.mockDownload = patch.object(
-            SpeechRecognitionManager, "_download_vosk_model"
-        )
+        self.mockDownload = patch.object(SpeechRecognitionManager, "_download_vosk_model")
 
         self.kaldiMock = self.mockKaldi.start()
         self.modelMock = self.mockModel.start()
@@ -695,9 +683,7 @@ class TestWhispercppInitialization(unittest.TestCase):
         self.mockMakeDirs = patch("os.makedirs")
         self.mockThread = patch("threading.Thread")
         self.mockPath = patch.object(SpeechRecognitionManager, "_get_vosk_model_path")
-        self.mockDownload = patch.object(
-            SpeechRecognitionManager, "_download_vosk_model"
-        )
+        self.mockDownload = patch.object(SpeechRecognitionManager, "_download_vosk_model")
 
         self.kaldiMock = self.mockKaldi.start()
         self.modelMock = self.mockModel.start()
@@ -794,9 +780,7 @@ class TestReconfiguration(unittest.TestCase):
         self.mockMakeDirs = patch("os.makedirs")
         self.mockThread = patch("threading.Thread")
         self.mockPath = patch.object(SpeechRecognitionManager, "_get_vosk_model_path")
-        self.mockDownload = patch.object(
-            SpeechRecognitionManager, "_download_vosk_model"
-        )
+        self.mockDownload = patch.object(SpeechRecognitionManager, "_download_vosk_model")
 
         self.kaldiMock = self.mockKaldi.start()
         self.modelMock = self.mockModel.start()
@@ -882,9 +866,7 @@ class TestProcessFinalBuffer(unittest.TestCase):
         self.mockMakeDirs = patch("os.makedirs")
         self.mockThread = patch("threading.Thread")
         self.mockPath = patch.object(SpeechRecognitionManager, "_get_vosk_model_path")
-        self.mockDownload = patch.object(
-            SpeechRecognitionManager, "_download_vosk_model"
-        )
+        self.mockDownload = patch.object(SpeechRecognitionManager, "_download_vosk_model")
 
         self.kaldiMock = self.mockKaldi.start()
         self.modelMock = self.mockModel.start()
@@ -968,9 +950,7 @@ class TestDownloadModels(unittest.TestCase):
         self.mockMakeDirs = patch("os.makedirs")
         self.mockThread = patch("threading.Thread")
         self.mockPath = patch.object(SpeechRecognitionManager, "_get_vosk_model_path")
-        self.mockDownload = patch.object(
-            SpeechRecognitionManager, "_download_vosk_model"
-        )
+        self.mockDownload = patch.object(SpeechRecognitionManager, "_download_vosk_model")
 
         self.kaldiMock = self.mockKaldi.start()
         self.modelMock = self.mockModel.start()
@@ -1063,9 +1043,7 @@ class TestMoonshineRecognitionManager(unittest.TestCase):
         self.mockMakeDirs = patch("os.makedirs")
         self.mockThread = patch("threading.Thread")
         self.mockPath = patch.object(SpeechRecognitionManager, "_get_vosk_model_path")
-        self.mockDownload = patch.object(
-            SpeechRecognitionManager, "_download_vosk_model"
-        )
+        self.mockDownload = patch.object(SpeechRecognitionManager, "_download_vosk_model")
 
         self.kaldiMock = self.mockKaldi.start()
         self.modelMock = self.mockModel.start()
@@ -1125,9 +1103,7 @@ class TestMoonshineRecognitionManager(unittest.TestCase):
         ):
             manager._init_moonshine()
 
-        moonshine_module.get_model_for_language.assert_called_once_with(
-            wanted_language="en"
-        )
+        moonshine_module.get_model_for_language.assert_called_once_with(wanted_language="en")
         transcriber_cls.assert_called_once_with(
             model_path="/mock/moonshine-model",
             model_arch=5,

--- a/tests/test_recognition_manager_core.py
+++ b/tests/test_recognition_manager_core.py
@@ -32,7 +32,9 @@ from conftest import mock_audio_feedback  # noqa: E402
 
 # Update import paths to use the new package structure
 from vocalinux.common_types import RecognitionState  # noqa: E402
-from vocalinux.speech_recognition.command_processor import CommandProcessor  # noqa: E402
+from vocalinux.speech_recognition.command_processor import (  # noqa: E402
+    CommandProcessor,
+)
 from vocalinux.speech_recognition.recognition_manager import (  # noqa: E402
     SpeechRecognitionManager,
     _get_supported_channels,
@@ -81,7 +83,9 @@ class TestGetAudioInputDevices(unittest.TestCase):
             "name": "Microphone",
             "maxInputChannels": 1,
         }
-        mock_pyaudio_instance.get_default_input_device_info.side_effect = IOError("No default")
+        mock_pyaudio_instance.get_default_input_device_info.side_effect = IOError(
+            "No default"
+        )
 
         mock_pyaudio = MagicMock()
         mock_pyaudio.PyAudio.return_value = mock_pyaudio_instance
@@ -263,7 +267,9 @@ class TestBufferManagement(unittest.TestCase):
         self.mockMakeDirs = patch("os.makedirs")
         self.mockThread = patch("threading.Thread")
         self.mockPath = patch.object(SpeechRecognitionManager, "_get_vosk_model_path")
-        self.mockDownload = patch.object(SpeechRecognitionManager, "_download_vosk_model")
+        self.mockDownload = patch.object(
+            SpeechRecognitionManager, "_download_vosk_model"
+        )
 
         self.kaldiMock = self.mockKaldi.start()
         self.modelMock = self.mockModel.start()
@@ -347,7 +353,9 @@ class TestProcessPartialResult(unittest.TestCase):
         self.mockMakeDirs = patch("os.makedirs")
         self.mockThread = patch("threading.Thread")
         self.mockPath = patch.object(SpeechRecognitionManager, "_get_vosk_model_path")
-        self.mockDownload = patch.object(SpeechRecognitionManager, "_download_vosk_model")
+        self.mockDownload = patch.object(
+            SpeechRecognitionManager, "_download_vosk_model"
+        )
 
         self.kaldiMock = self.mockKaldi.start()
         self.modelMock = self.mockModel.start()
@@ -437,7 +445,9 @@ class TestStartStopRecognition(unittest.TestCase):
         self.mockMakeDirs = patch("os.makedirs")
         self.mockThread = patch("threading.Thread")
         self.mockPath = patch.object(SpeechRecognitionManager, "_get_vosk_model_path")
-        self.mockDownload = patch.object(SpeechRecognitionManager, "_download_vosk_model")
+        self.mockDownload = patch.object(
+            SpeechRecognitionManager, "_download_vosk_model"
+        )
 
         self.kaldiMock = self.mockKaldi.start()
         self.modelMock = self.mockModel.start()
@@ -534,7 +544,9 @@ class TestPushToTalkMode(unittest.TestCase):
         self.mockMakeDirs = patch("os.makedirs")
         self.mockThread = patch("threading.Thread")
         self.mockPath = patch.object(SpeechRecognitionManager, "_get_vosk_model_path")
-        self.mockDownload = patch.object(SpeechRecognitionManager, "_download_vosk_model")
+        self.mockDownload = patch.object(
+            SpeechRecognitionManager, "_download_vosk_model"
+        )
 
         self.kaldiMock = self.mockKaldi.start()
         self.modelMock = self.mockModel.start()
@@ -601,7 +613,9 @@ class TestWhisperInitialization(unittest.TestCase):
         self.mockMakeDirs = patch("os.makedirs")
         self.mockThread = patch("threading.Thread")
         self.mockPath = patch.object(SpeechRecognitionManager, "_get_vosk_model_path")
-        self.mockDownload = patch.object(SpeechRecognitionManager, "_download_vosk_model")
+        self.mockDownload = patch.object(
+            SpeechRecognitionManager, "_download_vosk_model"
+        )
 
         self.kaldiMock = self.mockKaldi.start()
         self.modelMock = self.mockModel.start()
@@ -681,7 +695,9 @@ class TestWhispercppInitialization(unittest.TestCase):
         self.mockMakeDirs = patch("os.makedirs")
         self.mockThread = patch("threading.Thread")
         self.mockPath = patch.object(SpeechRecognitionManager, "_get_vosk_model_path")
-        self.mockDownload = patch.object(SpeechRecognitionManager, "_download_vosk_model")
+        self.mockDownload = patch.object(
+            SpeechRecognitionManager, "_download_vosk_model"
+        )
 
         self.kaldiMock = self.mockKaldi.start()
         self.modelMock = self.mockModel.start()
@@ -719,7 +735,10 @@ class TestWhispercppInitialization(unittest.TestCase):
 
         with patch.dict(
             sys.modules,
-            {"pywhispercpp": mock_pywhispercpp, "pywhispercpp.model": mock_pywhispercpp.model},
+            {
+                "pywhispercpp": mock_pywhispercpp,
+                "pywhispercpp.model": mock_pywhispercpp.model,
+            },
         ):
             with patch(
                 "vocalinux.speech_recognition.recognition_manager.get_model_path",
@@ -734,7 +753,9 @@ class TestWhispercppInitialization(unittest.TestCase):
                             mock_stat.return_value.st_size = 1000000
                             # Should convert invalid model to "tiny"
                             manager = SpeechRecognitionManager(
-                                engine="whisper_cpp", model_size="invalid", defer_download=True
+                                engine="whisper_cpp",
+                                model_size="invalid",
+                                defer_download=True,
                             )
                             # Invalid size should be converted to "tiny"
                             self.assertEqual(manager.model_size, "tiny")
@@ -746,7 +767,10 @@ class TestWhispercppInitialization(unittest.TestCase):
 
         with patch.dict(
             sys.modules,
-            {"pywhispercpp": mock_pywhispercpp, "pywhispercpp.model": mock_pywhispercpp.model},
+            {
+                "pywhispercpp": mock_pywhispercpp,
+                "pywhispercpp.model": mock_pywhispercpp.model,
+            },
         ):
             # Mock get_model_path to return a non-existent path
             with patch(
@@ -770,7 +794,9 @@ class TestReconfiguration(unittest.TestCase):
         self.mockMakeDirs = patch("os.makedirs")
         self.mockThread = patch("threading.Thread")
         self.mockPath = patch.object(SpeechRecognitionManager, "_get_vosk_model_path")
-        self.mockDownload = patch.object(SpeechRecognitionManager, "_download_vosk_model")
+        self.mockDownload = patch.object(
+            SpeechRecognitionManager, "_download_vosk_model"
+        )
 
         self.kaldiMock = self.mockKaldi.start()
         self.modelMock = self.mockModel.start()
@@ -856,7 +882,9 @@ class TestProcessFinalBuffer(unittest.TestCase):
         self.mockMakeDirs = patch("os.makedirs")
         self.mockThread = patch("threading.Thread")
         self.mockPath = patch.object(SpeechRecognitionManager, "_get_vosk_model_path")
-        self.mockDownload = patch.object(SpeechRecognitionManager, "_download_vosk_model")
+        self.mockDownload = patch.object(
+            SpeechRecognitionManager, "_download_vosk_model"
+        )
 
         self.kaldiMock = self.mockKaldi.start()
         self.modelMock = self.mockModel.start()
@@ -940,7 +968,9 @@ class TestDownloadModels(unittest.TestCase):
         self.mockMakeDirs = patch("os.makedirs")
         self.mockThread = patch("threading.Thread")
         self.mockPath = patch.object(SpeechRecognitionManager, "_get_vosk_model_path")
-        self.mockDownload = patch.object(SpeechRecognitionManager, "_download_vosk_model")
+        self.mockDownload = patch.object(
+            SpeechRecognitionManager, "_download_vosk_model"
+        )
 
         self.kaldiMock = self.mockKaldi.start()
         self.modelMock = self.mockModel.start()
@@ -1033,7 +1063,9 @@ class TestMoonshineRecognitionManager(unittest.TestCase):
         self.mockMakeDirs = patch("os.makedirs")
         self.mockThread = patch("threading.Thread")
         self.mockPath = patch.object(SpeechRecognitionManager, "_get_vosk_model_path")
-        self.mockDownload = patch.object(SpeechRecognitionManager, "_download_vosk_model")
+        self.mockDownload = patch.object(
+            SpeechRecognitionManager, "_download_vosk_model"
+        )
 
         self.kaldiMock = self.mockKaldi.start()
         self.modelMock = self.mockModel.start()
@@ -1093,7 +1125,9 @@ class TestMoonshineRecognitionManager(unittest.TestCase):
         ):
             manager._init_moonshine()
 
-        moonshine_module.get_model_for_language.assert_called_once_with(wanted_language="en")
+        moonshine_module.get_model_for_language.assert_called_once_with(
+            wanted_language="en"
+        )
         transcriber_cls.assert_called_once_with(
             model_path="/mock/moonshine-model",
             model_arch=5,


### PR DESCRIPTION
## Summary

Adds Moonshine as a fourth speech recognition engine in Vocalinux.

This keeps the existing audio capture, buffering, and segmentation flow in place and adds Moonshine as another backend instead of changing the overall architecture.

## Changes

- add optional `moonshine-voice` dependency
- add `moonshine` to engine selection paths
- add config support for Moonshine model selection
- add Moonshine initialization and transcription in `recognition_manager`
- convert buffered PCM audio into the float sample format Moonshine expects
- add language mapping and fallback handling for unsupported languages
- add settings dialog support for Moonshine
- keep voice commands disabled by default for Moonshine in the settings path
- add focused tests for config/helper behavior

## Install

```bash
pip install "vocalinux[moonshine]"
```

Or:

```bash
pip install moonshine-voice
```

## Notes

This is a minimal v1 backend integration. It reuses the existing audio flow and does not introduce a new recognition pipeline.

Moonshine model selection is handled separately where needed instead of forcing a wider cross-engine model refactor.

## Local verification

Tested locally with `moonshine-voice 0.0.56`.

Verified locally:
- app starts with `--engine moonshine`
- Moonshine initializes successfully
- end-to-end transcription works through the existing Vocalinux flow
- a spoken test phrase was transcribed and injected successfully
