### PR TITLE
fix(ibus): don't run setxkbmap on Wayland (#474)

### DIFF
--- a/src/vocalinux/text_injection/ibus_engine.py
+++ b/src/vocalinux/text_injection/ibus_engine.py
@@ -365,6 +365,19 @@ def restore_xkb_layout(layout: str, variant: str = "", option: str = "") -> bool
     if not layout:
         return False
 
+    # On Wayland the compositor owns the keyboard layout. setxkbmap only reaches
+    # the XWayland X11 server, so re-applying a layout here (or the historical
+    # "us" default when nothing was captured) silently switches XWayland — and
+    # therefore XWayland/Electron apps — to the wrong layout, while native
+    # Wayland apps and localectl stay correct. Skip it on Wayland and let the
+    # compositor manage the layout. See issue #474.
+    if _is_wayland_session():
+        logger.debug(
+            "Wayland session detected — skipping setxkbmap; the compositor "
+            "manages the keyboard layout (see #474)."
+        )
+        return False
+
     try:
         cmd = ["setxkbmap", "-layout", layout]
         if variant:
@@ -835,7 +848,10 @@ class IBusTextInjector:
 
         ensure_ibus_dir()
         self._previous_engine: Optional[str] = None
-        self._previous_xkb_layout: tuple = ("us", "", "")
+        # Empty until a real X11 layout is captured. A non-empty default (e.g.
+        # "us") would make stop()/restore re-apply a layout that was never
+        # captured, flipping non-US users to us. See issue #474.
+        self._previous_xkb_layout: tuple = ("", "", "")
 
         if auto_activate:
             self._setup_engine()

--- a/tests/test_ibus_xkb_wayland.py
+++ b/tests/test_ibus_xkb_wayland.py
@@ -1,0 +1,59 @@
+"""Regression tests for issue #474.
+
+On Wayland, Vocalinux must not call ``setxkbmap``. It only reaches the XWayland
+X11 server, so re-applying a layout there leaves XWayland (and XWayland/Electron
+apps) on the wrong layout while native Wayland apps and ``localectl`` stay
+correct — the "layout flips from de to us after dictation" symptom.
+"""
+
+import sys
+import unittest
+from unittest.mock import MagicMock, patch
+
+# Mock GI so importing ibus_engine does not require a real IBus/GTK stack.
+_mock_gi = MagicMock()
+_mock_gi_repo = MagicMock()
+_mock_gi_repo.IBus = MagicMock()
+_mock_gi_repo.GLib = MagicMock()
+_mock_gi_repo.GObject = MagicMock()
+_mock_gi_repo.IBus.Engine = MagicMock
+_mock_gi_repo.GLib.MainLoop = MagicMock
+sys.modules["gi"] = _mock_gi
+sys.modules["gi.repository"] = _mock_gi_repo
+
+for _key in list(sys.modules.keys()):
+    if "vocalinux" in _key and "ibus_engine" in _key:
+        del sys.modules[_key]
+
+from vocalinux.text_injection.ibus_engine import restore_xkb_layout  # noqa: E402
+
+
+class TestRestoreXkbLayoutWayland(unittest.TestCase):
+    """restore_xkb_layout must be a no-op on Wayland (issue #474)."""
+
+    @patch("vocalinux.text_injection.ibus_engine.subprocess.run")
+    @patch.dict("os.environ", {"XDG_SESSION_TYPE": "wayland"}, clear=True)
+    def test_wayland_does_not_call_setxkbmap(self, mock_run):
+        self.assertFalse(restore_xkb_layout("de"))
+        mock_run.assert_not_called()
+
+    @patch("vocalinux.text_injection.ibus_engine.subprocess.run")
+    @patch.dict("os.environ", {"XDG_SESSION_TYPE": "x11"}, clear=True)
+    def test_x11_still_restores_layout(self, mock_run):
+        mock_run.return_value = MagicMock(returncode=0, stderr="")
+        self.assertTrue(restore_xkb_layout("de"))
+        cmds = [c.args[0] for c in mock_run.call_args_list if c.args]
+        self.assertTrue(
+            any(c[:3] == ["setxkbmap", "-layout", "de"] for c in cmds),
+            "X11 should still apply the captured layout",
+        )
+
+    @patch("vocalinux.text_injection.ibus_engine.subprocess.run")
+    @patch.dict("os.environ", {"XDG_SESSION_TYPE": "x11"}, clear=True)
+    def test_empty_layout_is_noop(self, mock_run):
+        self.assertFalse(restore_xkb_layout(""))
+        mock_run.assert_not_called()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Fixes #474.

After you dictate on Wayland, XWayland/Electron apps suddenly switch to the `us` layout, even though your real layout (say `de`) is still fine in native Wayland apps and in `localectl`.

The culprit is our IBus injection path calling `restore_xkb_layout()`, which just shells out to `setxkbmap`. Under Wayland that never touches the compositor, only the XWayland X11 server, so it quietly rewrites XWayland's layout. It lands on `us` for two reasons: `restore_xkb_layout()` runs `setxkbmap` on Wayland at all, and `IBusTextInjector._previous_xkb_layout` starts life as `("us", "", "")` and never gets replaced in the warmup path (`prepare_engine` with `auto_activate=False`), so `stop()` happily re-applies `us`. Credit to @fsioni for tracing the XWayland side of this on the issue.

The fix is to stop calling `setxkbmap` on Wayland at all (the compositor owns the layout there), and to default `_previous_xkb_layout` to `("", "", "")` so we never re-apply a layout we never captured. That second part also removes a latent `us` flip on X11. X11 is otherwise untouched: a layout we did capture still gets restored after engine activation.

Tests are in `tests/test_ibus_xkb_wayland.py`: Wayland doesn't call `setxkbmap`, X11 still restores the captured layout, and an empty layout is a no-op.
