### PR TITLE
chore(release): prepare v0.12.0-beta

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,51 +32,41 @@ It's a free, GPLv3-licensed desktop app that lets you dictate text into *any* ap
 
 No internet required. No data leaves your machine. Just speak and type.
 
-## 📚 What's New in v0.11.0-beta
+## 📚 What's New in v0.12.0-beta
 
-> 🎉 **Release: Advanced Settings tab with anti-hallucination parameters, IBus/recognition hardening, and distro compatibility improvements.**
+> 🎉 **Release: Remote API recognition, Silero VAD, and reliability hardening across threading, IBus, settings, installer, and model metadata.**
 
 ### 🚀 Highlights
 
 | Feature | Description |
 |---------|-------------|
-| **⚙️ Advanced Settings Tab** | New Advanced tab with whisper.cpp anti-hallucination parameters (temperature, no_speech_threshold, etc.) |
-| **🔌 IBus Hardening** | Engine readiness probe at startup, runtime failure recovery, and proper engine destruction on layout switch |
-| **🎤 Recognition Reliability** | Preserve final speech on stop and improved stop-sound playback timing |
-| **📦 Distro Compatibility** | Hardened Debian layer, corrected openSUSE Tumbleweed deps, Python 3.14 support |
-| **🔧 Installer Fixes** | Repair pywhispercpp loading, validate proj configs before local repo mode, reuse existing whispercpp builds |
+| **🌐 Remote API Engine** | New speech recognition backend for self-hosted or compatible remote transcription services |
+| **🎙️ Silero VAD** | Neural voice activity detection drops silence-only buffers for cleaner, faster dictation |
+| **🧵 Thread Safety** | Hardened Remote API, IBus, and text injection threading behavior |
+| **🔌 IBus Reliability** | Preserves user engines for dead keys and captures scoped engines during activation |
+| **⚙️ Settings Polish** | Remote Server section now respects the Advanced toggle and the dialog fits lower-resolution screens |
+| **📦 Installer & Models** | CUDA diagnostics include auto-remediation and model download sizes are corrected |
 
 ### ✨ New Features
 
-- **Advanced Settings tab** — New tab in Settings dialog exposing whisper.cpp anti-hallucination parameters:
-  - Temperature override
-  - No-speech threshold
-  - Max segment length
-  - Other inference-time parameters for fine-tuning recognition behavior
+- **Remote API speech recognition engine** — Configure Vocalinux to use compatible remote transcription services while keeping existing local engines available (#335)
+- **Silero VAD** — Neural voice activity detection filters silence-only buffers for cleaner recognition when ONNX Runtime support is installed (#447)
 
 ### 🐛 Bug Fixes
 
-- **IBus**: Probe engine readiness at startup with hardened retries (#391)
-- **IBus**: Handle engine instance destruction on layout switch (#389)
-- **IBus**: Recover from runtime failures gracefully (#411)
-- **Recognition**: Preserve final speech when stopping (#401)
-- **Recognition**: Play stop sound immediately on release (#426) and after audio thread joins (#436)
-- **Install**: Repair pywhispercpp library loading (#433)
-- **Install**: Correct openSUSE Tumbleweed dependencies (#420, #418)
-- **Install**: Harden Debian compatibility layer (#437)
-- **Install**: Validate pyproject.toml/setup.py before local repo mode (#396)
-- **Install**: Reuse existing whispercpp builds (#421)
-- **Install**: Refresh ldconfig after openSUSE typelib install (#438)
-- **whisper.cpp**: Reduce CPU threads and ensure GPU backend builds in dev mode (#439)
-- **Logging**: Clean up runtime log noise and cache hardware detection
-- **Python 3.14 support**: Compatibility fix and lxml>=6.1.0 (#404)
+- **Threading**: Harden Remote API, IBus, and text injection thread safety (#452)
+- **IBus**: Preserve user engines for dead keys and capture the current engine during scoped activation (#457, #458)
+- **UI**: Keep the Remote Server section behind the Advanced toggle and reduce settings dialog height for lower-resolution screens (#454, #456)
+- **Installer**: Harden CUDA diagnostics with auto-remediation and behavioral tests (#451)
+- **Models**: Correct whisper.cpp and VOSK download size metadata (#453)
+- **Startup**: Allow launch without the pynput backend (#448)
+- **Website**: Clarify speech demo browser support (#449)
 
 ### 🔧 Improvements
 
-- **Installer refresh** — openSUSE fallback handling, Debian compatibility hardening
-- **Test coverage** — Recognition internals, IBus edge cases, CI notification suppression (#410, #414)
-- **Dependency bumps** — Next.js security updates (#399, #429), PostCSS (#2753679)
-- **PyPI docs** — Clarify installation requirements (#423)
+- **Developer docs** — Remote API test server instructions for easier backend testing (#455)
+- **Community** — GitHub Sponsors funding configuration added
+- **Behavioral coverage** — CUDA diagnostics and release-facing reliability fixes include targeted tests
 
 ---
 
@@ -393,7 +383,7 @@ Vocalinux is part of a family of privacy-first, offline voice dictation tools. S
 
 | Platform | Project | Website | GitHub | Status |
 |----------|---------|---------|--------|--------|
-| 🐧 Linux | **VocaLinux** | [vocalinux.com](https://vocalinux.com) | [jatinkrmalik/vocalinux](https://github.com/jatinkrmalik/vocalinux) | ✅ Beta v0.11.0 |
+| 🐧 Linux | **VocaLinux** | [vocalinux.com](https://vocalinux.com) | [jatinkrmalik/vocalinux](https://github.com/jatinkrmalik/vocalinux) | ✅ Beta v0.12.0 |
 | 🍎 macOS | **VocaMac** | [vocamac.com](https://vocamac.com) | [jatinkrmalik/vocamac](https://github.com/jatinkrmalik/vocamac) | 🚀 Beta |
 | 🪟 Windows | **VocaWin** | [vocawin.com](https://vocawin.com) | [jatinkrmalik/vocawin](https://github.com/jatinkrmalik/vocawin) | 📋 Planned |
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,7 +4,8 @@
 
 | Version | Supported          |
 | ------- | ------------------ |
-| 0.11.x  | :white_check_mark: |
+| 0.12.x  | :white_check_mark: |
+| 0.11.x  | :x:                |
 | 0.10.x  | :x:                |
 | 0.9.x   | :x:                |
 | 0.8.x   | :x:                |

--- a/docs/RELEASE_PROCESS.md
+++ b/docs/RELEASE_PROCESS.md
@@ -342,6 +342,7 @@ git push origin v0.5.1-beta
 | 0.10.1-beta | 2026-03-27 | Beta | Stability patch: tray resource bundling, engine-switch segfault prevention, settings close action, XKB layout preservation |
 | 0.10.2-beta | 2026-04-08 | Beta | Non-ASCII text injection, IBus Wayland detection, Pop!_OS deps, code quality refactor |
 | 0.11.0-beta | 2026-05-30 | Beta | Advanced Settings tab, IBus/recognition hardening, installer fixes, distro compatibility |
+| 0.12.0-beta | 2026-06-07 | Beta | Remote API engine, Silero VAD, threading/IBus hardening, settings and installer fixes |
 
 ## Questions?
 

--- a/docs/UPDATE.md
+++ b/docs/UPDATE.md
@@ -2,51 +2,41 @@
 
 This guide explains how to update Vocalinux to the latest version.
 
-## What's New in v0.11.0-beta
+## What's New in v0.12.0-beta
 
 ### 🚀 Highlights
 
 | Feature | Description |
 |---------|-------------|
-| **⚙️ Advanced Settings Tab** | New Advanced tab exposing whisper.cpp anti-hallucination parameters |
-| **🔌 IBus Hardening** | Engine readiness probe, runtime failure recovery, proper destruction on layout switch |
-| **🎤 Recognition Reliability** | Preserve final speech on stop and improved stop-sound timing |
-| **📦 Distro Compatibility** | Hardened Debian layer, corrected openSUSE deps, Python 3.14 support |
-| **🔧 Installer Fixes** | pywhispercpp loading repair, proj config validation, reused builds |
+| **🌐 Remote API Engine** | New backend for compatible remote transcription services |
+| **🎙️ Silero VAD** | Neural VAD drops silence-only buffers for cleaner dictation |
+| **🧵 Thread Safety** | Hardened Remote API, IBus, and text injection threading behavior |
+| **🔌 IBus Reliability** | Preserves user engines for dead keys and scoped activation |
+| **⚙️ Settings Polish** | Advanced-only Remote Server controls and lower dialog height |
+| **📦 Installer & Models** | CUDA auto-remediation and corrected model download metadata |
 
 ### ✨ New Features
 
-- **Advanced Settings tab** — New tab in the Settings dialog exposing whisper.cpp anti-hallucination parameters:
-  - Temperature override
-  - No-speech threshold
-  - Max segment length
-  - Other inference-time parameters for fine-tuning recognition
+- **Remote API speech recognition engine** — Configure compatible remote transcription services alongside local engines (#335)
+- **Silero VAD** — Neural voice activity detection filters silence-only buffers when ONNX Runtime support is installed (#447)
 
 ### 🐛 Bug Fixes
 
-- **IBus**: Probe engine readiness at startup with hardened retries (#391)
-- **IBus**: Handle engine instance destruction on layout switch (#389)
-- **IBus**: Recover from runtime failures gracefully (#411)
-- **Recognition**: Preserve final speech when stopping (#401)
-- **Recognition**: Play stop sound immediately on release (#426) and after audio thread joins (#436)
-- **Install**: Repair pywhispercpp library loading (#433)
-- **Install**: Correct openSUSE Tumbleweed dependencies (#420, #418)
-- **Install**: Harden Debian compatibility layer (#437)
-- **Install**: Validate pyproject.toml/setup.py before local repo mode (#396)
-- **Install**: Reuse existing whispercpp builds (#421)
-- **Install**: Refresh ldconfig after openSUSE typelib install (#438)
-- **whisper.cpp**: Reduce CPU threads and ensure GPU backend builds in dev mode (#439)
-- **Logging**: Clean up runtime log noise and cache hardware detection
-- **Python 3.14 support**: Compatibility fix and lxml>=6.1.0 (#404)
+- **Threading**: Harden Remote API, IBus, and text injection thread safety (#452)
+- **IBus**: Preserve user engines for dead keys and capture the current engine during scoped activation (#457, #458)
+- **UI**: Keep the Remote Server section behind the Advanced toggle and reduce settings dialog height (#454, #456)
+- **Installer**: Harden CUDA diagnostics with auto-remediation and behavioral tests (#451)
+- **Models**: Correct whisper.cpp and VOSK download size metadata (#453)
+- **Startup**: Allow launch without the pynput backend (#448)
+- **Website**: Clarify speech demo browser support (#449)
 
 ### 🔧 Improvements
 
-- **Installer refresh** — openSUSE fallback handling, Debian compatibility hardening
-- **Test coverage** — Recognition internals, IBus edge cases, CI notification suppression (#410, #414)
-- **Dependency bumps** — Next.js security updates (#399, #429), PostCSS
-- **PyPI docs** — Clarify installation requirements (#423)
+- **Developer docs** — Remote API test server instructions for backend testing (#455)
+- **Community** — GitHub Sponsors funding configuration added
+- **Behavioral coverage** — CUDA diagnostics and release-facing reliability fixes include targeted tests
 
-See the [full changelog](https://github.com/jatinkrmalik/vocalinux/releases/tag/v0.11.0-beta).
+See the [full changelog](https://github.com/jatinkrmalik/vocalinux/releases/tag/v0.12.0-beta).
 
 ---
 
@@ -212,7 +202,7 @@ The installer will:
 ```bash
 cd vocalinux
 git fetch origin
-git checkout v0.11.0-beta
+git checkout v0.12.0-beta
 ./install.sh
 ```
 

--- a/src/vocalinux/version.py
+++ b/src/vocalinux/version.py
@@ -2,8 +2,8 @@
 Version information for Vocalinux.
 """
 
-__version__ = "0.11.0-beta"
-__version_info__ = (0, 11, 0, "beta")
+__version__ = "0.12.0-beta"
+__version_info__ = (0, 12, 0, "beta")
 __author__ = "Jatin K Malik"
 __email__ = "jatinkrmalik@gmail.com"
 __license__ = "GPL-3.0"

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vocalinux-website",
-  "version": "0.11.0",
+  "version": "0.12.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vocalinux-website",
-      "version": "0.11.0",
+      "version": "0.12.0",
       "dependencies": {
         "@types/node": "^20.14.10",
         "@types/react": "^18.3.3",

--- a/web/package.json
+++ b/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vocalinux-website",
-  "version": "0.11.0",
+  "version": "0.12.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/web/src/app/changelog/page.tsx
+++ b/web/src/app/changelog/page.tsx
@@ -6,6 +6,23 @@ import { absoluteUrl, buildPageMetadata } from "@/lib/seo";
 
 const releases = [
   {
+    version: "v0.12.0-beta",
+    date: "2026-06-07",
+    type: "beta",
+    highlights: [
+      "Remote API speech recognition engine with installation and configuration support (PR #335)",
+      "Silero VAD drops silence-only buffers for cleaner dictation when ONNX Runtime support is available (PR #447)",
+      "Thread safety hardening for Remote API, IBus, and text injection paths (PR #452)",
+      "IBus preserves user engines for dead keys and captures the current engine during scoped activation (PR #457, #458)",
+      "Remote Server settings now respect the Advanced toggle and the settings dialog fits lower-resolution screens (PR #454, #456)",
+      "CUDA diagnostics now include auto-remediation and behavioral tests (PR #451)",
+      "Corrected whisper.cpp and VOSK model download size metadata (PR #453)",
+      "Startup now works without the pynput backend (PR #448)",
+      "Remote API developer test server documentation (PR #455)",
+      "Website speech demo browser support clarification (PR #449) and GitHub Sponsors funding configuration",
+    ],
+  },
+  {
     version: "v0.11.0-beta",
     date: "2026-05-30",
     type: "beta",
@@ -247,7 +264,7 @@ export default function ChangelogPage() {
     headline: "Vocalinux Changelog - Release History",
     description:
       "Complete release history for Vocalinux, the offline voice dictation software for Linux.",
-    dateModified: "2026-05-30",
+    dateModified: "2026-06-07",
     author: {
       "@type": "Person",
       name: "Jatin K Malik",

--- a/web/src/app/page.tsx
+++ b/web/src/app/page.tsx
@@ -64,7 +64,7 @@ const homeJsonLd = [
     },
     description:
       "Offline voice dictation and speech-to-text for Linux with whisper.cpp and VOSK.",
-    "softwareVersion": "0.11.0-beta",
+    "softwareVersion": "0.12.0-beta",
     author: {
       "@type": "Person",
       name: "Jatin K Malik",
@@ -310,7 +310,7 @@ export default function HomePage() {
             />
             <span className="font-bold text-lg sm:text-xl">Vocalinux</span>
             <span className="hidden sm:inline-block text-xs bg-gradient-to-r from-primary/20 to-green-500/20 text-primary border border-primary/30 px-2.5 py-1 rounded-full font-semibold shadow-sm shadow-primary/20">
-              v0.11.0 Beta
+              v0.12.0 Beta
             </span>
           </Link>
 

--- a/web/src/components/code-block.tsx
+++ b/web/src/components/code-block.tsx
@@ -3,17 +3,31 @@
 import React, { useState, useEffect } from "react";
 import dynamic from "next/dynamic";
 
+type SyntaxHighlighterStyle = Record<string, React.CSSProperties>;
+
+type SyntaxHighlighterProps = {
+  children: string;
+  language: string;
+  style: SyntaxHighlighterStyle;
+  className: string;
+  customStyle?: React.CSSProperties;
+  wrapLongLines: boolean;
+};
+
 // Lazy load syntax highlighter to reduce initial bundle size (~84KB savings)
-const SyntaxHighlighter = dynamic(
-  () => import("react-syntax-highlighter").then(mod => mod.default),
+const SyntaxHighlighter = dynamic<SyntaxHighlighterProps>(
+  () =>
+    import("react-syntax-highlighter").then(
+      (mod) => mod.default as React.ComponentType<SyntaxHighlighterProps>,
+    ),
   {
     ssr: false,
     loading: () => (
-      <div className="bg-zinc-900 rounded-lg p-4 text-sm">
-        <pre className="text-green-400 whitespace-pre-wrap">Loading...</pre>
+      <div className="rounded-lg bg-zinc-900 p-4 text-sm">
+        <pre className="whitespace-pre-wrap text-green-400">Loading...</pre>
       </div>
     ),
-  }
+  },
 );
 
 interface CodeBlockProps {
@@ -31,19 +45,22 @@ export function CodeBlock({
   customStyle,
   wrapLongLines = false,
 }: CodeBlockProps) {
-  const [style, setStyle] = useState<any>(null);
+  const [style, setStyle] = useState<SyntaxHighlighterStyle | null>(null);
 
   useEffect(() => {
     // Lazy load the style
-    import("react-syntax-highlighter/dist/esm/styles/hljs").then(mod => {
-      setStyle(mod.atomOneDark);
+    import("react-syntax-highlighter/dist/esm/styles/hljs").then((mod) => {
+      setStyle(mod.atomOneDark as SyntaxHighlighterStyle);
     });
   }, []);
 
   if (!style) {
     return (
-      <div className={`bg-zinc-900 rounded-lg p-4 text-sm ${className}`} style={customStyle}>
-        <pre className="text-green-400 whitespace-pre-wrap">{children}</pre>
+      <div
+        className={`rounded-lg bg-zinc-900 p-4 text-sm ${className}`}
+        style={customStyle}
+      >
+        <pre className="whitespace-pre-wrap text-green-400">{children}</pre>
       </div>
     );
   }

--- a/web/src/types/react-syntax-highlighter.d.ts
+++ b/web/src/types/react-syntax-highlighter.d.ts
@@ -1,0 +1,24 @@
+declare module "react-syntax-highlighter" {
+  import type { ComponentType, CSSProperties, ReactNode } from "react";
+
+  export type SyntaxHighlighterStyle = Record<string, CSSProperties>;
+
+  export interface SyntaxHighlighterProps {
+    children?: ReactNode;
+    language?: string;
+    style?: SyntaxHighlighterStyle;
+    className?: string;
+    customStyle?: CSSProperties;
+    wrapLongLines?: boolean;
+  }
+
+  const SyntaxHighlighter: ComponentType<SyntaxHighlighterProps>;
+
+  export default SyntaxHighlighter;
+}
+
+declare module "react-syntax-highlighter/dist/esm/styles/hljs" {
+  import type { SyntaxHighlighterStyle } from "react-syntax-highlighter";
+
+  export const atomOneDark: SyntaxHighlighterStyle;
+}


### PR DESCRIPTION
## Summary
- Prepare `v0.12.0-beta` based on the feature-level changes since `v0.11.0-beta`, including Remote API recognition and Silero VAD.
- Update Python/web version metadata, release notes, update guide, website changelog/header/schema, release history, and supported security version.
- Add local `react-syntax-highlighter` declarations and type the lazy highlighter so the website typecheck passes for the release branch.

## Why v0.12.0-beta
- The delta since `v0.11.0-beta` includes two new user-facing features (`Remote API` engine and `Silero VAD`) plus threading, IBus, settings UI, installer, model metadata, startup, and web reliability fixes.

## Verification
- `python3 -m py_compile src/vocalinux/version.py`
- `make lint`
- LSP diagnostics on modified Python/TS/TS declaration files
- `npx eslint src/app/page.tsx src/app/changelog/page.tsx src/components/code-block.tsx src/types/react-syntax-highlighter.d.ts` (passes with existing homepage `<img>` warnings only)
- `npm run typecheck`
- `npm run test -- --runInBand`
- `npm run build`

## Notes
- Repo-wide `make typecheck` still reports existing mypy errors outside this release prep; website typecheck now passes.