### PR TITLE
fix(whispercpp): don't default to all CPU cores on hybrid processors

### DIFF
--- a/src/vocalinux/speech_recognition/recognition_manager.py
+++ b/src/vocalinux/speech_recognition/recognition_manager.py
@@ -1203,7 +1203,16 @@ class SpeechRecognitionManager:
         elif has_gpu_libs:
             n_threads = max(1, multiprocessing.cpu_count() // 4)
         else:
-            n_threads = min(multiprocessing.cpu_count(), 8)
+            # Leave a couple of cores for the OS and audio capture, and avoid
+            # oversubscribing hybrid CPUs. Using *every* core drags the slow
+            # efficiency cores into the pool; whisper.cpp synchronises all threads
+            # at each decode step, so the barrier stalls on the slowest core and
+            # throughput collapses. On an 8-core hybrid CPU (Intel Core Ultra,
+            # P+E cores) the old `min(cpu_count, 8)` picked 8 = every core and
+            # measured RTF jumped from ~0.14x (6 threads) to ~2.1x (8 threads) —
+            # a ~15x slowdown. Cap at 8; base/small models rarely scale past that.
+            # Users can still override with the `whispercpp_n_threads` setting.
+            n_threads = max(1, min(multiprocessing.cpu_count() - 2, 8))
 
         load_start_time = time.time()
         loaded_backend = backend


### PR DESCRIPTION
## Problem

For CPU-only whisper.cpp, the auto thread count is `min(cpu_count(), 8)`
(`recognition_manager.py`). On an **8-core hybrid CPU** (Intel Core Ultra,
P + E cores) this selects **8 = every core**.

whisper.cpp synchronises all worker threads at each decode step, so pulling the
slow **efficiency** cores into the pool makes every barrier wait on the slowest
core — and leaves nothing for the OS and microphone capture. Throughput
collapses.

### Measured — Core Ultra 7 355 (8 cores, no SMT), `base` model, 6s clip

| n_threads | RTF |
|-----------|------|
| 4 | 0.17x |
| 6 | **0.14x** (optimal) |
| 8 (old default) | **2.13x** 🔴 |

Going 6 → 8 threads is a **~15× slowdown** — transcription becomes *slower than
real time*. In practice dictation latency went from instant to many seconds.
Same pattern is expected on any P/E hybrid (recent Intel Core Ultra, big.LITTLE
Arm, etc.).

## Fix

```python
n_threads = max(1, min(multiprocessing.cpu_count() - 2, 8))
```

Leaves ~2 cores for the OS/audio, never exceeds the previous value on any
machine, and picks **6** on the affected 8-core CPU (the measured optimum). No
new dependencies, no hardware detection. Users can still override with the
`whispercpp_n_threads` config setting.

| CPU | old | new |
|-----|-----|-----|
| 8-core hybrid | 8 🔴 | 6 ✅ |
| 4-core | 4 | 2 |
| 20-core | 8 | 8 |

## Notes

- Cross-checked on a 20-core Arm box (10 perf + 10 eff): a thread sweep peaks at
  ~10 (the performance-core count) and regresses past it — same underlying
  effect, confirming the "don't grab every core" principle.
- A fuller solution could detect performance-core count, but that needs
  per-platform probing; this one-line change removes the sharp cliff with zero
  risk and is easy to review.
