### PR TITLE
fix(install): refresh ldconfig after openSUSE typelib install

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1250,6 +1250,8 @@ suse_install_appindicator_runtime() {
             print_info "AppIndicator/Ayatana package is already installed ($PKG); verifying GI namespace..."
         elif sudo zypper install -y "$PKG" 2>/dev/null; then
             print_success "Installed AppIndicator/Ayatana package ($PKG)."
+            # Refresh the shared-library cache so the GI typelib is discoverable
+            sudo ldconfig 2>/dev/null || true
         else
             print_info "AppIndicator/Ayatana package '$PKG' not available, trying next option..."
             continue

--- a/scripts/distro-package-map.yaml
+++ b/scripts/distro-package-map.yaml
@@ -11,6 +11,10 @@ system_packages:
     fedora: ["python3-gobject", "gtk3", "gobject-introspection-devel"]
     arch: ["python-gobject", "gtk3", "gobject-introspection", "python-cairo"]
     # Tumbleweed often uses versioned Python package names such as python313-gobject.
+    # NOTE: "python3XY" is a placeholder convention. The XY suffix is resolved at
+    # install time by install.sh via suse_python_package_prefix() and
+    # suse_python_package_candidates(), which try the active Python minor version
+    # first (e.g. python313-gobject) and fall back to the unversioned name.
     opensuse: ["python3XY-gobject", "python3XY-gobject-cairo", "gtk3", "gobject-introspection-devel"]
     gentoo: ["dev-python/pygobject:3", "x11-libs/gtk+:3"]
     alpine: ["py3-gobject3", "py3-cairo", "gtk+3.0"]
@@ -49,6 +53,7 @@ system_packages:
     fedora: ["python3-devel", "python3-virtualenv"]
     arch: ["python"]  # Arch includes venv by default
     # Tumbleweed package names follow the active Python minor version, e.g. python313-devel.
+    # NOTE: "python3XY" is a placeholder — see gtk3.opensuse comment above for details.
     opensuse: ["python3XY-devel", "python3XY-virtualenv", "python3XY-venv", "python3XY-pip"]
     gentoo: ["dev-lang/python:3.9"]
     alpine: ["py3-virtualenv"]


### PR DESCRIPTION
## Summary

Follow-up polish from the review of #420. Two small improvements:

### 1. Refresh `ldconfig` after typelib install
After `suse_install_appindicator_runtime()` installs an AppIndicator/Ayatana typelib package via zypper, it now runs `sudo ldconfig` to refresh the shared-library cache. This ensures the GI typelib is immediately discoverable by GObject introspection without requiring a reboot or manual cache refresh.

### 2. Document the `python3XY` placeholder convention
Added section-level comments in `distro-package-map.yaml` explaining that `python3XY` entries (e.g. `python3XY-gobject`, `python3XY-devel`) are NOT real package names — they are a placeholder convention where the `XY` suffix is resolved at install time by `install.sh` via `suse_python_package_prefix()` and `suse_python_package_candidates()`. This prevents future contributors from trying to install `python3XY-gobject` as a literal package name.

## Changes

| File | Change |
|---|---|
| `install.sh` | +2 lines — `sudo ldconfig` after zypper typelib install |
| `scripts/distro-package-map.yaml` | +5 lines — clarifying comments |

## Type of Change

- [x] 🐛 Bug fix (belt-and-suspender for GI typelib discoverability)
- [x] 📖 Documentation (placeholder convention clarification)