### PR TITLE
fix: add Python 3.14 support and lxml>=6.1.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,7 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "Topic :: Desktop Environment :: Gnome",
     "Topic :: Multimedia :: Sound/Audio :: Speech",
     "Topic :: Text Processing",
@@ -49,6 +50,7 @@ dependencies = [
     "python-xlib; sys_platform == 'linux'",
     "PyGObject; sys_platform == 'linux'",
     "psutil>=5.9.0",
+    "lxml>=6.1.0",
 ]
 
 [project.optional-dependencies]
@@ -99,7 +101,7 @@ version = {attr = "vocalinux.version.__version__"}
 
 [tool.black]
 line-length = 100
-target-version = ['py39', 'py310', 'py311', 'py312', 'py313']
+target-version = ['py39', 'py310', 'py311', 'py312', 'py313', 'py314']
 include = '\.pyi?$'
 exclude = '''
 /(


### PR DESCRIPTION
## Summary

Fixes #404 — vocalinux fails to install on CachyOS (Arch-based, ships Python 3.14) because an old version of lxml gets resolved that doesn't support Python 3.14.

lxml 6.1.0 (released April 17, 2026) adds Python 3.14 compatibility.

## Changes

- **Add Python 3.14** to classifiers
- **Add `lxml>=6.1.0`** to dependencies — ensures pip resolves to a Python 3.14-compatible version, preventing transitive dependency resolution to older broken versions
- **Update black target-version** to include `py314`

## Testing

- No runtime code changes, only dependency/classifier metadata
- Verified `pyproject.toml` parses correctly

Closes #404
