### PR TITLE
fix(recognition): play stop sound after audio thread joins to prevent capture on short recordings

### DIFF
--- a/src/vocalinux/speech_recognition/recognition_manager.py
+++ b/src/vocalinux/speech_recognition/recognition_manager.py
@@ -1768,15 +1768,15 @@ class SpeechRecognitionManager:
         # Stop recording FIRST to prevent capturing the stop sound
         self.should_record = False
 
-        # Give immediate release feedback. The recorder may still finish one
-        # in-flight chunk, so the stop-sound guard below keeps the cue out.
-        play_stop_sound()
-
         # Wait for audio thread to finish recording and enqueue any pending audio
         # This is critical to prevent race condition where recognition thread exits
         # before the final audio segment is enqueued
         if self.audio_thread and self.audio_thread.is_alive():
             self.audio_thread.join(timeout=2.0)
+
+        # Play stop sound now that the audio thread is done and cannot capture it.
+        # Kept before buffer processing so the cue still feels immediate.
+        play_stop_sound()
 
         # Trim only a small tail to avoid the stop sound without clipping the user's final word.
         with self._buffer_lock:

--- a/tests/test_recognition_manager_advanced.py
+++ b/tests/test_recognition_manager_advanced.py
@@ -226,7 +226,7 @@ class TestStartStopRecognition(unittest.TestCase):
         mgr.stop_recognition()
         self.assertFalse(mgr.should_record)
 
-    def test_stop_sound_plays_before_audio_thread_join(self):
+    def test_stop_sound_plays_after_audio_thread_join(self):
         mgr = _make_manager()
         mgr.state = RecognitionState.LISTENING
         mgr.should_record = True
@@ -241,7 +241,8 @@ class TestStartStopRecognition(unittest.TestCase):
         ):
             mgr.stop_recognition()
 
-        self.assertEqual(events[:2], ["sound", "join"])
+        # sound must play after the audio thread has joined so the cue cannot be captured
+        self.assertEqual(events[:2], ["join", "sound"])
 
     def test_stop_sound_guard_chunk_calculation(self):
         mgr = _make_manager()


### PR DESCRIPTION
## Summary
Follow-up fix to #426. Moves `play_stop_sound()` to just after `audio_thread.join()` (so the audio thread is dead and cannot capture the cue) but still before the final buffer processing. This closes the race condition where short push-to-talk recordings (≤ ~192 ms) could have the stop sound captured by the audio thread's in-flight `stream.read()` chunk.

## Why
In #426 the stop sound was moved before `audio_thread.join()`. While this makes the cue feel immediate, it introduces a capture window: the audio thread may still be blocked in `stream.read()` and can append that chunk *after* `play_stop_sound()` starts. The existing guard trim only runs when `len(audio_buffer) > stop_sound_guard_chunks` (default 3 chunks ≈ 192ms), so very short buffers aren't trimmed and the cue leaks into transcription.

## What changed
- `recognition_manager.py`: moved `play_stop_sound()` after `audio_thread.join()`, before buffer trim/enqueue
- `test_recognition_manager_advanced.py`: updated ordering test to assert `["join", "sound"]`

## Validation
- `PYTHONPATH=src pytest tests/test_recognition_manager_advanced.py tests/test_recognition_manager_core.py -q` ✅
