### PR TITLE
feat(tray): add recent dictation snippets history menu 🤖🤖🤖

### DIFF
--- a/src/vocalinux/main.py
+++ b/src/vocalinux/main.py
@@ -276,6 +276,7 @@ def main():
     from .ui.action_handler import ActionHandler
     from .ui.config_manager import ConfigManager
     from .ui.logging_manager import initialize_logging
+    from .ui.transcription_history import TranscriptionHistory
 
     # Initialize logging manager early
     initialize_logging()
@@ -357,6 +358,10 @@ def main():
 
     advanced_settings = config_manager.get_settings().get("advanced", {})
 
+    history_settings = config_manager.get_settings().get("history", {})
+    history_enabled = history_settings.get("enabled", True)
+    history_max_items = history_settings.get("max_items", 10)
+
     logger.info(f"Final settings: engine={engine}, language={language}, model={model_size}")
     if audio_device_index is not None:
         logger.info(f"Using audio device index={audio_device_index} (from saved config)")
@@ -395,6 +400,16 @@ def main():
         # Initialize action handler
         action_handler = ActionHandler(text_system)
 
+        # Transcription history: an in-memory, newest-first list of recent
+        # dictation snippets surfaced in the tray menu. One snippet == one
+        # dictation session (everything said between start and stop).
+        transcription_history = TranscriptionHistory(
+            max_items=history_max_items, enabled=history_enabled
+        )
+        # Segments dictated during the current session, joined and committed to
+        # history when the session ends (state returns to IDLE).
+        session_segments: list[str] = []
+
         # --- Callback wiring ---------------------------------------------------
         # The speech engine emits three kinds of events, each handled by a
         # dedicated callback registered below:
@@ -430,6 +445,14 @@ def main():
             if not text_to_inject:
                 return
 
+            # Record the recognized segment in history regardless of whether
+            # injection succeeds: recovering text from a failed injection (e.g.
+            # on Wayland compositors where injection can silently no-op) is a
+            # primary reason to keep a history. Stored clean, without the
+            # inter-segment space added below.
+            if transcription_history.enabled:
+                session_segments.append(text_to_inject)
+
             # Add a separating space between consecutive dictation segments,
             # but never for the very first segment (avoids unwanted leading space
             # when starting dictation in an empty text field).
@@ -442,9 +465,16 @@ def main():
                 action_handler.set_last_injected_text(text_to_inject)
 
         def on_state_change(state: RecognitionState) -> None:
-            """Reset the last-injected buffer when a listening session ends."""
+            """Reset the last-injected buffer when a listening session ends.
+
+            Also commits the just-finished dictation session to the
+            transcription history as a single snippet.
+            """
             if state == RecognitionState.IDLE:
                 action_handler.set_last_injected_text("")
+                if session_segments:
+                    transcription_history.add(" ".join(session_segments))
+                    session_segments.clear()
 
         # Connect speech recognition to text injection and action handling
         speech_engine.register_text_callback(text_callback_wrapper)
@@ -455,6 +485,7 @@ def main():
         indicator = tray_indicator.TrayIndicator(
             speech_engine=speech_engine,
             text_injector=text_system,
+            transcription_history=transcription_history,
         )
 
         # Start the GTK main loop

--- a/src/vocalinux/ui/config_manager.py
+++ b/src/vocalinux/ui/config_manager.py
@@ -57,6 +57,10 @@ DEFAULT_CONFIG = {
     "text_injection": {
         "copy_to_clipboard": False,  # Disabled by default; users can enable in Settings
     },
+    "history": {
+        "enabled": True,  # Keep recent dictation snippets in the tray menu
+        "max_items": 10,  # How many snippets to retain (in-memory only, cleared on quit)
+    },
     "advanced": {
         "power_user_mode": False,
         "debug_logging": False,

--- a/src/vocalinux/ui/settings_dialog.py
+++ b/src/vocalinux/ui/settings_dialog.py
@@ -1207,9 +1207,63 @@ class SettingsDialog(Gtk.Dialog):
 
         self.general_tab.pack_start(group, False, False, 0)
 
+        # Transcription history group
+        history_group = PreferencesGroup(
+            title="Transcription History",
+            description="Recent dictation snippets are kept in memory and shown "
+            "in the tray menu. Nothing is written to disk; history clears on quit. "
+            "Changes take effect after restarting Vocalinux.",
+        )
+
+        self.history_enabled_switch = Gtk.Switch()
+        self.history_enabled_switch.set_tooltip_text(
+            "Keep recent dictation snippets in the tray menu for quick re-copying"
+        )
+        history_enabled_row = PreferenceRow(
+            title="Keep History",
+            subtitle="Show recent snippets in the tray menu",
+            widget=self.history_enabled_switch,
+        )
+        history_group.add_row(history_enabled_row)
+
+        self.history_max_items_spin = Gtk.SpinButton.new_with_range(1, 50, 1)
+        self.history_max_items_spin.set_tooltip_text("How many recent snippets to keep")
+        _prevent_scroll_on_hover(self.history_max_items_spin)
+        history_max_items_row = PreferenceRow(
+            title="Snippets to Keep",
+            subtitle="Number of recent snippets retained",
+            widget=self.history_max_items_spin,
+        )
+        history_group.add_row(history_max_items_row)
+
+        self.general_tab.pack_start(history_group, False, False, 0)
+
         self.autostart_switch.connect("state-set", self._on_autostart_toggled)
         self.start_minimized_switch.connect("state-set", self._on_start_minimized_toggled)
         self.copy_to_clipboard_switch.connect("state-set", self._on_copy_to_clipboard_toggled)
+        self.history_enabled_switch.connect("state-set", self._on_history_enabled_toggled)
+        self.history_max_items_spin.connect("value-changed", self._on_history_max_items_changed)
+
+    def _on_history_enabled_toggled(self, widget, state):
+        """Handle toggle of the keep-history switch."""
+        if self._initializing or self._applying_settings:
+            return False
+
+        enabled = bool(state)
+        logger.info(f"Transcription history toggled: {enabled}")
+        self.config_manager.set("history", "enabled", enabled)
+        self.config_manager.save_settings()
+        return False
+
+    def _on_history_max_items_changed(self, widget):
+        """Handle change of the snippets-to-keep spin button."""
+        if self._initializing or self._applying_settings:
+            return
+
+        max_items = widget.get_value_as_int()
+        logger.info(f"Transcription history max items: {max_items}")
+        self.config_manager.set("history", "max_items", max_items)
+        self.config_manager.save_settings()
 
     def _on_autostart_toggled(self, widget, state):
         """Handle toggle of the autostart switch."""
@@ -2189,15 +2243,20 @@ class SettingsDialog(Gtk.Dialog):
         general_settings = self.config_manager.get_settings().get("general", {})
         ui_settings = self.config_manager.get_settings().get("ui", {})
         text_injection_settings = self.config_manager.get_settings().get("text_injection", {})
+        history_settings = self.config_manager.get_settings().get("history", {})
 
         autostart_enabled = general_settings.get("autostart", False)
         start_minimized = ui_settings.get("start_minimized", False)
         copy_to_clipboard = text_injection_settings.get("copy_to_clipboard", False)
+        history_enabled = history_settings.get("enabled", True)
+        history_max_items = history_settings.get("max_items", 10)
 
         self.autostart_switch.set_active(autostart_enabled)
         self.start_minimized_switch.set_active(start_minimized)
         self.copy_to_clipboard_switch.set_active(copy_to_clipboard)
         self.sound_effects_switch.set_active(self.config_manager.is_sound_effects_enabled())
+        self.history_enabled_switch.set_active(history_enabled)
+        self.history_max_items_spin.set_value(history_max_items)
 
         available_engines = get_available_engines()
         available_count = 0

--- a/src/vocalinux/ui/transcription_history.py
+++ b/src/vocalinux/ui/transcription_history.py
@@ -1,0 +1,119 @@
+"""In-memory transcription history for Vocalinux.
+
+Keeps a bounded, newest-first list of recent dictation snippets so the user
+can review and re-copy recent voice input from the tray menu.
+
+The history lives only for the lifetime of the running process — nothing is
+written to disk — so dictated text never persists past the current session.
+This is a deliberate privacy choice: a dictation tool sees everything the user
+types by voice, and that should not silently accumulate in a file.
+"""
+
+import logging
+import threading
+from collections import deque
+from typing import Callable, List, Optional
+
+logger = logging.getLogger(__name__)
+
+# Default number of snippets to retain. Kept small so the tray menu stays
+# readable; configurable via the "history" config section.
+DEFAULT_MAX_ITEMS = 10
+
+
+class TranscriptionHistory:
+    """A bounded, thread-safe, in-memory store of recent dictation snippets.
+
+    A "snippet" is the text of a single dictation session (everything said
+    between starting and stopping voice typing). Entries are stored oldest to
+    newest internally and returned newest-first for display.
+
+    Recording happens on the speech-recognition thread while the tray menu is
+    rebuilt on the GTK main thread, so all access is guarded by a lock. The
+    optional change callback lets the UI refresh when entries are added,
+    cleared, or trimmed; callers are responsible for marshalling that callback
+    onto the correct thread (e.g. via ``GLib.idle_add``).
+    """
+
+    def __init__(self, max_items: int = DEFAULT_MAX_ITEMS, enabled: bool = True):
+        self._max_items = max(1, int(max_items))
+        self._enabled = bool(enabled)
+        self._entries: deque = deque(maxlen=self._max_items)
+        self._lock = threading.Lock()
+        self._change_callback: Optional[Callable[[], None]] = None
+
+    def set_change_callback(self, callback: Optional[Callable[[], None]]) -> None:
+        """Register a callback invoked whenever the history changes."""
+        self._change_callback = callback
+
+    @property
+    def enabled(self) -> bool:
+        """Whether new snippets are being recorded."""
+        return self._enabled
+
+    @property
+    def max_items(self) -> int:
+        """The maximum number of snippets retained."""
+        return self._max_items
+
+    def set_max_items(self, max_items: int) -> None:
+        """Change the retained-snippet cap, trimming oldest entries if needed."""
+        max_items = max(1, int(max_items))
+        with self._lock:
+            if max_items == self._max_items:
+                return
+            self._max_items = max_items
+            # deque(maxlen=...) keeps the rightmost (newest) items on trim.
+            self._entries = deque(self._entries, maxlen=max_items)
+        self._notify()
+
+    def set_enabled(self, enabled: bool) -> None:
+        """Enable or disable recording. Disabling also clears existing entries."""
+        enabled = bool(enabled)
+        with self._lock:
+            if enabled == self._enabled:
+                return
+            self._enabled = enabled
+            if not enabled:
+                self._entries.clear()
+        self._notify()
+
+    def add(self, text: str) -> None:
+        """Add a snippet. No-op when disabled or when text is empty."""
+        if not text:
+            return
+        text = text.strip()
+        if not text:
+            return
+        with self._lock:
+            if not self._enabled:
+                return
+            self._entries.append(text)
+        self._notify()
+
+    def get_all(self) -> List[str]:
+        """Return all snippets, newest first."""
+        with self._lock:
+            return list(reversed(self._entries))
+
+    def clear(self) -> None:
+        """Remove all snippets."""
+        with self._lock:
+            if not self._entries:
+                return
+            self._entries.clear()
+        self._notify()
+
+    def __len__(self) -> int:
+        with self._lock:
+            return len(self._entries)
+
+    def _notify(self) -> None:
+        callback = self._change_callback
+        if callback is None:
+            return
+        try:
+            callback()
+        except Exception:
+            # A misbehaving UI callback must never break recording.
+            logger.exception("Transcription history change callback failed")

--- a/src/vocalinux/ui/tray_indicator.py
+++ b/src/vocalinux/ui/tray_indicator.py
@@ -25,7 +25,7 @@ except (ImportError, ValueError):
         gi.require_version("AyatanaAppindicator3", "0.1")
         from gi.repository import AyatanaAppindicator3 as AppIndicator3
 
-from gi.repository import GdkPixbuf, Gio, GLib, GObject, Gtk
+from gi.repository import Gdk, GdkPixbuf, Gio, GLib, GObject, Gtk
 
 # Import local modules - Use protocols to avoid circular imports
 from ..common_types import RecognitionState, SpeechRecognitionManagerProtocol, TextInjectorProtocol
@@ -34,6 +34,7 @@ from ..utils.resource_manager import ResourceManager
 from .config_manager import ConfigManager
 from .keyboard_shortcuts import KeyboardShortcutManager
 from .settings_dialog import SettingsDialog
+from .transcription_history import TranscriptionHistory
 
 logger = logging.getLogger(__name__)
 
@@ -48,6 +49,9 @@ ICON_DIR = _resource_manager.icons_dir
 DEFAULT_ICON = "vocalinux-microphone-off"
 ACTIVE_ICON = "vocalinux-microphone"
 PROCESSING_ICON = "vocalinux-microphone-process"
+
+# Maximum characters shown for a history snippet label before truncation.
+_HISTORY_LABEL_MAX_CHARS = 50
 
 # /dev/input settle-detection tuning (used after resume)
 _INPUT_SETTLE_SECONDS = 2
@@ -67,6 +71,7 @@ class TrayIndicator:
         self,
         speech_engine: SpeechRecognitionManagerProtocol,
         text_injector: TextInjectorProtocol,
+        transcription_history: Optional[TranscriptionHistory] = None,
     ):
         """
         Initialize the system tray indicator.
@@ -74,11 +79,23 @@ class TrayIndicator:
         Args:
             speech_engine: The speech recognition manager instance
             text_injector: The text injector instance
+            transcription_history: Optional in-memory store of recent dictation
+                snippets. When provided, a "Recent Snippets" submenu is shown.
         """
         self.speech_engine = speech_engine
         self.text_injector = text_injector
+        self.transcription_history = transcription_history
         self.config_manager = ConfigManager()  # Added: Initialize ConfigManager
         self._syncing_autostart_menu = False
+        self._history_menu_item = None
+
+        # Refresh the history submenu whenever the history changes. The change
+        # callback fires on the recognition thread, so marshal onto the GTK
+        # main thread before touching widgets.
+        if self.transcription_history is not None:
+            self.transcription_history.set_change_callback(
+                lambda: GLib.idle_add(self._refresh_history_menu)
+            )
 
         # Get configured shortcut and mode from config
         shortcut = self.config_manager.get_str("shortcuts", "toggle_recognition", "ctrl+ctrl")
@@ -218,6 +235,13 @@ class TrayIndicator:
         self._add_menu_item("Start Voice Typing", self._on_start_clicked)
         self._add_menu_item("Stop Voice Typing", self._on_stop_clicked)
         self._add_menu_separator()
+
+        # Recent snippets submenu (only when history is enabled)
+        if self.transcription_history is not None and self.transcription_history.enabled:
+            self._history_menu_item = Gtk.MenuItem.new_with_label("Recent Snippets")
+            self.menu.append(self._history_menu_item)
+            self._refresh_history_menu()
+            self._add_menu_separator()
 
         self._autostart_menu_item = self._add_menu_checkbox(
             "Start on Login", self._on_autostart_toggled
@@ -459,6 +483,57 @@ class TrayIndicator:
         """Handle click on the Stop Voice Typing menu item."""
         logger.debug("Stop Voice Typing clicked")
         self.speech_engine.stop_recognition()
+
+    def _refresh_history_menu(self):
+        """Rebuild the Recent Snippets submenu from the current history."""
+        if self._history_menu_item is None or self.transcription_history is None:
+            return False  # Remove idle callback
+
+        submenu = Gtk.Menu()
+        entries = self.transcription_history.get_all()
+
+        if not entries:
+            empty_item = Gtk.MenuItem.new_with_label("(no snippets yet)")
+            empty_item.set_sensitive(False)
+            submenu.append(empty_item)
+        else:
+            for entry in entries:
+                item = Gtk.MenuItem.new_with_label(self._truncate_label(entry))
+                item.set_tooltip_text(entry)
+                # The full snippet is passed as connect user-data, so each item
+                # copies its own text (no late-binding closure pitfall).
+                item.connect("activate", self._on_history_item_clicked, entry)
+                submenu.append(item)
+
+            submenu.append(Gtk.SeparatorMenuItem())
+            clear_item = Gtk.MenuItem.new_with_label("Clear History")
+            clear_item.connect("activate", self._on_clear_history_clicked)
+            submenu.append(clear_item)
+
+        submenu.show_all()
+        self._history_menu_item.set_submenu(submenu)
+        return False  # Remove idle callback
+
+    @staticmethod
+    def _truncate_label(text: str) -> str:
+        """Collapse whitespace and truncate a snippet for menu display."""
+        single_line = " ".join(text.split())
+        if len(single_line) > _HISTORY_LABEL_MAX_CHARS:
+            return single_line[: _HISTORY_LABEL_MAX_CHARS - 1].rstrip() + "…"
+        return single_line
+
+    def _on_history_item_clicked(self, widget, text: str):
+        """Copy the selected snippet to the clipboard."""
+        logger.debug("History snippet clicked, copying to clipboard")
+        clipboard = Gtk.Clipboard.get(Gdk.SELECTION_CLIPBOARD)
+        clipboard.set_text(text, -1)
+        clipboard.store()
+
+    def _on_clear_history_clicked(self, widget):
+        """Clear all stored snippets."""
+        logger.debug("Clear history clicked")
+        if self.transcription_history is not None:
+            self.transcription_history.clear()
 
     def _on_settings_clicked(self, widget):
         """Handle click on the Settings menu item."""

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -5,7 +5,7 @@ Tests for the main module functionality.
 import argparse
 import sys
 import unittest
-from unittest.mock import MagicMock, patch
+from unittest.mock import ANY, MagicMock, patch
 
 # Mock GTK modules before importing vocalinux.main
 sys.modules["gi"] = MagicMock()
@@ -247,7 +247,9 @@ class TestMainModule(unittest.TestCase):
             mock_text.assert_called_once_with(wayland_mode=True)
             mock_action_handler.assert_called_once_with(mock_text_instance)
             mock_tray.assert_called_once_with(
-                speech_engine=mock_speech_instance, text_injector=mock_text_instance
+                speech_engine=mock_speech_instance,
+                text_injector=mock_text_instance,
+                transcription_history=ANY,
             )
 
             # Verify callbacks were registered

--- a/tests/test_transcription_history.py
+++ b/tests/test_transcription_history.py
@@ -1,0 +1,119 @@
+"""
+Tests for the in-memory transcription history.
+"""
+
+import unittest
+
+from vocalinux.ui.transcription_history import DEFAULT_MAX_ITEMS, TranscriptionHistory
+
+
+class TestTranscriptionHistory(unittest.TestCase):
+    """Test cases for the TranscriptionHistory store."""
+
+    def test_defaults(self):
+        history = TranscriptionHistory()
+        self.assertEqual(history.max_items, DEFAULT_MAX_ITEMS)
+        self.assertTrue(history.enabled)
+        self.assertEqual(len(history), 0)
+        self.assertEqual(history.get_all(), [])
+
+    def test_add_and_newest_first(self):
+        history = TranscriptionHistory()
+        history.add("first")
+        history.add("second")
+        history.add("third")
+        self.assertEqual(history.get_all(), ["third", "second", "first"])
+        self.assertEqual(len(history), 3)
+
+    def test_add_strips_whitespace(self):
+        history = TranscriptionHistory()
+        history.add("  hello world  ")
+        self.assertEqual(history.get_all(), ["hello world"])
+
+    def test_empty_and_whitespace_ignored(self):
+        history = TranscriptionHistory()
+        history.add("")
+        history.add("   ")
+        history.add(None)  # type: ignore[arg-type]
+        self.assertEqual(len(history), 0)
+
+    def test_max_items_cap_drops_oldest(self):
+        history = TranscriptionHistory(max_items=3)
+        for text in ["a", "b", "c", "d"]:
+            history.add(text)
+        # "a" dropped; newest first.
+        self.assertEqual(history.get_all(), ["d", "c", "b"])
+        self.assertEqual(len(history), 3)
+
+    def test_set_max_items_trims_keeping_newest(self):
+        history = TranscriptionHistory(max_items=5)
+        for text in ["a", "b", "c", "d", "e"]:
+            history.add(text)
+        history.set_max_items(2)
+        self.assertEqual(history.max_items, 2)
+        self.assertEqual(history.get_all(), ["e", "d"])
+
+    def test_max_items_floor_is_one(self):
+        history = TranscriptionHistory(max_items=0)
+        self.assertEqual(history.max_items, 1)
+        history.add("a")
+        history.add("b")
+        self.assertEqual(history.get_all(), ["b"])
+
+    def test_clear(self):
+        history = TranscriptionHistory()
+        history.add("a")
+        history.add("b")
+        history.clear()
+        self.assertEqual(history.get_all(), [])
+        self.assertEqual(len(history), 0)
+
+    def test_disabled_does_not_record(self):
+        history = TranscriptionHistory(enabled=False)
+        self.assertFalse(history.enabled)
+        history.add("ignored")
+        self.assertEqual(len(history), 0)
+
+    def test_set_enabled_false_clears_entries(self):
+        history = TranscriptionHistory()
+        history.add("a")
+        history.set_enabled(False)
+        self.assertFalse(history.enabled)
+        self.assertEqual(len(history), 0)
+        history.add("b")  # still ignored while disabled
+        self.assertEqual(len(history), 0)
+        history.set_enabled(True)
+        history.add("c")
+        self.assertEqual(history.get_all(), ["c"])
+
+    def test_change_callback_fires_on_mutations(self):
+        history = TranscriptionHistory()
+        calls = []
+        history.set_change_callback(lambda: calls.append(1))
+
+        history.add("a")  # fires
+        history.clear()  # fires
+        history.clear()  # no-op, already empty -> no fire
+        self.assertEqual(len(calls), 2)
+
+    def test_change_callback_not_fired_when_disabled_add(self):
+        history = TranscriptionHistory(enabled=False)
+        calls = []
+        history.set_change_callback(lambda: calls.append(1))
+        history.add("a")
+        self.assertEqual(calls, [])
+
+    def test_change_callback_exception_is_swallowed(self):
+        history = TranscriptionHistory()
+
+        def boom():
+            raise RuntimeError("callback failure")
+
+        history.set_change_callback(boom)
+        # Must not propagate.
+        history.add("a")
+        self.assertEqual(history.get_all(), ["a"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_tray_indicator.py
+++ b/tests/test_tray_indicator.py
@@ -547,3 +547,84 @@ class TestTrayIndicator(unittest.TestCase):
             delattr(self.tray_indicator, "menu")
 
         self.tray_indicator._set_menu_item_enabled("Start Voice Typing", True)
+
+    # --- Recent Snippets history menu -------------------------------------
+
+    def test_truncate_label_collapses_and_truncates(self):
+        from vocalinux.ui.tray_indicator import TrayIndicator
+
+        self.assertEqual(TrayIndicator._truncate_label("  a   b\nc  "), "a b c")
+        long = "x" * 200
+        truncated = TrayIndicator._truncate_label(long)
+        self.assertTrue(truncated.endswith("…"))
+        self.assertEqual(len(truncated), 50)
+
+    def test_refresh_history_menu_populated(self):
+        from vocalinux.ui.transcription_history import TranscriptionHistory
+
+        history = TranscriptionHistory()
+        history.add("first snippet")
+        history.add("second snippet")
+        self.tray_indicator.transcription_history = history
+        self.tray_indicator._history_menu_item = MagicMock()
+
+        result = self.tray_indicator._refresh_history_menu()
+
+        self.assertFalse(result)
+        self.tray_indicator._history_menu_item.set_submenu.assert_called_once()
+
+    def test_refresh_history_menu_empty(self):
+        from vocalinux.ui.transcription_history import TranscriptionHistory
+
+        self.tray_indicator.transcription_history = TranscriptionHistory()
+        self.tray_indicator._history_menu_item = MagicMock()
+
+        result = self.tray_indicator._refresh_history_menu()
+
+        self.assertFalse(result)
+        self.tray_indicator._history_menu_item.set_submenu.assert_called_once()
+
+    def test_refresh_history_menu_noop_without_item(self):
+        self.tray_indicator.transcription_history = None
+        self.tray_indicator._history_menu_item = None
+
+        # Should return False and not raise.
+        self.assertFalse(self.tray_indicator._refresh_history_menu())
+
+    def test_on_history_item_clicked_copies_to_clipboard(self):
+        self.tray_indicator._on_history_item_clicked(MagicMock(), "some snippet")
+
+        clipboard = mock_gtk.Clipboard.get.return_value
+        clipboard.set_text.assert_called_once_with("some snippet", -1)
+        clipboard.store.assert_called_once()
+
+    def test_on_clear_history_clicked_clears(self):
+        from vocalinux.ui.transcription_history import TranscriptionHistory
+
+        history = TranscriptionHistory()
+        history.add("a")
+        history.add("b")
+        self.tray_indicator.transcription_history = history
+
+        self.tray_indicator._on_clear_history_clicked(MagicMock())
+
+        self.assertEqual(len(history), 0)
+
+    def test_construct_with_history_creates_submenu_and_wires_callback(self):
+        from vocalinux.ui.transcription_history import TranscriptionHistory
+        from vocalinux.ui.tray_indicator import TrayIndicator
+
+        history = TranscriptionHistory()
+        tray = TrayIndicator(
+            speech_engine=self.mock_speech_engine,
+            text_injector=self.mock_text_injector,
+            transcription_history=history,
+        )
+        tray.shortcut_manager = self.mock_ksm
+
+        # The submenu item is created during _init_indicator.
+        self.assertIsNotNone(tray._history_menu_item)
+        # Adding a snippet fires the change callback, which refreshes the menu
+        # (GLib.idle_add runs synchronously under the test mocks).
+        history.add("live snippet")
+        self.assertTrue(tray._history_menu_item.set_submenu.called)


### PR DESCRIPTION
## Description

Adds a **Recent Snippets** history menu to the system tray indicator. Each completed dictation session is kept as a snippet; clicking one copies its full text to the clipboard, and a **Clear History** entry empties the list. This makes it easy to re-paste something you just dictated, or recover earlier input if a paste went wrong.

Key behaviours:

- **One snippet per dictation session** (everything said between start and stop). Voice commands like "delete that" are *not* recorded — they go through a separate callback path.
- **Recorded on recognition, not on injection success**, so text can be recovered even when injection silently no-ops (e.g. on some Wayland compositors). The history is most valuable precisely when a paste/inject goes wrong, so it must not depend on injection succeeding.
- **In-memory only** — nothing is written to disk; history clears on quit. A deliberate privacy choice for a tool that sees everything the user dictates. (Disk persistence could be added later behind an explicit opt-in.)
- New `history` config section (`enabled`, `max_items`) with a matching **Settings → General → Transcription History** group (toggle + count).

Implementation notes:

- New `vocalinux/ui/transcription_history.py`: a small, thread-safe, bounded (`deque(maxlen=...)`) store with a change-callback. Recording happens on the recognition thread; the tray submenu is rebuilt on the GTK main thread via `GLib.idle_add`.
- `TrayIndicator` gains an optional `transcription_history=` parameter, so existing callers/tests that don't pass it keep working unchanged.

## Related Issue

N/A — no existing issue for this; happy to open one to track it if you'd prefer.

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 📖 Documentation update
- [ ] 🧹 Code refactoring
- [ ] ✅ Test update

## Checklist

- [x] My code follows the code style of this project (black, isort)
- [ ] I have updated the documentation accordingly (no doc change felt necessary — the feature is discoverable in the tray + Settings; glad to add a README note if you'd like)
- [x] I have added tests to cover my changes (`tests/test_transcription_history.py`, plus updated `tests/test_main.py`)
- [x] All new and existing tests pass locally
- [x] Pre-commit hooks pass (`black`, `isort`, `flake8 --select=E9,F63,F7,F82`)

## Screenshots (if applicable)

<!-- Tray "Recent Snippets" submenu — can add a screenshot on request. -->

## Additional Notes

- Verified live on TUXEDO OS / KDE Plasma (Wayland): snippets record per dictation session, appear newest-first in the tray, and copy to the clipboard on click.
- Opted into the agent-assisted fast-track per CONTRIBUTING.md (🤖🤖🤖 in the title).
