### PR TITLE
fix(wayland): reliable clipboard copy and ydotool injection on non-US layouts

### DIFF
--- a/src/vocalinux/text_injection/text_injector.py
+++ b/src/vocalinux/text_injection/text_injector.py
@@ -331,11 +331,18 @@ class TextInjector:
         return tools
 
     def _run_clipboard_command(self, tool: str, text: str) -> bool:
+        # NB: wl-copy/xclip/xsel fork a background process that keeps owning the
+        # selection in order to serve it. That child inherits our pipes, so
+        # capturing stderr via subprocess.PIPE makes run() block until the child
+        # exits (i.e. until the clipboard is next overwritten) and then time out
+        # — even though the copy itself succeeded. Redirect to DEVNULL so run()
+        # only waits for the short-lived foreground process.
         if tool == "wl-copy":
             subprocess.run(
                 ["wl-copy", text],
                 check=True,
-                stderr=subprocess.PIPE,
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
                 text=True,
                 timeout=self._clipboard_timeout,
             )
@@ -346,7 +353,8 @@ class TextInjector:
                 ["xclip", "-selection", "clipboard"],
                 input=text,
                 check=True,
-                stderr=subprocess.PIPE,
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
                 text=True,
                 timeout=self._clipboard_timeout,
             )
@@ -357,7 +365,8 @@ class TextInjector:
                 ["xsel", "--clipboard", "--input"],
                 input=text,
                 check=True,
-                stderr=subprocess.PIPE,
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
                 text=True,
                 timeout=self._clipboard_timeout,
             )
@@ -898,18 +907,19 @@ class TextInjector:
         Raises:
             subprocess.CalledProcessError: If the tool fails, with stderr captured
         """
-        # ydotool can only handle ASCII characters because it works at the
-        # evdev keycode level. For non-ASCII text, use clipboard paste instead.
-        if self.wayland_tool == "ydotool" and self._has_non_ascii(text):
-            logger.info(
-                "Text contains non-ASCII characters, using clipboard paste "
-                "for ydotool (evdev keycodes are ASCII-only)"
-            )
+        # ydotool emits *positional* evdev keycodes, so `ydotool type` is
+        # re-interpreted through the active keyboard layout, which it assumes is
+        # US QWERTY. On any other layout (AZERTY, QWERTZ, Dvorak, ...) the text
+        # comes out scrambled (e.g. "message" -> ",essqge" on AZERTY), and
+        # non-ASCII characters are dropped entirely. Always paste via the
+        # clipboard instead: Ctrl+V is layout-independent and Unicode-safe.
+        if self.wayland_tool == "ydotool":
+            logger.info("Using clipboard paste for ydotool (layout-independent, Unicode-safe)")
             if self._inject_via_clipboard_paste(text):
                 return
             logger.warning(
                 "Clipboard paste failed, falling back to ydotool type "
-                "(non-ASCII characters may be dropped)"
+                "(text may be scrambled on non-US layouts)"
             )
 
         if self.wayland_tool == "wtype":

--- a/tests/test_text_injector.py
+++ b/tests/test_text_injector.py
@@ -540,10 +540,16 @@ class TestTextInjector(unittest.TestCase):
     @patch("vocalinux.text_injection.text_injector.is_ibus_available", return_value=False)
     @patch("vocalinux.text_injection.text_injector.shutil.which")
     @patch("vocalinux.text_injection.text_injector.subprocess.run")
-    def test_ydotool_ascii_uses_type_directly(
+    def test_ydotool_ascii_also_uses_clipboard_paste(
         self, mock_run, mock_which, mock_ibus_avail, mock_ibus_active
     ):
-        """Test that ydotool still uses type for plain ASCII text."""
+        """ydotool always pastes via the clipboard, even for plain ASCII.
+
+        `ydotool type` emits positional evdev keycodes that get re-interpreted
+        through the active keyboard layout (assumed US QWERTY), so typing ASCII
+        is scrambled on non-US layouts (e.g. AZERTY). Clipboard paste (Ctrl+V)
+        is layout-independent, so it is used unconditionally for ydotool.
+        """
         mock_which.side_effect = lambda x: x in ("ydotool", "wl-copy")
         mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
 
@@ -557,12 +563,16 @@ class TestTextInjector(unittest.TestCase):
 
             calls = [c.args[0] for c in mock_run.call_args_list if c.args]
             self.assertTrue(
-                any(c[:2] == ["ydotool", "type"] for c in calls),
-                "Should use ydotool type for ASCII text",
+                any(c[0] == "wl-copy" for c in calls),
+                "Should copy ASCII text to the clipboard",
+            )
+            self.assertTrue(
+                any(c[:2] == ["ydotool", "key"] for c in calls),
+                "Should paste with ydotool key (Ctrl+V)",
             )
             self.assertFalse(
-                any(c[0] == "wl-copy" for c in calls),
-                "Should NOT invoke clipboard for ASCII text",
+                any(c[:2] == ["ydotool", "type"] for c in calls),
+                "Should NOT use layout-dependent ydotool type",
             )
 
     @patch("vocalinux.text_injection.text_injector.is_ibus_active_input_method", return_value=False)
@@ -626,6 +636,27 @@ class TestTextInjector(unittest.TestCase):
             calls = [c.args[0] for c in mock_run.call_args_list if c.args]
             has_xsel = any(c[0] == "xsel" for c in calls)
             self.assertTrue(has_xsel, "Should use xsel as fallback")
+
+    @patch("vocalinux.text_injection.text_injector.subprocess.run")
+    def test_clipboard_command_does_not_capture_pipe(self, mock_run):
+        """_run_clipboard_command must not capture the tool's stderr via a pipe.
+
+        wl-copy/xclip/xsel fork a background process that keeps owning the
+        selection; if stderr is captured with subprocess.PIPE the call blocks on
+        the surviving child and times out even though the copy succeeded.
+        Redirecting to DEVNULL avoids that hang (regression guard).
+        """
+        mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
+        injector = TextInjector.__new__(TextInjector)
+        injector._clipboard_timeout = 0.35
+
+        for tool in ("wl-copy", "xclip", "xsel"):
+            mock_run.reset_mock()
+            self.assertTrue(injector._run_clipboard_command(tool, "café"))
+            _, kwargs = mock_run.call_args
+            self.assertEqual(kwargs.get("stdout"), subprocess.DEVNULL)
+            self.assertEqual(kwargs.get("stderr"), subprocess.DEVNULL)
+            self.assertNotEqual(kwargs.get("stderr"), subprocess.PIPE)
 
     @patch("vocalinux.text_injection.text_injector.is_ibus_active_input_method", return_value=False)
     @patch("vocalinux.text_injection.text_injector.is_ibus_available", return_value=False)


### PR DESCRIPTION
## Summary

Fixes two independent text-injection bugs on Wayland that, combined, made dictation produce nothing usable (no text in the focused field, empty clipboard) on a GNOME/Mutter + AZERTY setup.

### 1. Clipboard copy silently failed (`_run_clipboard_command`)

`wl-copy` (and `xclip`/`xsel`) fork a background process that keeps **owning the selection** in order to serve it. That child inherits the pipes created by `subprocess.run(..., stderr=subprocess.PIPE)`, so `run()` blocks reading stderr until the child exits — i.e. until the clipboard is *next overwritten*, which may be never. The call therefore hits `_clipboard_timeout` and `_copy_to_clipboard` returns `False`, **even though the copy actually succeeded**.

Reproduced on a real session:

```
WARNING wl-copy failed: Command '['wl-copy', '...']' timed out after 2.5 seconds
copy_to_clipboard -> False
# ...yet:
$ wl-paste
...the exact text was on the clipboard all along
```

Fix: redirect `stdout`/`stderr` to `DEVNULL` so `run()` only waits for the short-lived foreground process. Measured: `PIPE` → timeout; `DEVNULL` → returns in ~0.06 s with the clipboard correctly set. I couldn't find this one reported elsewhere.

### 2. `ydotool type` scrambles text on non-US layouts (`_inject_with_wayland_tool`)

`ydotool type` emits **positional evdev keycodes** that the compositor re-interprets through the active keyboard layout, which ydotool assumes is US QWERTY. On AZERTY/QWERTZ/Dvorak the output is garbled (e.g. `message` → `,essqge`, `avec` → `qvec`) and non-ASCII characters are dropped.

The code already used clipboard paste for *non-ASCII* text (#362); this extends it to **all** text when the tool is ydotool, since `Ctrl+V` is both layout-independent and Unicode-safe. (`ydotool key` Ctrl+V uses keycodes 29+47, which map to the same physical keys on QWERTY and AZERTY.)

This completes #164: that issue was closed but only the non-ASCII case was actually fixed (via #362) — plain ASCII still garbled on non-US layouts.

## Tests

- `tests/test_text_injector.py` and `tests/test_text_injector_ext.py` pass.
- Updated `test_ydotool_ascii_*` to reflect that ydotool now always pastes.
- Added `test_clipboard_command_does_not_capture_pipe` as a regression guard for the PIPE→DEVNULL fix.
- `black` and `isort` clean.

## Related issues

- Completes #164 (ydotool wrong characters on non-US layouts) — remaining ASCII case.
- Builds on #362 (accented characters via clipboard paste).
- Distinct from #425 (Firefox-specific clipboard fallback on the IBus path) — this is the `wl-copy`/`xclip` PIPE hang plus the `ydotool` ASCII case.
- Context: users land on the `ydotool`/clipboard path largely because the IBus backend is often a silent no-op on Wayland (#478, #380), which is what surfaced both bugs here.

## Notes / scope

- `wtype` keeps its native Unicode typing path (it speaks the Wayland text-input protocol, so it is layout- and Unicode-correct already).
- Clipboard paste necessarily overwrites the user's clipboard for ydotool dictation; this was already the behaviour for accented text and is unavoidable with ydotool on Wayland.
- Deliberately **out of scope** here: the IBus-vs-ydotool backend-selection policy (#478) and the `setxkbmap`-rewrites-XWayland-to-`us` side effect (#474) — kept separate to keep this PR to two self-contained bug fixes.

https://claude.ai/code/session_01EhyratrEE4vDWhriirUB9k
