### PR TITLE
Pipe transcriptions through an optional postprocessing script

### DIFF
--- a/README.md
+++ b/README.md
@@ -281,9 +281,14 @@ Configuration is stored in `~/.config/vocalinux/config.json`:
     "model_size": "tiny",
     "vad_sensitivity": 3,
     "silence_timeout": 2.0
+  },
+  "post_processing": {
+    "script_path": ""
   }
 }
 ```
+
+Set `post_processing.script_path` to the path of an executable to transform each transcription result (stdin → stdout) before it is injected. Leave empty to disable.
 
 For whisper.cpp, `model_size` may be a size such as `tiny` or an exact ggml model ID
 such as `medium.en-q5_0` or `large-v3-turbo`. You can also configure this through

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -158,6 +158,28 @@ To check which backend is being used, look for these log messages when starting 
 [INFO] whisper.cpp configured with n_threads=16
 ```
 
+### Post-Processing
+
+Vocalinux can pipe each transcription result through a user-defined script before injecting it into your application. This lets you apply custom transformations — for example, grammar correction, abbreviation expansion, or domain-specific formatting.
+
+**To configure:**
+1. Open Settings from the tray icon menu (right-click)
+2. Go to the **Post-Processing** tab
+3. Enter the path to your script, or click **Browse…** to select it
+4. Leave the field empty to disable post-processing
+
+**Script contract:**
+- The script receives the transcription on **stdin**
+- It must write the replacement text to **stdout**
+- A non-zero exit code or a script that times out (10 s) causes the original text to be used unchanged
+
+**Example** — a shell script that uppercases everything:
+```bash
+#!/bin/bash
+tr '[:lower:]' '[:upper:]'
+```
+Make the script executable (`chmod +x`) before setting the path in Vocalinux.
+
 ## Troubleshooting
 
 If you encounter issues, check the [Installation Guide](INSTALL.md) troubleshooting section or run the application with debug logging:

--- a/src/vocalinux/main.py
+++ b/src/vocalinux/main.py
@@ -216,6 +216,7 @@ def main():
     """Main entry point for the application."""
     # Check for single instance BEFORE any initialization
     from . import single_instance
+    from .post_processor import PostProcessor
 
     if not single_instance.acquire_lock():
         # Another instance is already running - show notification and exit
@@ -429,6 +430,12 @@ def main():
             text_to_inject = text.strip()
             if not text_to_inject:
                 return
+
+            post_processor_path = config_manager.get_str("post_processing", "script_path", "")
+            if post_processor_path:
+                text_to_inject = PostProcessor(post_processor_path).process(text_to_inject)
+                if not text_to_inject:
+                    return
 
             # Add a separating space between consecutive dictation segments,
             # but never for the very first segment (avoids unwanted leading space

--- a/src/vocalinux/main.py
+++ b/src/vocalinux/main.py
@@ -216,7 +216,7 @@ def main():
     """Main entry point for the application."""
     # Check for single instance BEFORE any initialization
     from . import single_instance
-    from .post_processor import PostProcessor
+    from .post_processor import apply_post_processing
 
     if not single_instance.acquire_lock():
         # Another instance is already running - show notification and exit
@@ -431,11 +431,9 @@ def main():
             if not text_to_inject:
                 return
 
-            post_processor_path = config_manager.get_str("post_processing", "script_path", "")
-            if post_processor_path:
-                text_to_inject = PostProcessor(post_processor_path).process(text_to_inject)
-                if not text_to_inject:
-                    return
+            text_to_inject = apply_post_processing(text_to_inject, config_manager)
+            if text_to_inject is None:
+                return
 
             # Add a separating space between consecutive dictation segments,
             # but never for the very first segment (avoids unwanted leading space

--- a/src/vocalinux/post_processor.py
+++ b/src/vocalinux/post_processor.py
@@ -1,0 +1,35 @@
+"""Post-processing of transcribed text via an external executable."""
+
+import logging
+import subprocess
+
+logger = logging.getLogger(__name__)
+
+
+class PostProcessor:
+    """Pipes transcribed text through a user-defined executable and returns the output."""
+
+    def __init__(self, script_path: str):
+        self.script_path = script_path
+
+    def process(self, text: str) -> str:
+        """Run the script with text on stdin; return stdout. Falls back to original on failure."""
+        logger.info("Running post-processor: %s", self.script_path)
+        try:
+            result = subprocess.run(
+                [self.script_path],
+                input=text,
+                capture_output=True,
+                text=True,
+                timeout=10,
+            )
+            if result.returncode != 0:
+                logger.warning(
+                    "Post-processor exited %d: %s", result.returncode, result.stderr.strip()
+                )
+                return text
+            logger.info("Post-processor returned: %r", result.stdout[:100])
+            return result.stdout.rstrip("\n")
+        except Exception as e:
+            logger.warning("Post-processor failed: %s", e)
+            return text

--- a/src/vocalinux/post_processor.py
+++ b/src/vocalinux/post_processor.py
@@ -33,3 +33,16 @@ class PostProcessor:
         except Exception as e:
             logger.warning("Post-processor failed: %s", e)
             return text
+
+
+def apply_post_processing(text: str, config_manager) -> "str | None":
+    """Apply post-processing script to text if configured.
+
+    Returns processed text, or None to signal the caller should skip injection.
+    Returns original text unchanged when no script is configured.
+    """
+    script_path = config_manager.get_str("post_processing", "script_path", "")
+    if not script_path:
+        return text
+    result = PostProcessor(script_path).process(text)
+    return result if result else None

--- a/src/vocalinux/ui/config_manager.py
+++ b/src/vocalinux/ui/config_manager.py
@@ -57,6 +57,9 @@ DEFAULT_CONFIG = {
     "text_injection": {
         "copy_to_clipboard": False,  # Disabled by default; users can enable in Settings
     },
+    "post_processing": {
+        "script_path": "",  # Path to executable; empty = disabled
+    },
     "advanced": {
         "power_user_mode": False,
         "debug_logging": False,

--- a/src/vocalinux/ui/settings_dialog.py
+++ b/src/vocalinux/ui/settings_dialog.py
@@ -1025,6 +1025,12 @@ class SettingsDialog(Gtk.Dialog):
         self.advanced_tab.set_margin_start(16)
         self.advanced_tab.set_margin_end(16)
 
+        self.post_processing_tab = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=12)
+        self.post_processing_tab.set_margin_top(16)
+        self.post_processing_tab.set_margin_bottom(16)
+        self.post_processing_tab.set_margin_start(16)
+        self.post_processing_tab.set_margin_end(16)
+
         # Add tabs to notebook (ordered by importance)
         # Speech Engine tab - most important (what model/language to use)
         speech_engine_label = Gtk.Label(label="Speech Engine")
@@ -1057,6 +1063,11 @@ class SettingsDialog(Gtk.Dialog):
             "Advanced whisper.cpp parameters and settings for power users"
         )
         self.advanced_page_num = notebook.append_page(self.advanced_tab, advanced_label)
+
+        post_processing_label = Gtk.Label(label="Post-Processing")
+        post_processing_label.set_tooltip_text("Run a script to transform transcribed text")
+        notebook.append_page(self.post_processing_tab, post_processing_label)
+
         notebook.connect("switch-page", self._on_settings_page_switched)
 
         self.get_content_area().pack_start(notebook, True, True, 0)
@@ -1072,6 +1083,7 @@ class SettingsDialog(Gtk.Dialog):
         self._build_recognition_section()
         self._build_shortcuts_section()
         self._build_advanced_section()
+        self._build_post_processing_section()
         self._build_test_section()
 
         # Load settings and populate UI
@@ -1984,6 +1996,61 @@ class SettingsDialog(Gtk.Dialog):
 
         self.power_user_switch.connect("state-set", self._on_power_user_toggled)
 
+    def _build_post_processing_section(self):
+        """Build the Post-Processing section."""
+        group = PreferencesGroup(
+            title="Post-Processing Script",
+            description=(
+                "Run an executable on each transcription result. "
+                "The script receives the text on stdin and must write the replacement text to stdout."
+            ),
+        )
+
+        path_box = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=8)
+        self.post_processor_entry = Gtk.Entry()
+        self.post_processor_entry.set_placeholder_text("/path/to/script.sh")
+        self.post_processor_entry.set_tooltip_text(
+            "Path to an executable that transforms transcribed text"
+        )
+        self.post_processor_entry.set_hexpand(True)
+
+        browse_button = Gtk.Button(label="Browse…")
+        browse_button.connect("clicked", self._on_post_processor_browse_clicked)
+
+        path_box.pack_start(self.post_processor_entry, True, True, 0)
+        path_box.pack_start(browse_button, False, False, 0)
+
+        script_row = PreferenceRow(
+            title="Script Path",
+            subtitle="Leave empty to disable post-processing",
+            widget=path_box,
+        )
+        group.add_row(script_row)
+        self.post_processing_tab.pack_start(group, False, False, 0)
+
+        self.post_processor_entry.connect("changed", self._on_post_processor_script_changed)
+
+    def _on_post_processor_browse_clicked(self, widget):
+        dialog = Gtk.FileChooserDialog(
+            title="Select Post-Processing Script",
+            parent=self,
+            action=Gtk.FileChooserAction.OPEN,
+        )
+        dialog.add_buttons(
+            Gtk.STOCK_CANCEL, Gtk.ResponseType.CANCEL,
+            Gtk.STOCK_OPEN, Gtk.ResponseType.OK,
+        )
+        if dialog.run() == Gtk.ResponseType.OK:
+            self.post_processor_entry.set_text(dialog.get_filename())
+        dialog.destroy()
+
+    def _on_post_processor_script_changed(self, widget):
+        if self._initializing or self._applying_settings:
+            return
+        path = widget.get_text().strip()
+        self.config_manager.set("post_processing", "script_path", path)
+        self.config_manager.save_config()
+
     def _build_remote_server_section(self):
         """Build the Remote Server configuration section (shown when Remote API engine is selected)."""
         self.remote_server_group = PreferencesGroup(
@@ -2198,6 +2265,9 @@ class SettingsDialog(Gtk.Dialog):
         self.start_minimized_switch.set_active(start_minimized)
         self.copy_to_clipboard_switch.set_active(copy_to_clipboard)
         self.sound_effects_switch.set_active(self.config_manager.is_sound_effects_enabled())
+
+        post_processing_settings = self.config_manager.get_settings().get("post_processing", {})
+        self.post_processor_entry.set_text(post_processing_settings.get("script_path", ""))
 
         available_engines = get_available_engines()
         available_count = 0

--- a/src/vocalinux/ui/settings_dialog.py
+++ b/src/vocalinux/ui/settings_dialog.py
@@ -2037,8 +2037,10 @@ class SettingsDialog(Gtk.Dialog):
             action=Gtk.FileChooserAction.OPEN,
         )
         dialog.add_buttons(
-            Gtk.STOCK_CANCEL, Gtk.ResponseType.CANCEL,
-            Gtk.STOCK_OPEN, Gtk.ResponseType.OK,
+            Gtk.STOCK_CANCEL,
+            Gtk.ResponseType.CANCEL,
+            Gtk.STOCK_OPEN,
+            Gtk.ResponseType.OK,
         )
         if dialog.run() == Gtk.ResponseType.OK:
             self.post_processor_entry.set_text(dialog.get_filename())

--- a/tests/test_config_manager.py
+++ b/tests/test_config_manager.py
@@ -449,6 +449,10 @@ class TestConfigManager(unittest.TestCase):
         new_config_manager = ConfigManager()
         self.assertFalse(new_config_manager.is_sound_effects_enabled())
 
+    def test_post_processing_script_path_empty_by_default(self):
+        config_manager = ConfigManager()
+        self.assertEqual(config_manager.get_str("post_processing", "script_path", ""), "")
+
 
 class TestTypedAccessors(unittest.TestCase):
     """Tests for typed config accessors."""

--- a/tests/test_post_processor.py
+++ b/tests/test_post_processor.py
@@ -1,0 +1,97 @@
+"""Tests for PostProcessor and apply_post_processing."""
+
+import subprocess
+import unittest
+from unittest.mock import MagicMock, patch
+
+from vocalinux.post_processor import PostProcessor, apply_post_processing
+
+
+def _make_run_result(returncode=0, stdout="", stderr=""):
+    result = MagicMock()
+    result.returncode = returncode
+    result.stdout = stdout
+    result.stderr = stderr
+    return result
+
+
+class TestPostProcessor(unittest.TestCase):
+    def setUp(self):
+        self.patch_run = patch("vocalinux.post_processor.subprocess.run")
+        self.mock_run = self.patch_run.start()
+
+    def tearDown(self):
+        self.patch_run.stop()
+
+    def test_happy_path_strips_trailing_newline(self):
+        self.mock_run.return_value = _make_run_result(stdout="hello\n")
+        result = PostProcessor("/script.sh").process("hello")
+        self.assertEqual(result, "hello")
+
+    def test_multiline_output_only_strips_trailing_newline(self):
+        self.mock_run.return_value = _make_run_result(stdout="a\nb\n")
+        result = PostProcessor("/script.sh").process("a\nb")
+        self.assertEqual(result, "a\nb")
+
+    def test_empty_stdout_returns_empty_string(self):
+        self.mock_run.return_value = _make_run_result(stdout="")
+        result = PostProcessor("/script.sh").process("original")
+        self.assertEqual(result, "")
+
+    def test_nonzero_exit_returns_original(self):
+        self.mock_run.return_value = _make_run_result(returncode=1, stderr="oops")
+        result = PostProcessor("/script.sh").process("original")
+        self.assertEqual(result, "original")
+
+    def test_timeout_returns_original(self):
+        self.mock_run.side_effect = subprocess.TimeoutExpired(cmd="/script.sh", timeout=10)
+        result = PostProcessor("/script.sh").process("original")
+        self.assertEqual(result, "original")
+
+    def test_exception_returns_original(self):
+        self.mock_run.side_effect = OSError("not found")
+        result = PostProcessor("/script.sh").process("original")
+        self.assertEqual(result, "original")
+
+    def test_subprocess_called_with_correct_args(self):
+        self.mock_run.return_value = _make_run_result(stdout="out")
+        PostProcessor("/my/script.sh").process("input text")
+        self.mock_run.assert_called_once_with(
+            ["/my/script.sh"],
+            input="input text",
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+
+
+class TestApplyPostProcessing(unittest.TestCase):
+    def setUp(self):
+        self.patch_processor = patch("vocalinux.post_processor.PostProcessor")
+        self.mock_processor_cls = self.patch_processor.start()
+        self.mock_processor = MagicMock()
+        self.mock_processor_cls.return_value = self.mock_processor
+
+    def tearDown(self):
+        self.patch_processor.stop()
+
+    def _config(self, script_path):
+        config_manager = MagicMock()
+        config_manager.get_str.return_value = script_path
+        return config_manager
+
+    def test_no_script_returns_original_text(self):
+        config_manager = self._config("")
+        result = apply_post_processing("hello", config_manager)
+        self.assertEqual(result, "hello")
+        self.mock_processor_cls.assert_not_called()
+
+    def test_script_configured_returns_processed_text(self):
+        self.mock_processor.process.return_value = "modified"
+        result = apply_post_processing("hello", self._config("/s.sh"))
+        self.assertEqual(result, "modified")
+
+    def test_script_returns_empty_string_gives_none(self):
+        self.mock_processor.process.return_value = ""
+        result = apply_post_processing("hello", self._config("/s.sh"))
+        self.assertIsNone(result)


### PR DESCRIPTION
## Description

Add a configurable post-processing step that passes each transcription
    result to an external executable via stdin and uses its stdout as the
    text to type. Enables custom transforms (formatting, LLM rewriting, etc.)
    without modifying Vocalinux. Falls back to original text on script
    failure or timeout.

## Related Issue

None

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 📖 Documentation update
- [ ] 🧹 Code refactoring
- [ ] ✅ Test update

## Checklist

- [x] My code follows the code style of this project (black, isort)
- [x] I have updated the documentation accordingly
- [x] I have added tests to cover my changes
- [x] All new and existing tests pass locally
- [x] Pre-commit hooks pass

## Screenshots (if applicable)

<img width="832" height="422" alt="image" src="https://github.com/user-attachments/assets/67cbe87f-5d77-4070-96c3-233c68f2ca7b" />

## Additional Notes

<!-- Add any additional notes for reviewers -->
