### PR TITLE
fix: play stop sound immediately on release

### DIFF
--- a/src/vocalinux/speech_recognition/recognition_manager.py
+++ b/src/vocalinux/speech_recognition/recognition_manager.py
@@ -1651,6 +1651,10 @@ class SpeechRecognitionManager:
         # Stop recording FIRST to prevent capturing the stop sound
         self.should_record = False
 
+        # Give immediate release feedback. The recorder may still finish one
+        # in-flight chunk, so the stop-sound guard below keeps the cue out.
+        play_stop_sound()
+
         # Wait for audio thread to finish recording and enqueue any pending audio
         # This is critical to prevent race condition where recognition thread exits
         # before the final audio segment is enqueued
@@ -1673,9 +1677,6 @@ class SpeechRecognitionManager:
                 logger.debug(f"Enqueuing final buffer with {len(self.audio_buffer)} chunks")
                 self._enqueue_audio_segment(self.audio_buffer)
                 self.audio_buffer = []
-
-        # Now play the stop sound (after recording has stopped)
-        play_stop_sound()
 
         # Wake up recognition thread so it can drain queued segments and stop
         self._signal_recognition_stop()

--- a/tests/test_recognition_manager_advanced.py
+++ b/tests/test_recognition_manager_advanced.py
@@ -226,6 +226,23 @@ class TestStartStopRecognition(unittest.TestCase):
         mgr.stop_recognition()
         self.assertFalse(mgr.should_record)
 
+    def test_stop_sound_plays_before_audio_thread_join(self):
+        mgr = _make_manager()
+        mgr.state = RecognitionState.LISTENING
+        mgr.should_record = True
+        mgr.audio_thread = MagicMock()
+        mgr.audio_thread.is_alive.return_value = True
+        events = []
+        mgr.audio_thread.join.side_effect = lambda timeout=None: events.append("join")
+
+        with patch(
+            "vocalinux.speech_recognition.recognition_manager.play_stop_sound",
+            side_effect=lambda: events.append("sound"),
+        ):
+            mgr.stop_recognition()
+
+        self.assertEqual(events[:2], ["sound", "join"])
+
     def test_stop_sound_guard_chunk_calculation(self):
         mgr = _make_manager()
 


### PR DESCRIPTION
## Summary
- play the stop sound immediately after recording is marked stopped
- keep the existing stop-sound guard trim so the cue is not transcribed
- add a regression test that the cue plays before waiting for the audio thread to join

## Why
Push-to-talk users get delayed feedback today because the stop sound is played only after audio-thread shutdown and final buffer handling. Recording is already marked stopped first, and the existing guard trim handles any in-flight chunk, so the feedback can be moved earlier without changing transcription flow.

## Impact
The release cue feels immediate while preserving the current final-buffer transcription path.

## Validation
- `PYTHONPATH=src /home/juanfra/.local/share/vocalinux/venv/bin/python -m pytest tests/test_recognition_manager_advanced.py tests/test_recognition_manager_core.py -q`
- `PYTHONPATH=src /home/juanfra/.local/share/vocalinux/venv/bin/python -m py_compile src/vocalinux/speech_recognition/recognition_manager.py tests/test_recognition_manager_advanced.py`
- `black --check` on changed files