### PR TITLE
fix(text-injection): restore GNOME Wayland IBus with bare xkb engine

### DIFF
--- a/src/vocalinux/text_injection/text_injector.py
+++ b/src/vocalinux/text_injection/text_injector.py
@@ -244,9 +244,6 @@ class TextInjector:
         # bypassing keyboard layout issues entirely
         if is_ibus_available():
             ibus_active = is_ibus_active_input_method()
-            kde_wayland = (
-                self.environment == DesktopEnvironment.WAYLAND and _is_kde_plasma_session()
-            )
             gtk_im = os.environ.get("GTK_IM_MODULE", "").lower()
             qt_im = os.environ.get("QT_IM_MODULE", "").lower()
             xmodifiers = os.environ.get("XMODIFIERS", "").lower()
@@ -255,15 +252,17 @@ class TextInjector:
                 or (qt_im and "ibus" not in qt_im)
                 or (xmodifiers and "@im=" in xmodifiers and "@im=ibus" not in xmodifiers)
             )
-            kde_wayland_ibus = kde_wayland and not explicit_non_ibus_im
+            # Bridging Wayland DEs (GNOME/KDE): inject_text() switches to the
+            # real vocalinux engine for each commit, so a bare xkb:* baseline is
+            # fine (#501, #504). Unbridged compositors still bail below.
+            wayland_scoped_ibus = (
+                self.environment == DesktopEnvironment.WAYLAND and not explicit_non_ibus_im
+            )
 
             # Check if IBus is the active input method (not just installed)
             # This is important because IBus may be installed but not being used,
-            # e.g., when the user has configured ydotool or Fcitx instead. KDE
-            # Plasma Wayland can still route the Vocalinux engine through IBus
-            # Wayland when its current engine is only an xkb:* layout; GNOME and
-            # other desktops must keep the real-engine guard from issue #478.
-            if not ibus_active and not kde_wayland_ibus:
+            # e.g., when the user has configured ydotool or Fcitx instead.
+            if not ibus_active and not wayland_scoped_ibus:
                 logger.info(
                     "IBus is installed but not the active input method. "
                     "Falling back to alternative text injection method."
@@ -286,10 +285,10 @@ class TextInjector:
                 )
             else:
                 try:
-                    if kde_wayland_ibus and not ibus_active:
+                    if wayland_scoped_ibus and not ibus_active:
                         logger.info(
-                            "KDE Plasma Wayland detected with ibus-daemon running; "
-                            "using IBus Wayland despite the inactive input-method heuristic"
+                            "Wayland with ibus-daemon running; using scoped IBus injection "
+                            "despite bare/inactive baseline engine"
                         )
                     self._ibus_injector = IBusTextInjector(auto_activate=False)
                     ibus_requested = True

--- a/tests/test_text_injector_ext.py
+++ b/tests/test_text_injector_ext.py
@@ -190,7 +190,44 @@ class TestCheckDependencies(unittest.TestCase):
         mock_start.assert_called_once_with()
         self.assertEqual(obj.wayland_tool, "wtype")
 
-    def test_gnome_wayland_keeps_xkb_engine_fallback(self):
+    def test_gnome_wayland_uses_ibus_when_daemon_runs_with_xkb_engine(self):
+        from vocalinux.text_injection.text_injector import DesktopEnvironment
+
+        obj = _make_injector(DesktopEnvironment.WAYLAND)
+        mock_ibus = MagicMock()
+
+        with (
+            patch.dict(
+                os.environ,
+                {"XDG_SESSION_TYPE": "wayland", "XDG_CURRENT_DESKTOP": "GNOME"},
+                clear=True,
+            ),
+            patch("vocalinux.text_injection.text_injector.is_ibus_available", return_value=True),
+            patch(
+                "vocalinux.text_injection.text_injector.is_ibus_active_input_method",
+                return_value=False,
+            ),
+            patch(
+                "vocalinux.text_injection.text_injector.is_ibus_daemon_running",
+                return_value=True,
+            ),
+            patch(
+                "vocalinux.text_injection.text_injector.IBusTextInjector",
+                return_value=mock_ibus,
+            ),
+            patch.object(obj, "_start_ibus_initialization") as mock_start,
+            patch(
+                "shutil.which",
+                side_effect=lambda cmd: "/usr/bin/wtype" if cmd == "wtype" else None,
+            ),
+        ):
+            obj._check_dependencies()
+
+        self.assertIs(obj._ibus_injector, mock_ibus)
+        mock_start.assert_called_once_with()
+        self.assertEqual(obj.wayland_tool, "wtype")
+
+    def test_unbridged_wayland_skips_ibus_when_engine_is_xkb(self):
         from vocalinux.text_injection.text_injector import DesktopEnvironment
 
         obj = _make_injector(DesktopEnvironment.WAYLAND)
@@ -198,7 +235,7 @@ class TestCheckDependencies(unittest.TestCase):
         with (
             patch.dict(
                 os.environ,
-                {"XDG_SESSION_TYPE": "wayland", "XDG_CURRENT_DESKTOP": "GNOME"},
+                {"XDG_SESSION_TYPE": "wayland", "XDG_CURRENT_DESKTOP": "sway"},
                 clear=True,
             ),
             patch("vocalinux.text_injection.text_injector.is_ibus_available", return_value=True),


### PR DESCRIPTION
Fixes #504.

## Problem

On stock GNOME/Mutter Wayland (and similar bridging sessions like Zorin), the active IBus engine is usually a bare `xkb:*` layout. After #478/#491, `is_ibus_active_input_method()` treats that as inactive, so Vocalinux skips IBus and falls back to `wtype`. Mutter does not implement the virtual keyboard protocol, so injection fails and text only lands on the clipboard.

#502 fixed the same failure mode for KDE only, and intentionally left the GNOME real-engine guard in place. That was the wrong call for bridging compositors: injection already switches to the real `vocalinux` engine for each commit, then restores the previous engine. The baseline does not need to be a real IM engine.

## Fix

- On Wayland, if the user has not explicitly chosen another IM (Fcitx, etc.), allow the IBus path whenever `ibus-daemon` is running, even when the baseline engine is only `xkb:*`.
- Keep the compositor denylist for COSMIC/Sway/Hyprland/niri-style sessions that do not bridge IBus.
- Keep respecting explicit non-IBus input methods.
- Collapse the KDE-only exception into this general Wayland rule.

## Validation

- `PYTHONPATH=src pytest tests/test_text_injector_ext.py tests/test_text_injector.py tests/test_ibus_active_engine_guard.py` (all passed)
- `black --check` clean on touched files
- pre-commit hooks passed on commit