### PR TITLE
fix(logging): clean up runtime log noise and cache hardware detection

### DIFF
--- a/src/vocalinux/main.py
+++ b/src/vocalinux/main.py
@@ -284,10 +284,6 @@ def main():
         logger.debug(f"Could not start IBus daemon: {e}")
 
     config_manager = ConfigManager()
-    initialize_logging()
-    logger.info("Logging system initialized")
-
-    config_manager = ConfigManager()
     saved_settings = config_manager.get_settings().get("speech_recognition", {})
     audio_settings = config_manager.get_settings().get("audio", {})
 

--- a/src/vocalinux/speech_recognition/recognition_manager.py
+++ b/src/vocalinux/speech_recognition/recognition_manager.py
@@ -1600,7 +1600,7 @@ class SpeechRecognitionManager:
                 )
 
             if self.audio_buffer:
-                logger.info(f"DEBUG: Enqueuing final buffer with {len(self.audio_buffer)} chunks")
+                logger.debug(f"Enqueuing final buffer with {len(self.audio_buffer)} chunks")
                 self._enqueue_audio_segment(self.audio_buffer)
                 self.audio_buffer = []
 
@@ -1914,9 +1914,7 @@ class SpeechRecognitionManager:
             return
 
         # Process text - either with voice commands or pass through directly
-        logger.info(
-            f"DEBUG: _process_audio_buffer got text='{text[:50] if text else '(empty)'}...'"
-        )
+        logger.debug(f"_process_audio_buffer got text='{text[:50] if text else '(empty)'}...'")
         if text:
             if self._voice_commands_enabled:
                 # Process with voice commands (original behavior)
@@ -1927,13 +1925,13 @@ class SpeechRecognitionManager:
                 actions = []
 
             # Call text callbacks with processed text
-            logger.info(
-                f"DEBUG: processed_text='{processed_text[:50] if processed_text else '(empty)'}...', callbacks={len(self.text_callbacks)}"
+            logger.debug(
+                f"processed_text='{processed_text[:50] if processed_text else '(empty)'}...', callbacks={len(self.text_callbacks)}"
             )
             if processed_text:
                 for callback in self.text_callbacks:
-                    logger.info(
-                        f"DEBUG: invoking text callback: {callback.__name__ if hasattr(callback, '__name__') else callback}"
+                    logger.debug(
+                        f"invoking text callback: {callback.__name__ if hasattr(callback, '__name__') else callback}"
                     )
                     callback(processed_text)
 
@@ -1944,89 +1942,65 @@ class SpeechRecognitionManager:
 
     def _perform_recognition(self):
         """Perform speech recognition in real-time."""
-        logger.info("DEBUG: _perform_recognition thread started")
+        logger.debug("_perform_recognition thread started")
         while True:
             logger.debug(
-                f"DEBUG: Recognition loop - should_record={self.should_record}, queue_empty={self._segment_queue.empty()}"
+                f"Recognition loop - should_record={self.should_record}, queue_empty={self._segment_queue.empty()}"
             )
             try:
                 segment = self._segment_queue.get(timeout=0.1)
             except queue.Empty:
                 # Only exit if we're not recording AND queue is empty
                 if not self.should_record and self._segment_queue.empty():
-                    logger.info(
-                        "DEBUG: Recognition loop - not recording and queue empty, checking for final items..."
+                    logger.debug(
+                        "Recognition loop - not recording and queue empty, checking for final items..."
                     )
                     # Give a brief moment for any final items to be enqueued
                     try:
                         segment = self._segment_queue.get(timeout=0.5)
                     except queue.Empty:
-                        logger.info("DEBUG: Recognition loop - no more items, exiting")
+                        logger.debug("Recognition loop - no more items, exiting")
                         break
                 else:
-                    logger.debug("DEBUG: Recognition loop - queue timeout, continuing")
+                    logger.debug("Recognition loop - queue timeout, continuing")
                     continue
 
             if segment is None:
-                logger.info(
-                    "DEBUG: Recognition loop - got None signal, draining remaining items..."
-                )
+                logger.debug("Recognition loop - got None signal, draining remaining items...")
                 # Drain any remaining items before exiting
                 while not self._segment_queue.empty():
                     try:
                         remaining = self._segment_queue.get_nowait()
                         if remaining is not None:
-                            logger.info(
-                                f"DEBUG: Recognition loop - processing remaining segment with {len(remaining)} chunks"
+                            logger.debug(
+                                f"Recognition loop - processing remaining segment with {len(remaining)} chunks"
                             )
                             self._update_state(RecognitionState.PROCESSING)
                             self._process_audio_buffer(remaining)
                     except queue.Empty:
                         break
-                logger.info("DEBUG: Recognition loop - exiting after None signal")
+                logger.debug("Recognition loop - exiting after None signal")
                 break
 
-            logger.info(f"DEBUG: Recognition loop - processing segment with {len(segment)} chunks")
+            logger.debug(f"Recognition loop - processing segment with {len(segment)} chunks")
             self._update_state(RecognitionState.PROCESSING)
             self._process_audio_buffer(segment)
             if self.should_record:
                 self._update_state(RecognitionState.LISTENING)
-        logger.info("DEBUG: _perform_recognition thread exiting")
-        """Perform speech recognition in real-time."""
-        logger.info("DEBUG: _perform_recognition thread started")
-        while self.should_record or not self._segment_queue.empty():
-            logger.debug(
-                f"DEBUG: Recognition loop - should_record={self.should_record}, queue_empty={self._segment_queue.empty()}"
-            )
-            try:
-                segment = self._segment_queue.get(timeout=0.1)
-            except queue.Empty:
-                logger.debug("DEBUG: Recognition loop - queue timeout, continuing")
-                continue
-
-            if segment is None:
-                logger.info("DEBUG: Recognition loop - got None signal, continuing")
-                continue
-
-            logger.info(f"DEBUG: Recognition loop - processing segment with {len(segment)} chunks")
-            self._update_state(RecognitionState.PROCESSING)
-            self._process_audio_buffer(segment)
-            if self.should_record:
-                self._update_state(RecognitionState.LISTENING)
-        logger.info("DEBUG: _perform_recognition thread exiting")
+        logger.debug("_perform_recognition thread exiting")
 
     def _enqueue_audio_segment(self, audio_buffer: list[bytes]):
         """Queue an audio segment for asynchronous transcription."""
         segment = audio_buffer.copy()
         if not segment:
-            logger.warning("DEBUG: _enqueue_audio_segment called with empty buffer")
+            logger.warning("_enqueue_audio_segment called with empty buffer")
             return
 
-        logger.info(f"DEBUG: _enqueue_audio_segment called with {len(segment)} chunks")
+        logger.debug(f"_enqueue_audio_segment called with {len(segment)} chunks")
 
         try:
             self._segment_queue.put_nowait(segment)
-            logger.info("DEBUG: Enqueued segment successfully")
+            logger.debug("Enqueued segment successfully")
         except queue.Full:
             logger.warning("Transcription queue is full, dropping oldest pending segment")
             try:

--- a/src/vocalinux/utils/whispercpp_model_info.py
+++ b/src/vocalinux/utils/whispercpp_model_info.py
@@ -8,6 +8,7 @@ for whisper.cpp, supporting Vulkan, CUDA, and CPU backends.
 import logging
 import os
 import subprocess
+from functools import lru_cache
 from typing import Optional
 
 logger = logging.getLogger(__name__)
@@ -60,7 +61,14 @@ class ComputeBackend:
     CPU = "cpu"
 
 
+@lru_cache(maxsize=1)
 def detect_vulkan_support() -> tuple[bool, Optional[str]]:
+    """
+    Detect if Vulkan is available and get device info.
+
+    Returns:
+        Tuple of (is_available, device_name)
+    """
     """
     Detect if Vulkan is available and get device info.
 
@@ -91,6 +99,7 @@ def detect_vulkan_support() -> tuple[bool, Optional[str]]:
     return False, None
 
 
+@lru_cache(maxsize=1)
 def detect_cuda_support() -> tuple[bool, Optional[str]]:
     """
     Detect if NVIDIA CUDA is available and get device info.
@@ -119,6 +128,7 @@ def detect_cuda_support() -> tuple[bool, Optional[str]]:
     return False, None
 
 
+@lru_cache(maxsize=1)
 def detect_compute_backend() -> tuple[str, str]:
     """
     Detect the best available compute backend.
@@ -143,6 +153,7 @@ def detect_compute_backend() -> tuple[str, str]:
     return ComputeBackend.CPU, cpu_info
 
 
+@lru_cache(maxsize=1)
 def detect_cpu_info() -> str:
     """
     Detect CPU information for CPU backend.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -81,6 +81,32 @@ sys.modules["vocalinux.ui.audio_feedback"] = mock_audio_feedback
 
 
 @pytest.fixture(autouse=True)
+def _clear_hardware_detection_cache():
+    """Clear lru_cache on hardware-detection helpers between tests.
+
+    Hardware detection results are cached for the lifetime of the process
+    in production, but tests mock subprocess.run and call these helpers
+    multiple times with different mock return values; without clearing
+    the cache, later assertions would see the first call's cached result.
+    """
+    try:
+        from vocalinux.utils import whispercpp_model_info as _wmi
+
+        for fn_name in (
+            "detect_vulkan_support",
+            "detect_cuda_support",
+            "detect_compute_backend",
+            "detect_cpu_info",
+        ):
+            fn = getattr(_wmi, fn_name, None)
+            if fn is not None and hasattr(fn, "cache_clear"):
+                fn.cache_clear()
+    except Exception:
+        pass
+    yield
+
+
+@pytest.fixture(autouse=True)
 def _cleanup_ibus_server():
     """Stop any leftover IBus socket server threads after each test.
 


### PR DESCRIPTION
## Summary

Found four issues while investigating a runtime log from a fresh install of latest `main` (post-v0.10.2 merges). Three are duplicated-code artifacts from recent merges; one is a perf bug that adds ~1.3 s of UI lag whenever the settings dialog opens.

## Findings & Fixes

### 1. Duplicate `_perform_recognition` loop body (`recognition_manager.py`)

Commit d049473 (#401, *preserve final speech on stop*) added a new `while True:` loop body but left the previous `while self.should_record or not self._segment_queue.empty():` body glued in immediately after, with a stray docstring acting as an expression statement. The dead loop ran once after every recording and produced a spurious extra:
```
DEBUG: _perform_recognition thread started
DEBUG: _perform_recognition thread exiting
```
visible in the attached log. Removed.

### 2. Duplicate startup init in `main.py`

Commit cb9b66a (#261) introduced a duplicated block:
```python
config_manager = ConfigManager()
initialize_logging()
logger.info(\"Logging system initialized\")

config_manager = ConfigManager()
```
Causing `Logging system initialized` and `Loaded configuration from /home/jk/.config/vocalinux/config.json` to log twice on every startup and reading the config file from disk once more than necessary. Removed the duplicate.

### 3. Hardware detection re-shells out on every settings-dialog interaction (`whispercpp_model_info.py`)

`detect_vulkan_support()`, `detect_cuda_support()`, `detect_cpu_info()`, and `detect_compute_backend()` shell out to `vulkaninfo --summary` / `nvidia-smi` every call. The settings dialog calls them while populating model dropdowns; the attached log shows **10+ Vulkan probes within ~1.3 s** every time the dialog opens.

Decorated all four with `@lru_cache(maxsize=1)` — hardware doesn't change at runtime. Added an autouse `conftest.py` fixture to clear the caches between tests so existing `subprocess.run` mocks keep working as written.

### 4. Demoted `logger.info(\"DEBUG: ...\")` breadcrumbs to `logger.debug(...)`

13 internal queue/thread breadcrumbs in `recognition_manager.py` were logged at INFO level with a literal `DEBUG:` prefix, flooding default-level logs. Demoted to `logger.debug` so they only appear with `--debug`.

## Verification

- `make lint` (black, isort, flake8) ✅
- Targeted tests: `test_whispercpp_model_info_ext.py`, `test_recognition_manager_*`, `test_whisper_support.py`, `test_misc_edge_cases.py` — **151 passed**
- Full suite (excluding `test_main*.py` which fail pre-existing on this machine because a Vocalinux instance is currently running and holds the lock — verified identical failures on clean `main`) — **1428 passed**

## Before vs After (representative log lines per recording)

Before (from the user-reported log):
```
[19:36:13.282] INFO ... DEBUG: _perform_recognition thread started
[19:36:13.282] INFO ... Loaded configuration from .../config.json
...
[19:36:16.371] INFO ... DEBUG: invoking text callback: text_callback_wrapper
[19:36:16.371] INFO ... DEBUG: _perform_recognition thread exiting
[19:36:16.371] INFO ... DEBUG: _perform_recognition thread started   ← dead loop
[19:36:16.371] INFO ... DEBUG: _perform_recognition thread exiting   ← dead loop
```

After: dead loop gone, all `DEBUG:`-prefixed lines moved to `logger.debug` (suppressed unless `--debug`), settings dialog no longer log-spams Vulkan detection.