### PR TITLE
feat(ci): add automatic PR labeling workflow

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,62 @@
+# PR Labeler configuration
+# See https://github.com/actions/labeler for details
+
+# Core Python application (src, packaging, desktop entry)
+app:
+  - changed-files:
+      - any-glob-to-any-file:
+          - "src/**/*"
+          - "pyproject.toml"
+          - "MANIFEST.in"
+          - "vocalinux.desktop"
+
+# Next.js website
+web:
+  - changed-files:
+      - any-glob-to-any-file:
+          - "web/**/*"
+
+# Documentation (docs dir, markdown files, license)
+documentation:
+  - changed-files:
+      - any-glob-to-any-file:
+          - "docs/**/*"
+          - "*.md"
+          - "LICENSE"
+
+# CI/CD, build tooling, scripts, linting config
+ci:
+  - changed-files:
+      - any-glob-to-any-file:
+          - ".github/**/*"
+          - "Makefile"
+          - "scripts/**/*"
+          - ".flake8"
+          - ".pre-commit-config.yaml"
+
+# Test suite
+tests:
+  - changed-files:
+      - any-glob-to-any-file:
+          - "tests/**/*"
+
+# Installer / uninstaller scripts
+installer:
+  - changed-files:
+      - any-glob-to-any-file:
+          - "install.sh"
+          - "uninstall.sh"
+
+# Icons, sounds, screenshots, promo assets
+resources:
+  - changed-files:
+      - any-glob-to-any-file:
+          - "resources/**/*"
+
+# Dependency manifests
+dependencies:
+  - changed-files:
+      - any-glob-to-any-file:
+          - "pyproject.toml"
+          - "web/package.json"
+          - "web/package-lock.json"

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,18 @@
+name: "Pull Request Labeler"
+
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened]
+
+jobs:
+  labeler:
+    permissions:
+      contents: read
+      pull-requests: write
+    runs-on: ubuntu-latest
+    steps:
+      - name: Label PR
+        uses: actions/labeler@v5
+        with:
+          repo-token: "${{ secrets.GITHUB_TOKEN }}"
+          sync-labels: true


### PR DESCRIPTION
## Summary

- Configure `actions/labeler@v5` to automatically label PRs based on file paths
- Add 6 new labels: `app`, `web`, `ci`, `tests`, `installer`, `resources`
- Enable better PR organization and filtering

## Changes

**`.github/labeler.yml`** — Maps file paths to labels:
- `app` → `src/**`, `pyproject.toml`, `MANIFEST.in`, `vocalinux.desktop`
- `web` → `web/**`
- `documentation` → `docs/**`, `*.md`, `LICENSE`
- `ci` → `.github/**`, `Makefile`, `scripts/**`, `.flake8`, `.pre-commit-config.yaml`
- `tests` → `tests/**`
- `installer` → `install.sh`, `uninstall.sh`
- `resources` → `resources/**`
- `dependencies` → `pyproject.toml`, `web/package.json`, `web/package-lock.json`

**`.github/workflows/labeler.yml`** — Runs on PR open/sync/reopen with `sync-labels: true`

## Test plan

- [ ] Open a PR that touches `src/` files → should get `app` label
- [ ] Open a PR that touches `web/` files → should get `web` label
- [ ] Open a PR that touches `tests/` files → should get `tests` label
- [ ] Verify labels are removed when files are no longer changed (sync-labels)