### PR TITLE
chore(release): prepare v0.13.0-beta

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,41 +32,39 @@ It's a free, GPLv3-licensed desktop app that lets you dictate text into *any* ap
 
 No internet required. No data leaves your machine. Just speak and type.
 
-## 📚 What's New in v0.12.0-beta
+## 📚 What's New in v0.13.0-beta
 
-> 🎉 **Release: Remote API recognition, Silero VAD, and reliability hardening across threading, IBus, settings, installer, and model metadata.**
+> 🎉 **Release: Guided whisper.cpp model selection, plus Wayland text-injection reliability, hotplug keyboard support, dictation spacing fixes, and refreshed website docs.**
 
 ### 🚀 Highlights
 
 | Feature | Description |
 |---------|-------------|
-| **🌐 Remote API Engine** | New speech recognition backend for self-hosted or compatible remote transcription services |
-| **🎙️ Silero VAD** | Neural voice activity detection drops silence-only buffers for cleaner, faster dictation |
-| **🧵 Thread Safety** | Hardened Remote API, IBus, and text injection threading behavior |
-| **🔌 IBus Reliability** | Preserves user engines for dead keys and captures scoped engines during activation |
-| **⚙️ Settings Polish** | Remote Server section now respects the Advanced toggle and the dialog fits lower-resolution screens |
-| **📦 Installer & Models** | CUDA diagnostics include auto-remediation and model download sizes are corrected |
+| **🎙️ Guided Whisper Models** | Pick a whisper.cpp **size** and **specialization** (English-only, quantized, Turbo) through split dropdowns with in-app guidance |
+| **🔌 Hotplug Keyboard Support** | Shortcuts keep working on keyboards connected after startup, with automatic recovery from disconnects |
+| **✍️ Dictation Spacing** | Spacing is preserved between speech segments separated by a pause in the same session |
+| **🖥️ Wayland Reliability** | Fixes silent text drops on wlroots/COSMIC compositors and garbled output on non-US keyboard layouts |
 
 ### ✨ New Features
 
-- **Remote API speech recognition engine** — Configure Vocalinux to use compatible remote transcription services while keeping existing local engines available (#335)
-- **Silero VAD** — Neural voice activity detection filters silence-only buffers for cleaner recognition when ONNX Runtime support is installed (#447)
+- **Guided whisper.cpp model variants** — The Settings dialog now splits whisper.cpp selection into **Model Size** and **Specialization**, exposing English-only, quantized (Q5/Q8), Large v3 Turbo, and legacy large models with language-aware recommendations and hover guidance. Exact model IDs (e.g. `medium.en-q5_0`, `large-v3-turbo`) can also be passed to `--model` (#465)
 
 ### 🐛 Bug Fixes
 
-- **Threading**: Harden Remote API, IBus, and text injection thread safety (#452)
-- **IBus**: Preserve user engines for dead keys and capture the current engine during scoped activation (#457, #458)
-- **UI**: Keep the Remote Server section behind the Advanced toggle and reduce settings dialog height for lower-resolution screens (#454, #456)
-- **Installer**: Harden CUDA diagnostics with auto-remediation and behavioral tests (#451)
-- **Models**: Correct whisper.cpp and VOSK download size metadata (#453)
-- **Startup**: Allow launch without the pynput backend (#448)
-- **Website**: Clarify speech demo browser support (#449)
+- **Dictation**: Preserve spacing between speech segments separated by a pause, so words no longer run together after a silence within the same session (#464)
+- **Shortcuts**: The evdev keyboard backend rescans for hotplugged keyboards, so shortcuts work on devices connected after startup and disconnected devices can be replugged (#467)
+- **KDE Plasma Wayland**: Detect KDE Plasma Wayland sessions and guide you to enable IBus Wayland (System Settings → Keyboard → Virtual Keyboard) when `wtype` injection fails, with matching hints during install and in logs (#466)
+- **Wayland**: Fix garbled output on non-US keyboard layouts (AZERTY/QWERTZ/Dvorak) and a clipboard-copy hang; ydotool now pastes through the clipboard for layout-independent injection (#480)
+- **Wayland/IBus**: Use wtype/ydotool instead of IBus on compositors that don't bridge IBus to native apps (COSMIC, Sway, Hyprland, and similar), fixing silent text drops (#486)
+- **Wayland/IBus**: Require a real IM engine before using IBus on Wayland, so a bare `xkb` layout no longer causes silent text drops on GNOME/Mutter and other compositors (#478)
+- **Wayland**: Preserve the keyboard layout on Wayland by not running `setxkbmap`, which was flipping XWayland/Electron apps to `us` after dictation (#474)
+- **UI**: Cap the settings dialog height on high-resolution displays (#465)
 
 ### 🔧 Improvements
 
-- **Developer docs** — Remote API test server instructions for easier backend testing (#455)
-- **Community** — GitHub Sponsors funding configuration added
-- **Behavioral coverage** — CUDA diagnostics and release-facing reliability fixes include targeted tests
+- **Performance** — Faster ydotool text injection via an explicit `--key-delay` (#488)
+- **Website** — New documentation pages for Remote API, Silero VAD, advanced whisper.cpp settings, and desktop reliability, plus responsive layout polish (#470)
+- **CI** — Automatic pull-request labeling by changed files (#473)
 
 ---
 
@@ -388,7 +386,7 @@ Vocalinux is part of a family of privacy-first, offline voice dictation tools. S
 
 | Platform | Project | Website | GitHub | Status |
 |----------|---------|---------|--------|--------|
-| 🐧 Linux | **VocaLinux** | [vocalinux.com](https://vocalinux.com) | [jatinkrmalik/vocalinux](https://github.com/jatinkrmalik/vocalinux) | ✅ Beta v0.12.0 |
+| 🐧 Linux | **VocaLinux** | [vocalinux.com](https://vocalinux.com) | [jatinkrmalik/vocalinux](https://github.com/jatinkrmalik/vocalinux) | ✅ Beta v0.13.0 |
 | 🍎 macOS | **VocaMac** | [vocamac.com](https://vocamac.com) | [jatinkrmalik/vocamac](https://github.com/jatinkrmalik/vocamac) | 🚀 Beta |
 | 🪟 Windows | **VocaWin** | [vocawin.com](https://vocawin.com) | [jatinkrmalik/vocawin](https://github.com/jatinkrmalik/vocawin) | 📋 Planned |
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,7 +4,8 @@
 
 | Version | Supported          |
 | ------- | ------------------ |
-| 0.12.x  | :white_check_mark: |
+| 0.13.x  | :white_check_mark: |
+| 0.12.x  | :x:                |
 | 0.11.x  | :x:                |
 | 0.10.x  | :x:                |
 | 0.9.x   | :x:                |

--- a/docs/RELEASE_PROCESS.md
+++ b/docs/RELEASE_PROCESS.md
@@ -343,6 +343,7 @@ git push origin v0.5.1-beta
 | 0.10.2-beta | 2026-04-08 | Beta | Non-ASCII text injection, IBus Wayland detection, Pop!_OS deps, code quality refactor |
 | 0.11.0-beta | 2026-05-30 | Beta | Advanced Settings tab, IBus/recognition hardening, installer fixes, distro compatibility |
 | 0.12.0-beta | 2026-06-07 | Beta | Remote API engine, Silero VAD, threading/IBus hardening, settings and installer fixes |
+| 0.13.0-beta | 2026-06-30 | Beta | Guided whisper.cpp model variants, Wayland text-injection reliability, hotplug keyboard support, dictation spacing fix, website docs refresh |
 
 ## Questions?
 

--- a/docs/UPDATE.md
+++ b/docs/UPDATE.md
@@ -2,6 +2,42 @@
 
 This guide explains how to update Vocalinux to the latest version.
 
+## What's New in v0.13.0-beta
+
+### 🚀 Highlights
+
+| Feature | Description |
+|---------|-------------|
+| **🎙️ Guided Whisper Models** | Pick a whisper.cpp size and specialization (English-only, quantized, Turbo) with in-app guidance |
+| **🔌 Hotplug Keyboard Support** | Shortcuts keep working on keyboards connected after startup |
+| **✍️ Dictation Spacing** | Spacing preserved between speech segments separated by a pause in the same session |
+| **🖥️ Wayland Reliability** | Fixes silent text drops on wlroots/COSMIC compositors and garbled non-US-layout output |
+
+### ✨ New Features
+
+- **Guided whisper.cpp model variants** — The Settings dialog now splits whisper.cpp selection into **Model Size** and **Specialization**, exposing English-only, quantized (Q5/Q8), Large v3 Turbo, and legacy large models with language-aware recommendations and hover guidance. Exact model IDs (e.g. `medium.en-q5_0`, `large-v3-turbo`) can also be passed to `--model` (#465)
+
+### 🐛 Bug Fixes
+
+- **Dictation**: Preserve spacing between speech segments separated by a pause (#464)
+- **Shortcuts**: Rescan for hotplugged keyboards so shortcuts work on devices connected after startup (#467)
+- **KDE Plasma Wayland**: Detect KDE Plasma Wayland sessions and guide you to enable IBus Wayland when `wtype` injection fails (#466)
+- **Wayland**: Fix garbled output on non-US keyboard layouts and a clipboard-copy hang; ydotool now pastes through the clipboard (#480)
+- **Wayland/IBus**: Use wtype/ydotool instead of IBus on compositors that don't bridge IBus to native apps like COSMIC, Sway, and Hyprland (#486)
+- **Wayland/IBus**: Require a real IM engine on Wayland so a bare `xkb` layout no longer causes silent text drops on GNOME/Mutter and similar (#478)
+- **Wayland**: Preserve the keyboard layout on Wayland by not running `setxkbmap` (was flipping XWayland apps to `us`) (#474)
+- **UI**: Cap the settings dialog height on high-resolution displays (#465)
+
+### 🔧 Improvements
+
+- **Performance**: Faster ydotool text injection via an explicit `--key-delay` (#488)
+- **Website**: New documentation pages for Remote API, Silero VAD, advanced whisper.cpp settings, and desktop reliability (#470)
+- **CI**: Automatic pull-request labeling by changed files (#473)
+
+See the [full changelog](https://github.com/jatinkrmalik/vocalinux/releases/tag/v0.13.0-beta).
+
+---
+
 ## What's New in v0.12.0-beta
 
 ### 🚀 Highlights
@@ -202,7 +238,7 @@ The installer will:
 ```bash
 cd vocalinux
 git fetch origin
-git checkout v0.12.0-beta
+git checkout v0.13.0-beta
 ./install.sh
 ```
 

--- a/src/vocalinux/version.py
+++ b/src/vocalinux/version.py
@@ -2,8 +2,8 @@
 Version information for Vocalinux.
 """
 
-__version__ = "0.12.0-beta"
-__version_info__ = (0, 12, 0, "beta")
+__version__ = "0.13.0-beta"
+__version_info__ = (0, 13, 0, "beta")
 __author__ = "Jatin K Malik"
 __email__ = "jatinkrmalik@gmail.com"
 __license__ = "GPL-3.0"

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vocalinux-website",
-  "version": "0.12.0",
+  "version": "0.13.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vocalinux-website",
-      "version": "0.12.0",
+      "version": "0.13.0",
       "dependencies": {
         "@types/node": "^20.14.10",
         "@types/react": "^18.3.3",

--- a/web/package.json
+++ b/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vocalinux-website",
-  "version": "0.12.0",
+  "version": "0.13.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/web/src/app/changelog/page.tsx
+++ b/web/src/app/changelog/page.tsx
@@ -15,6 +15,24 @@ import { absoluteUrl, buildPageMetadata } from "@/lib/seo";
 
 const releases = [
   {
+    version: "v0.13.0-beta",
+    date: "2026-06-30",
+    type: "beta",
+    highlights: [
+      "Guided whisper.cpp model selection: pick a size plus a specialization (English-only, quantized Q5/Q8, or Large v3 Turbo) through split Model Size and Specialization dropdowns with in-app guidance; the --model flag also accepts exact IDs like medium.en-q5_0 and large-v3-turbo (PR #465)",
+      "Dictation now keeps a space between segments spoken with a pause in between, so words no longer run together after a silence (PR #464)",
+      "Keyboard shortcuts now work on keyboards hotplugged after Vocalinux starts, with the evdev backend rescanning for new devices and recovering from disconnects (PR #467)",
+      "Vocalinux now detects KDE Plasma Wayland sessions and points you to enable IBus Wayland for reliable text injection, surfaced during install and when wtype injection fails (PR #466)",
+      "Wayland: fixed garbled text on non-US keyboard layouts (AZERTY/QWERTZ/Dvorak) and a clipboard-copy hang; ydotool now pastes through the clipboard, which is layout-independent (PR #480)",
+      "Wayland: use wtype/ydotool instead of IBus on compositors that don't bridge it to native apps like COSMIC, Sway, and Hyprland, fixing silent text drops (PR #486)",
+      "Wayland/IBus: require a real IM engine before using IBus, so a bare xkb layout no longer causes silent text drops on GNOME/Mutter and other compositors (#478)",
+      "Wayland: keep the keyboard layout intact by not running setxkbmap, which was flipping XWayland apps to us after dictation (#474)",
+      "Faster ydotool text injection via an explicit --key-delay (PR #488)",
+      "Settings dialog height capped on high-resolution displays (PR #465)",
+      "Refreshed website docs with new feature pages for Remote API, Silero VAD, advanced whisper.cpp settings, and desktop reliability, plus responsive layout polish (PR #470)",
+    ],
+  },
+  {
     version: "v0.12.0-beta",
     date: "2026-06-07",
     type: "beta",
@@ -276,7 +294,7 @@ export default function ChangelogPage() {
     headline: "Vocalinux Changelog - Release History",
     description:
       "Complete release history for Vocalinux, the offline voice dictation software for Linux.",
-    dateModified: "2026-06-11",
+    dateModified: "2026-06-30",
     author: {
       "@type": "Person",
       name: "Jatin K Malik",

--- a/web/src/app/page.tsx
+++ b/web/src/app/page.tsx
@@ -68,7 +68,7 @@ const homeJsonLd = [
     },
     description:
       "Offline voice dictation and speech-to-text for Linux with whisper.cpp and VOSK.",
-    softwareVersion: "0.12.0-beta",
+    softwareVersion: "0.13.0-beta",
     author: {
       "@type": "Person",
       name: "Jatin K Malik",
@@ -340,7 +340,7 @@ export default function HomePage() {
             />
             <span className="text-lg font-bold sm:text-xl">Vocalinux</span>
             <span className="from-primary/20 border-primary/30 shadow-primary/20 hidden rounded-full border bg-gradient-to-r to-green-500/20 px-2.5 py-1 text-xs font-semibold text-primary shadow-sm sm:inline-block">
-              v0.12.0 Beta
+              v0.13.0 Beta
             </span>
           </Link>
 


### PR DESCRIPTION
Prepares the repo for the **v0.13.0-beta** release (minor bump from v0.12.0-beta).

The headline is guided whisper.cpp model selection. The rest is reliability work on Wayland text injection and keyboard handling, plus a website docs refresh.

## Version bump
- `src/vocalinux/version.py` → `0.13.0-beta`
- Website metadata: `web/package.json`, `web/package-lock.json`, `web/src/app/page.tsx` (schema + badge)
- `SECURITY.md` supported versions (0.13.x)
- `docs/RELEASE_PROCESS.md` version history
- Release notes: `README.md`, `docs/UPDATE.md`, `web/src/app/changelog/page.tsx`

## What's in this release (since v0.12.0-beta)

**New**
- Guided whisper.cpp model variants: split Model Size + Specialization pickers (English-only, quantized, Turbo, legacy), language-aware recommendations, exact `--model` IDs (#465)

**Fixes**
- Preserve spacing between speech segments separated by a pause (#464)
- Rescan hotplugged keyboards after startup (#467)
- KDE Plasma Wayland: detect the session and guide to IBus Wayland (#466)
- Wayland: fix non-US-layout scrambling and a clipboard-copy hang; ydotool now pastes via the clipboard (#480)
- Wayland/IBus: skip IBus on compositors that don't bridge it to native apps (COSMIC/Sway/Hyprland), fixing silent text drops (#486)
- Cap settings dialog height on high-res displays (#465)

**Improvements**
- Website docs refresh: Remote API, Silero VAD, advanced whisper.cpp settings, and desktop reliability pages (#470)
- Automatic PR labeling workflow (#473)

## Checklist
- [ ] CI green (tests / lint / build / website)
- [ ] Tag `v0.13.0-beta` after merge to trigger the release workflow

Note: #480 and #486 were reviewed and merged into main as part of this release cut, so they're included above.
