### PR TITLE
chore: ignore opentree worktree dir and config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -152,3 +152,7 @@ temp/
 # Analysis documents (keep local)
 CROSS_DISTRO_ANALYSIS.md
 FIX_PLAN.md
+
+# opentree - local AI worktree orchestration tool (per-developer, not shared)
+.opentree/
+opentree.toml


### PR DESCRIPTION
## Summary

- Adds `.opentree/` to `.gitignore` — this directory is created by [opentree](https://github.com/axelgar/opentree) to store git worktrees for parallel AI coding sessions; it's a local developer artifact, not project code
- Adds `opentree.toml` to `.gitignore` — per-repo opentree config is personal/local (each dev may use different agents, settings, etc.)

> Note: `opentree.toml` at repo root is valid per the opentree docs (it searches up the directory tree for config, similar to git finding `.git`). It's just not something that should be shared across contributors.