### PR TITLE
style(whispercpp): drop long comment on default thread count

### DIFF
--- a/src/vocalinux/speech_recognition/recognition_manager.py
+++ b/src/vocalinux/speech_recognition/recognition_manager.py
@@ -1266,15 +1266,6 @@ class SpeechRecognitionManager:
         elif has_gpu_libs:
             n_threads = max(1, multiprocessing.cpu_count() // 4)
         else:
-            # Leave a couple of cores for the OS and audio capture, and avoid
-            # oversubscribing hybrid CPUs. Using *every* core drags the slow
-            # efficiency cores into the pool; whisper.cpp synchronises all threads
-            # at each decode step, so the barrier stalls on the slowest core and
-            # throughput collapses. On an 8-core hybrid CPU (Intel Core Ultra,
-            # P+E cores) the old `min(cpu_count, 8)` picked 8 = every core and
-            # measured RTF jumped from ~0.14x (6 threads) to ~2.1x (8 threads) —
-            # a ~15x slowdown. Cap at 8; base/small models rarely scale past that.
-            # Users can still override with the `whispercpp_n_threads` setting.
             n_threads = max(1, min(multiprocessing.cpu_count() - 2, 8))
 
         load_start_time = time.time()


### PR DESCRIPTION
## Summary

Follow-up to #492. Removes the multi-line comment above the CPU-only `n_threads` default.

The heuristic is unchanged:

```python
n_threads = max(1, min(multiprocessing.cpu_count() - 2, 8))
```

Rationale for the change stays in #492 / git history, as requested on that PR.

## Validation of the #492 fix

The formula is correct for the reported hybrid-CPU problem:

| cores | old (`min(n, 8)`) | new (`max(1, min(n-2, 8))`) |
|------:|------------------:|----------------------------:|
| 1 | 1 | 1 |
| 2 | 2 | 1 |
| 4 | 4 | 2 |
| 8 (affected hybrid) | 8 | **6** (measured optimum) |
| 10+ | 8 | 8 |

- Always leaves at least 1 thread
- Never exceeds the previous default
- On the reported 8-core hybrid CPU, picks 6 (matches the author's RTF sweep)
- Still capped at 8 on large machines
- Users can still override with `whispercpp_n_threads`

Trade-off: pure 4-core boxes go 4 → 2 by default, which is more conservative. That is intentional with this simple heuristic; override remains available.

## Test plan

- [x] Related unit tests: `pytest tests/test_whisper_support.py tests/test_recognition_manager_advanced.py`
- [x] CI green on this PR

Refs #492