### PR TITLE
fix(models): correct download size metadata for whisper.cpp and VOSK

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ curl -fsSL raw.githubusercontent.com/jatinkrmalik/vocalinux/main/install.sh -o /
 The installer will:
 - **Auto-detect your hardware** (GPU, RAM, Vulkan support)
 - **Recommend the best engine** for your system
-- **Download the appropriate model** (~39MB for whisper.cpp tiny)
+- **Download the appropriate model** (~74MB for whisper.cpp tiny)
 - **Install neural VAD support** when ONNX Runtime is available
 - **Install in ~1-2 minutes** (vs 5-10 min with old Whisper)
 

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -16,7 +16,7 @@ That's it! The installer handles everything automatically:
 - ✅ Installs whisper.cpp (~1-2 minutes, no heavy dependencies!)
 - ✅ Auto-detects your GPU (AMD, Intel, NVIDIA all supported)
 - ✅ Installs neural VAD support when ONNX Runtime is available
-- ✅ Downloads the tiny model (~39MB)
+- ✅ Downloads the tiny model (~74MB)
 - ✅ Configures everything automatically
 
 > ⏱️ **Installation Time**: ~1-2 minutes (vs 5-10 minutes with old Whisper AI)
@@ -205,7 +205,7 @@ Examples:
    - **VOSK**: Lightweight engine for older systems
 5. **Installs neural VAD support** when ONNX Runtime is available, with a safe amplitude-VAD fallback otherwise
 6. **Downloads speech recognition models**:
-   - whisper.cpp: ~39MB tiny model (or larger if selected)
+   - whisper.cpp: ~74MB tiny model (or larger if selected)
    - Whisper: ~75MB tiny model + PyTorch dependencies (~2.3GB with CUDA)
    - VOSK: ~40MB small model
 7. **Installs desktop integration** (icons, .desktop file)
@@ -215,7 +215,7 @@ Examples:
 
 | Engine | Download Size | Install Time | GPU Support |
 |--------|---------------|--------------|-------------|
-| **whisper.cpp** (default) | ~39-500MB | ~1-2 min | AMD, Intel, NVIDIA (Vulkan) |
+| **whisper.cpp** (default) | ~74-500MB | ~1-2 min | AMD, Intel, NVIDIA (Vulkan) |
 | Whisper (OpenAI) | ~2.3GB+ | ~5-10 min | NVIDIA only (CUDA) |
 | VOSK | ~40MB | ~30 sec | CPU only |
 
@@ -438,7 +438,7 @@ gtk-update-icon-cache -f -t ~/.local/share/icons/hicolor
 **whisper.cpp** is a high-performance C++ port of OpenAI's Whisper speech recognition model. It's now the **default engine** in Vocalinux because it offers significant advantages:
 
 **Performance Benefits:**
-- **10x faster installation** - No 2.3GB PyTorch download (just ~39MB model)
+- **10x faster installation** - No 2.3GB PyTorch download (just ~74MB model)
 - **C++ optimized inference** - Faster than Python-based Whisper
 - **True multi-threading** - Uses all CPU cores (no Python GIL limitations)
 - **Lower memory usage** - More efficient than PyTorch
@@ -450,11 +450,11 @@ gtk-update-icon-cache -f -t ~/.local/share/icons/hicolor
 
 **Models:**
 whisper.cpp uses the same models as OpenAI Whisper, converted to `ggml` format:
-- **tiny** (~39MB) - Fastest, good for real-time dictation
-- **base** (~74MB) - Good balance of speed and accuracy
-- **small** (~244MB) - Better accuracy, still fast
-- **medium** (~769MB) - High accuracy
-- **large** (~1.5GB) - Best accuracy, slower
+- **tiny** (~74MB) - Fastest, good for real-time dictation
+- **base** (~141MB) - Good balance of speed and accuracy
+- **small** (~465MB) - Better accuracy, still fast
+- **medium** (~1.5GB) - High accuracy
+- **large** (~3.0GB) - Best accuracy, slower
 
 ### Checking GPU Support
 

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -116,11 +116,11 @@ Vocalinux now offers **three speech recognition engines**:
    - whisper
    - vosk
 4. Select your **Model Size**:
-   - **tiny** (~39MB) - Fastest, good for real-time dictation
-   - **base** (~74MB) - Good balance
-   - **small** (~244MB) - Better accuracy
-   - **medium** (~769MB) - High accuracy
-   - **large** (~1.5GB) - Best accuracy, slower
+   - **tiny** (~74MB) - Fastest, good for real-time dictation
+   - **base** (~141MB) - Good balance
+   - **small** (~465MB) - Better accuracy
+   - **medium** (~1.5GB) - High accuracy
+   - **large** (~3.0GB) - Best accuracy, slower
 
 ### When to Use Each Model
 

--- a/src/vocalinux/utils/vosk_model_info.py
+++ b/src/vocalinux/utils/vosk_model_info.py
@@ -56,8 +56,6 @@ SUPPORTED_LANGUAGES = {
 
 
 # VOSK model metadata for display
-# The large option uses the same model as medium, because 0.42 seems unavailable
-# TODO @violog: specify correct size for each model
 VOSK_MODEL_INFO = {
     "small": {
         "size_mb": 40,
@@ -76,7 +74,7 @@ VOSK_MODEL_INFO = {
         },
     },
     "medium": {
-        "size_mb": 1800,
+        "size_mb": 1500,
         "desc": "Balanced accuracy/speed",
         "languages": {
             "en-us": "vosk-model-en-us-0.22",
@@ -90,7 +88,7 @@ VOSK_MODEL_INFO = {
         },
     },
     "large": {
-        "size_mb": 1800,
+        "size_mb": 1500,
         "desc": "Same as medium (best available)",
         "languages": {
             "en-us": "vosk-model-en-us-0.22",

--- a/src/vocalinux/utils/whispercpp_model_info.py
+++ b/src/vocalinux/utils/whispercpp_model_info.py
@@ -17,31 +17,31 @@ logger = logging.getLogger(__name__)
 # Models are downloaded from Hugging Face (ggml format)
 WHISPERCPP_MODEL_INFO = {
     "tiny": {
-        "size_mb": 39,
+        "size_mb": 74,
         "params": "39M",
         "desc": "Fastest, lowest accuracy",
         "url": "https://huggingface.co/ggerganov/whisper.cpp/resolve/main/ggml-tiny.bin",
     },
     "base": {
-        "size_mb": 74,
+        "size_mb": 141,
         "params": "74M",
         "desc": "Fast, good for basic use",
         "url": "https://huggingface.co/ggerganov/whisper.cpp/resolve/main/ggml-base.bin",
     },
     "small": {
-        "size_mb": 244,
+        "size_mb": 465,
         "params": "244M",
         "desc": "Balanced speed/accuracy",
         "url": "https://huggingface.co/ggerganov/whisper.cpp/resolve/main/ggml-small.bin",
     },
     "medium": {
-        "size_mb": 769,
+        "size_mb": 1463,
         "params": "769M",
         "desc": "High accuracy, slower",
         "url": "https://huggingface.co/ggerganov/whisper.cpp/resolve/main/ggml-medium.bin",
     },
     "large": {
-        "size_mb": 1550,
+        "size_mb": 2952,
         "params": "1550M",
         "desc": "Highest accuracy, slowest",
         "url": "https://huggingface.co/ggerganov/whisper.cpp/resolve/main/ggml-large-v3.bin",

--- a/web/src/app/compare/page.tsx
+++ b/web/src/app/compare/page.tsx
@@ -10,7 +10,7 @@ const engineTable = [
     speed: "Fastest startup + low latency",
     hardware: "CPU + AMD/Intel/NVIDIA GPU",
     accuracy: "High (best overall balance)",
-    footprint: "Small models available (~39MB tiny)",
+    footprint: "Small models available (~74MB tiny)",
     bestFor: "Most users who want strong speed + quality",
     icon: Zap,
     iconColor: "text-amber-500",

--- a/web/src/app/gpu-acceleration/page.tsx
+++ b/web/src/app/gpu-acceleration/page.tsx
@@ -65,7 +65,7 @@ const gpuBackends = [
 const modelPerformance = [
   {
     model: "tiny",
-    size: "~39MB",
+    size: "~74MB",
     cpuSpeed: "~0.5s",
     gpuSpeed: "~0.2s",
     accuracy: "Good for real-time",
@@ -73,7 +73,7 @@ const modelPerformance = [
   },
   {
     model: "base",
-    size: "~74MB",
+    size: "~141MB",
     cpuSpeed: "~0.8s",
     gpuSpeed: "~0.3s",
     accuracy: "Better accuracy",
@@ -81,7 +81,7 @@ const modelPerformance = [
   },
   {
     model: "small",
-    size: "~244MB",
+    size: "~465MB",
     cpuSpeed: "~1.5s",
     gpuSpeed: "~0.5s",
     accuracy: "High accuracy",
@@ -89,7 +89,7 @@ const modelPerformance = [
   },
   {
     model: "medium",
-    size: "~769MB",
+    size: "~1.5GB",
     cpuSpeed: "~4s",
     gpuSpeed: "~1.2s",
     accuracy: "Very high accuracy",
@@ -97,7 +97,7 @@ const modelPerformance = [
   },
   {
     model: "large",
-    size: "~1.5GB",
+    size: "~3.0GB",
     cpuSpeed: "~8s",
     gpuSpeed: "~2.5s",
     accuracy: "Best accuracy",

--- a/web/src/app/offline/page.tsx
+++ b/web/src/app/offline/page.tsx
@@ -241,7 +241,7 @@ export default function OfflinePage() {
           </li>
         </ul>
         <p className="mt-4 text-sm text-emerald-700 dark:text-emerald-400">
-          Models are downloaded once (39MB-1.5GB depending on size), then all processing happens
+          Models are downloaded once (74MB-3.0GB depending on size), then all processing happens
           locally. No network requests during dictation.
         </p>
       </section>

--- a/web/src/app/page.tsx
+++ b/web/src/app/page.tsx
@@ -1051,7 +1051,7 @@ export default function HomePage() {
                     "10x faster installation (~1-2 min)",
                     "Universal GPU support (AMD/Intel/NVIDIA)",
                     "C++ optimized, true multi-threading",
-                    "Tiny model only ~39MB",
+                    "Tiny model only ~74MB",
                   ].map((item, i) => (
                     <li key={i} className="flex items-center gap-2 text-sm">
                       <CheckCircle2 className="h-4 w-4 text-green-500" />
@@ -1060,7 +1060,7 @@ export default function HomePage() {
                   ))}
                 </ul>
                 <div className="text-sm text-muted-foreground">
-                  <strong>Model sizes:</strong> Tiny (39MB) • Base (74MB) • Small (244MB) • Medium (769MB) • Large (1.5GB)
+                  <strong>Model sizes:</strong> Tiny (74MB) • Base (141MB) • Small (465MB) • Medium (1.5GB) • Large (3.0GB)
                 </div>
                 <div className="mt-4">
                   <Link href="/gpu-acceleration/" className="text-sm font-medium text-primary hover:underline flex items-center gap-1">
@@ -1165,7 +1165,7 @@ export default function HomePage() {
                 question: "What are the system requirements?",
                 answer: (
                   <>
-                    Minimum: 4GB RAM, Python 3.9+, ~200MB disk space. 8GB+ RAM recommended for larger Whisper models. The default whisper.cpp tiny model (~39MB) works great on modest hardware. GPU acceleration is available via Vulkan for AMD, Intel, and NVIDIA GPUs.{" "}
+                    Minimum: 4GB RAM, Python 3.9+, ~200MB disk space. 8GB+ RAM recommended for larger Whisper models. The default whisper.cpp tiny model (~74MB) works great on modest hardware. GPU acceleration is available via Vulkan for AMD, Intel, and NVIDIA GPUs.{" "}
                     <Link href="/install/" className="text-primary hover:underline">View full installation requirements</Link>.
                   </>
                 ),

--- a/web/src/app/whisper-model-guide/page.tsx
+++ b/web/src/app/whisper-model-guide/page.tsx
@@ -15,7 +15,7 @@ import { absoluteUrl, buildPageMetadata } from "@/lib/seo";
 const modelComparison = [
   {
     model: "Tiny",
-    size: "~39MB",
+    size: "~74MB",
     ramCpu: "~0.8-1.2GB",
     ramGpu: "~0.5-0.8GB VRAM",
     accuracy: "Good",
@@ -24,7 +24,7 @@ const modelComparison = [
   },
   {
     model: "Base",
-    size: "~74MB",
+    size: "~141MB",
     ramCpu: "~1.2-1.8GB",
     ramGpu: "~0.8-1.2GB VRAM",
     accuracy: "Good+",
@@ -33,7 +33,7 @@ const modelComparison = [
   },
   {
     model: "Small",
-    size: "~244MB",
+    size: "~465MB",
     ramCpu: "~2-3GB",
     ramGpu: "~1.5-2.5GB VRAM",
     accuracy: "High",
@@ -42,7 +42,7 @@ const modelComparison = [
   },
   {
     model: "Medium",
-    size: "~769MB",
+    size: "~1.5GB",
     ramCpu: "~4-6GB",
     ramGpu: "~3-5GB VRAM",
     accuracy: "Very high",
@@ -51,7 +51,7 @@ const modelComparison = [
   },
   {
     model: "Large",
-    size: "~1.5GB",
+    size: "~3.0GB",
     ramCpu: "~8GB+",
     ramGpu: "~6-10GB VRAM",
     accuracy: "Best",


### PR DESCRIPTION
## Summary
- Fixed incorrect model size display in UI dropdowns for both whisper.cpp and VOSK engines
- whisper.cpp models were showing ~2x smaller sizes than actual downloads (e.g., 39 MB displayed vs 74 MB actual for tiny model)
- VOSK medium/large models adjusted from 1800 MB to 1500 MB to better represent actual downloads

## Changes
- Updated `WHISPERCPP_MODEL_INFO` size_mb values with verified sizes from Hugging Face
- Updated `VOSK_MODEL_INFO` medium/large size_mb values
- Removed outdated TODO comment in vosk_model_info.py

## Root Cause
The whisper.cpp model metadata was using parameter counts (39M, 74M, etc.) as if they were MB values, but actual file sizes are roughly double the parameter count.

## Testing
- All pre-commit hooks passed (black, isort, flake8)
- Existing tests only validate that size_mb exists and is positive, so no test updates needed