### PR TITLE
chore(release): prepare v0.11.0-beta

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,40 +32,51 @@ It's a free, GPLv3-licensed desktop app that lets you dictate text into *any* ap
 
 No internet required. No data leaves your machine. Just speak and type.
 
-## 📚 What's New in v0.10.2-beta
+## 📚 What's New in v0.11.0-beta
 
-> 🎉 **Release: non-ASCII text injection, IBus Wayland detection fixes, Pop!_OS dependency support, and code quality improvements.**
+> 🎉 **Release: Advanced Settings tab with anti-hallucination parameters, IBus/recognition hardening, and distro compatibility improvements.**
 
-### 🚀 Highlights (v0.10.1 → v0.10.2)
+### 🚀 Highlights
 
 | Feature | Description |
 |---------|-------------|
-| **🌍 Non-ASCII Text Injection** | ydotool now falls back to clipboard paste for non-ASCII characters (á, é, ñ, etc.) |
-| **🔌 IBus on Wayland** | IBus now detected and started correctly on Wayland without legacy env vars |
-| **🚀 IBus Engine Startup** | Engine process now starts before registration check — fixes startup on some systems |
-| **📦 Pop!\_OS / Ubuntu 24.04+** | Added missing system dependencies (cmake, libcairo2-dev, libgirepository1.0-dev) |
-| **⚡ Code Quality** | Systematic refactor across 20 quality dimensions |
-| **🖼️ Website OG Image** | Redesigned Open Graph image — cleaner and more professional |
+| **⚙️ Advanced Settings Tab** | New Advanced tab with whisper.cpp anti-hallucination parameters (temperature, no_speech_threshold, etc.) |
+| **🔌 IBus Hardening** | Engine readiness probe at startup, runtime failure recovery, and proper engine destruction on layout switch |
+| **🎤 Recognition Reliability** | Preserve final speech on stop and improved stop-sound playback timing |
+| **📦 Distro Compatibility** | Hardened Debian layer, corrected openSUSE Tumbleweed deps, Python 3.14 support |
+| **🔧 Installer Fixes** | Repair pywhispercpp loading, validate proj configs before local repo mode, reuse existing whispercpp builds |
 
-### ✨ Scope
+### ✨ New Features
 
-- **Patch release focused on compatibility** - IBus/Wayland improvements, non-ASCII text injection, and distro support
-- **Broader platform coverage** - Pop!_OS, Ubuntu 24.04+, Wayland IBus users
-- **Code quality** - Systematic refactor across 20 dimensions for long-term maintainability
+- **Advanced Settings tab** — New tab in Settings dialog exposing whisper.cpp anti-hallucination parameters:
+  - Temperature override
+  - No-speech threshold
+  - Max segment length
+  - Other inference-time parameters for fine-tuning recognition behavior
 
-### 🐛 Bug Fixes (v0.10.2)
+### 🐛 Bug Fixes
 
-- **#362 / #376**: Handle non-ASCII characters with ydotool via clipboard paste fallback
-- **#360 / #361**: Start IBus engine process before checking registration
-- **#381**: Detect IBus on Wayland without legacy env vars and fix text injection
-- **#379**: Add missing dependencies for Pop!_OS and Ubuntu 24.04+
+- **IBus**: Probe engine readiness at startup with hardened retries (#391)
+- **IBus**: Handle engine instance destruction on layout switch (#389)
+- **IBus**: Recover from runtime failures gracefully (#411)
+- **Recognition**: Preserve final speech when stopping (#401)
+- **Recognition**: Play stop sound immediately on release (#426) and after audio thread joins (#436)
+- **Install**: Repair pywhispercpp library loading (#433)
+- **Install**: Correct openSUSE Tumbleweed dependencies (#420, #418)
+- **Install**: Harden Debian compatibility layer (#437)
+- **Install**: Validate pyproject.toml/setup.py before local repo mode (#396)
+- **Install**: Reuse existing whispercpp builds (#421)
+- **Install**: Refresh ldconfig after openSUSE typelib install (#438)
+- **whisper.cpp**: Reduce CPU threads and ensure GPU backend builds in dev mode (#439)
+- **Logging**: Clean up runtime log noise and cache hardware detection
+- **Python 3.14 support**: Compatibility fix and lxml>=6.1.0 (#404)
 
 ### 🔧 Improvements
 
-- **Code quality** - Systematic refactor across 20 quality dimensions (#377)
-- **Debian support** - Clarify missing GNOME AppIndicator support messaging (#385)
-- **Website** - Redesigned OG image for vocalinux.com (#392)
-- **Tests** - Additional coverage for tray, IBus, and notification edge cases
+- **Installer refresh** — openSUSE fallback handling, Debian compatibility hardening
+- **Test coverage** — Recognition internals, IBus edge cases, CI notification suppression (#410, #414)
+- **Dependency bumps** — Next.js security updates (#399, #429), PostCSS (#2753679)
+- **PyPI docs** — Clarify installation requirements (#423)
 
 ---
 
@@ -369,7 +380,7 @@ Vocalinux is part of a family of privacy-first, offline voice dictation tools. S
 
 | Platform | Project | Website | GitHub | Status |
 |----------|---------|---------|--------|--------|
-| 🐧 Linux | **VocaLinux** | [vocalinux.com](https://vocalinux.com) | [jatinkrmalik/vocalinux](https://github.com/jatinkrmalik/vocalinux) | ✅ Beta v0.10.2 |
+| 🐧 Linux | **VocaLinux** | [vocalinux.com](https://vocalinux.com) | [jatinkrmalik/vocalinux](https://github.com/jatinkrmalik/vocalinux) | ✅ Beta v0.11.0 |
 | 🍎 macOS | **VocaMac** | [vocamac.com](https://vocamac.com) | [jatinkrmalik/vocamac](https://github.com/jatinkrmalik/vocamac) | 🚀 Beta |
 | 🪟 Windows | **VocaWin** | [vocawin.com](https://vocawin.com) | [jatinkrmalik/vocawin](https://github.com/jatinkrmalik/vocawin) | 📋 Planned |
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,8 +4,8 @@
 
 | Version | Supported          |
 | ------- | ------------------ |
-| 0.10.x  | :white_check_mark: |
-| 0.10.1  | :x:                |
+| 0.11.x  | :white_check_mark: |
+| 0.10.x  | :x:                |
 | 0.9.x   | :x:                |
 | 0.8.x   | :x:                |
 | < 0.8   | :x:                |

--- a/docs/RELEASE_PROCESS.md
+++ b/docs/RELEASE_PROCESS.md
@@ -341,6 +341,7 @@ git push origin v0.5.1-beta
 | 0.10.0-beta | 2026-03-25 | Beta | Keyboard/audio reliability hardening, IBus/tray stability fixes, CI + test coverage improvements |
 | 0.10.1-beta | 2026-03-27 | Beta | Stability patch: tray resource bundling, engine-switch segfault prevention, settings close action, XKB layout preservation |
 | 0.10.2-beta | 2026-04-08 | Beta | Non-ASCII text injection, IBus Wayland detection, Pop!_OS deps, code quality refactor |
+| 0.11.0-beta | 2026-05-30 | Beta | Advanced Settings tab, IBus/recognition hardening, installer fixes, distro compatibility |
 
 ## Questions?
 

--- a/docs/UPDATE.md
+++ b/docs/UPDATE.md
@@ -2,6 +2,54 @@
 
 This guide explains how to update Vocalinux to the latest version.
 
+## What's New in v0.11.0-beta
+
+### 🚀 Highlights
+
+| Feature | Description |
+|---------|-------------|
+| **⚙️ Advanced Settings Tab** | New Advanced tab exposing whisper.cpp anti-hallucination parameters |
+| **🔌 IBus Hardening** | Engine readiness probe, runtime failure recovery, proper destruction on layout switch |
+| **🎤 Recognition Reliability** | Preserve final speech on stop and improved stop-sound timing |
+| **📦 Distro Compatibility** | Hardened Debian layer, corrected openSUSE deps, Python 3.14 support |
+| **🔧 Installer Fixes** | pywhispercpp loading repair, proj config validation, reused builds |
+
+### ✨ New Features
+
+- **Advanced Settings tab** — New tab in the Settings dialog exposing whisper.cpp anti-hallucination parameters:
+  - Temperature override
+  - No-speech threshold
+  - Max segment length
+  - Other inference-time parameters for fine-tuning recognition
+
+### 🐛 Bug Fixes
+
+- **IBus**: Probe engine readiness at startup with hardened retries (#391)
+- **IBus**: Handle engine instance destruction on layout switch (#389)
+- **IBus**: Recover from runtime failures gracefully (#411)
+- **Recognition**: Preserve final speech when stopping (#401)
+- **Recognition**: Play stop sound immediately on release (#426) and after audio thread joins (#436)
+- **Install**: Repair pywhispercpp library loading (#433)
+- **Install**: Correct openSUSE Tumbleweed dependencies (#420, #418)
+- **Install**: Harden Debian compatibility layer (#437)
+- **Install**: Validate pyproject.toml/setup.py before local repo mode (#396)
+- **Install**: Reuse existing whispercpp builds (#421)
+- **Install**: Refresh ldconfig after openSUSE typelib install (#438)
+- **whisper.cpp**: Reduce CPU threads and ensure GPU backend builds in dev mode (#439)
+- **Logging**: Clean up runtime log noise and cache hardware detection
+- **Python 3.14 support**: Compatibility fix and lxml>=6.1.0 (#404)
+
+### 🔧 Improvements
+
+- **Installer refresh** — openSUSE fallback handling, Debian compatibility hardening
+- **Test coverage** — Recognition internals, IBus edge cases, CI notification suppression (#410, #414)
+- **Dependency bumps** — Next.js security updates (#399, #429), PostCSS
+- **PyPI docs** — Clarify installation requirements (#423)
+
+See the [full changelog](https://github.com/jatinkrmalik/vocalinux/releases/tag/v0.11.0-beta).
+
+---
+
 ## What's New in v0.10.2-beta
 
 ### 🚀 Highlights
@@ -163,7 +211,7 @@ The installer will:
 ```bash
 cd vocalinux
 git fetch origin
-git checkout v0.10.1-beta
+git checkout v0.11.0-beta
 ./install.sh
 ```
 

--- a/src/vocalinux/version.py
+++ b/src/vocalinux/version.py
@@ -2,8 +2,8 @@
 Version information for Vocalinux.
 """
 
-__version__ = "0.10.2-beta"
-__version_info__ = (0, 10, 2, "beta")
+__version__ = "0.11.0-beta"
+__version_info__ = (0, 11, 0, "beta")
 __author__ = "Jatin K Malik"
 __email__ = "jatinkrmalik@gmail.com"
 __license__ = "GPL-3.0"

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vocalinux-website",
-  "version": "0.10.2",
+  "version": "0.11.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vocalinux-website",
-      "version": "0.10.2",
+      "version": "0.11.0",
       "dependencies": {
         "@types/node": "^20.14.10",
         "@types/react": "^18.3.3",

--- a/web/package.json
+++ b/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vocalinux-website",
-  "version": "0.10.2",
+  "version": "0.11.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/web/src/app/changelog/page.tsx
+++ b/web/src/app/changelog/page.tsx
@@ -6,6 +6,31 @@ import { absoluteUrl, buildPageMetadata } from "@/lib/seo";
 
 const releases = [
   {
+    version: "v0.11.0-beta",
+    date: "2026-05-30",
+    type: "beta",
+    highlights: [
+      "New Advanced Settings tab with whisper.cpp anti-hallucination parameters — temperature, no_speech_threshold, max segment length, and more (PR #415)",
+      "IBus engine readiness probe at startup with hardened retries (PR #391)",
+      "IBus runtime failure recovery without app restart (PR #411)",
+      "IBus engine instance destruction handled on keyboard layout switch (fixes #388, closes #389)",
+      "Preserve final speech on stop — no more truncated transcriptions (fixes #401)",
+      "Play stop sound immediately on release and after audio thread joins (PR #426, #436)",
+      "Repair pywhispercpp library loading in installer (PR #433)",
+      "Reduce whisper.cpp CPU threads and ensure GPU backend builds in dev mode (PR #439)",
+      "Correct openSUSE Tumbleweed dependencies with fallback handling (PR #418, #420)",
+      "Harden Debian compatibility layer in installer (PR #437)",
+      "Add Python 3.14 support and bump lxml>=6.1.0 (fixes #404)",
+      "Validate pyproject.toml/setup.py content before entering local repo mode (fixes #396)",
+      "Reuse existing whispercpp builds during install (PR #421)",
+      "Refresh ldconfig after openSUSE typelib install, clarify python3XY placeholder convention (PR #438)",
+      "Clean up runtime log noise and cache hardware detection",
+      "Test coverage: recognition internals, IBus edge cases, CI notification suppression (PR #410, #414)",
+      "Clarify PyPI installation requirements (PR #423)",
+      "Dependency bumps: Next.js security updates (PR #399, #429), PostCSS",
+    ],
+  },
+  {
     version: "v0.10.2-beta",
     date: "2026-04-08",
     type: "beta",
@@ -222,7 +247,7 @@ export default function ChangelogPage() {
     headline: "Vocalinux Changelog - Release History",
     description:
       "Complete release history for Vocalinux, the offline voice dictation software for Linux.",
-    dateModified: "2026-03-30",
+    dateModified: "2026-05-30",
     author: {
       "@type": "Person",
       name: "Jatin K Malik",

--- a/web/src/app/page.tsx
+++ b/web/src/app/page.tsx
@@ -64,7 +64,7 @@ const homeJsonLd = [
     },
     description:
       "Offline voice dictation and speech-to-text for Linux with whisper.cpp and VOSK.",
-    "softwareVersion": "0.10.2-beta",
+    "softwareVersion": "0.11.0-beta",
     author: {
       "@type": "Person",
       name: "Jatin K Malik",
@@ -310,7 +310,7 @@ export default function HomePage() {
             />
             <span className="font-bold text-lg sm:text-xl">Vocalinux</span>
             <span className="hidden sm:inline-block text-xs bg-gradient-to-r from-primary/20 to-green-500/20 text-primary border border-primary/30 px-2.5 py-1 rounded-full font-semibold shadow-sm shadow-primary/20">
-              v0.10.2 Beta
+              v0.11.0 Beta
             </span>
           </Link>
 


### PR DESCRIPTION
## Summary

This PR prepares the repository for the **v0.11.0-beta** release — a minor bump from v0.10.2-beta with **24 commits** including new features, bug fixes, and improvements.

## What's New in v0.11.0-beta

### ✨ New Features
- **Advanced Settings tab** — New tab in Settings dialog exposing whisper.cpp anti-hallucination parameters (temperature, no_speech_threshold, max segment length, and more)

### 🐛 Bug Fixes
- **IBus hardening** — Engine readiness probe at startup, runtime failure recovery, proper engine destruction on layout switch
- **Recognition reliability** — Preserve final speech on stop, improved stop-sound playback timing
- **Installer fixes** — pywhispercpp loading repair, Debian compatibility hardening, openSUSE dependency corrections, proj config validation, reused builds
- **Distro compatibility** — Python 3.14 support, lxml>=6.1.0, refresh ldconfig for openSUSE typelib
- **whisper.cpp** — Reduce CPU threads, ensure GPU backend builds in dev mode

### 🔧 Improvements
- Test coverage for recognition internals, IBus edge cases
- Dependency bumps (Next.js, PostCSS)
- PyPI docs clarification

## Files Changed

| File | Change |
|------|--------|
| `src/vocalinux/version.py` | Bump to 0.11.0-beta |
| `README.md` | Update What's New section & Voca Ecosystem version |
| `docs/UPDATE.md` | Add What's New for v0.11.0-beta |
| `docs/RELEASE_PROCESS.md` | Add version history entry |
| `SECURITY.md` | Update supported versions to 0.11.x |
| `web/package.json` | Bump to 0.11.0 |
| `web/package-lock.json` | Bump to 0.11.0 |
| `web/src/app/page.tsx` | Update softwareVersion schema & badge |
| `web/src/app/changelog/page.tsx` | Add v0.11.0-beta release entry |

## Checklist
- [x] All version references updated
- [x] Pre-commit hooks passed (black, isort, flake8)
- [x] Changelog updated
- [x] Documentation updated
- [x] Website version info updated