### PR TITLE
fix(ui): reduce settings dialog height to prevent overflow on lower-res screens

### DIFF
--- a/src/vocalinux/ui/settings_dialog.py
+++ b/src/vocalinux/ui/settings_dialog.py
@@ -811,7 +811,7 @@ class SettingsDialog(Gtk.Dialog):
         else:
             screen_height = 1080  # Default fallback
             screen_width = 1920
-        dialog_height = int(screen_height * 0.5)
+        dialog_height = int(screen_height * 0.4)
         dialog_width = min(700, int(screen_width * 0.8))
         self.set_default_size(dialog_width, dialog_height)
         self.get_style_context().add_class("settings-dialog")
@@ -1646,7 +1646,7 @@ class SettingsDialog(Gtk.Dialog):
         # Scrollable container for the controls
         scrolled = Gtk.ScrolledWindow()
         scrolled.set_policy(Gtk.PolicyType.NEVER, Gtk.PolicyType.AUTOMATIC)
-        scrolled.set_min_content_height(500)
+        scrolled.set_min_content_height(350)
 
         controls_box = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=12)
 


### PR DESCRIPTION
## Summary
- Reduce settings dialog height ratio from 50% to 40% of viewport height
- Revert Advanced tab scrolled window `min_content_height` from 500px back to 350px

## Problem
The settings dialog was taking up too much vertical space, especially on lower-resolution screens. The `min_content_height(500)` on the Advanced tab's scrolled window (bumped from 350 → 500 in #454 for the Remote Server section) forced the entire dialog to grow beyond its viewport-based height cap on any screen under 1000px tall.

## Changes
| Setting | Before | After |
|---------|--------|-------|
| Dialog height ratio | `screen_height * 0.5` (540px @ 1080p) | `screen_height * 0.4` (432px @ 1080p) |
| Advanced tab `min_content_height` | 500px | 350px |

The scrolled window will scroll internally when content exceeds 350px, which is the correct GTK behavior rather than pushing the whole dialog taller.