### PR TITLE
chore(release): prepare v0.14.0-beta

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,40 +32,37 @@ It's a free, GPLv3-licensed desktop app that lets you dictate text into *any* ap
 
 No internet required. No data leaves your machine. Just speak and type.
 
-## 📚 What's New in v0.13.0-beta
+## 📚 What's New in v0.14.0-beta
 
-> 🎉 **Release: Guided whisper.cpp model selection, plus Wayland text-injection reliability, hotplug keyboard support, dictation spacing fixes, and refreshed website docs.**
+> 🎉 **Release: Configurable keyboard shortcuts, FunASR/SenseVoice remote-API support, and another round of Wayland reliability fixes.**
 
 ### 🚀 Highlights
 
 | Feature | Description |
 |---------|-------------|
-| **🎙️ Guided Whisper Models** | Pick a whisper.cpp **size** and **specialization** (English-only, quantized, Turbo) through split dropdowns with in-app guidance |
-| **🔌 Hotplug Keyboard Support** | Shortcuts keep working on keyboards connected after startup, with automatic recovery from disconnects |
-| **✍️ Dictation Spacing** | Spacing is preserved between speech segments separated by a pause in the same session |
-| **🖥️ Wayland Reliability** | Fixes silent text drops on wlroots/COSMIC compositors and garbled output on non-US keyboard layouts |
+| **⌨️ Configurable Shortcuts** | Bind any modifier combination to a key — e.g. `Alt+R`, `Ctrl+Shift+V`, or `Super+F10` |
+| **🌐 FunASR / SenseVoice Remote API** | Remote-API engine now supports FunASR and SenseVoice models via OpenAI-compatible endpoints |
+| **🖥️ GNOME Wayland IBus Reliability** | Text injection works again on GNOME Wayland with bare `xkb` layouts and engine restore fallbacks are fixed |
+| **🎙️ Audio Crash Fix** | Recording no longer crashes when the system audio device index changes between sessions |
+| **⚡ Hybrid-CPU Efficiency** | whisper.cpp no longer defaults to all cores on hybrid Intel/AMD processors |
 
 ### ✨ New Features
 
-- **Guided whisper.cpp model variants** — The Settings dialog now splits whisper.cpp selection into **Model Size** and **Specialization**, exposing English-only, quantized (Q5/Q8), Large v3 Turbo, and legacy large models with language-aware recommendations and hover guidance. Exact model IDs (e.g. `medium.en-q5_0`, `large-v3-turbo`) can also be passed to `--model` (#465)
-- **Remote API FunASR/SenseVoice support** — OpenAI-compatible remote servers can send a model name (e.g. `sensevoice`) and return richer response shapes; SenseVoice metadata labels are stripped before text injection (#468, #469)
+- **Configurable modifier+key hotkeys** — The Settings dialog now lets you set custom shortcuts using any combination of Ctrl, Alt, Shift, and Super plus a letter/number key. The legacy defaults still work, and you can now bind combinations like `Alt+R` or `Ctrl+Shift+V` (#493)
+- **Remote API FunASR/SenseVoice support** — OpenAI-compatible remote endpoints can specify FunASR/SenseVoice model names (e.g. `sensevoice`) and return richer response shapes; SenseVoice metadata labels are stripped before text injection (#468)
 
 ### 🐛 Bug Fixes
 
-- **Dictation**: Preserve spacing between speech segments separated by a pause, so words no longer run together after a silence within the same session (#464)
-- **Shortcuts**: The evdev keyboard backend rescans for hotplugged keyboards, so shortcuts work on devices connected after startup and disconnected devices can be replugged (#467)
-- **KDE Plasma Wayland**: Detect KDE Plasma Wayland sessions and guide you to enable IBus Wayland (System Settings → Keyboard → Virtual Keyboard) when `wtype` injection fails, with matching hints during install and in logs (#466)
-- **Wayland**: Fix garbled output on non-US keyboard layouts (AZERTY/QWERTZ/Dvorak) and a clipboard-copy hang; ydotool now pastes through the clipboard for layout-independent injection (#480)
-- **Wayland/IBus**: Use wtype/ydotool instead of IBus on compositors that don't bridge IBus to native apps (COSMIC, Sway, Hyprland, and similar), fixing silent text drops (#486)
-- **Wayland/IBus**: Require a real IM engine before using IBus on Wayland, so a bare `xkb` layout no longer causes silent text drops on GNOME/Mutter and other compositors (#478)
-- **Wayland**: Preserve the keyboard layout on Wayland by not running `setxkbmap`, which was flipping XWayland/Electron apps to `us` after dictation (#474)
-- **UI**: Cap the settings dialog height on high-resolution displays (#465)
+- **GNOME Wayland/IBus**: Restore text injection when only a bare `xkb` engine is configured; the engine restore fallback now picks the correct IM engine instead of silently dropping text (#506, #500)
+- **KDE Wayland/IBus**: Restore the KDE Plasma Wayland IBus text-injection path that was regressed in recent compositor-detection changes (#502)
+- **Wayland injection**: Wait for held modifiers (Ctrl/Alt/Shift/Super) to release before injecting text, preventing accidental shortcut triggers and garbled output on modifier-heavy workflows (#494)
+- **whisper.cpp**: Stop defaulting to all CPU cores on hybrid processors (Intel Performance + Efficient cores), which caused UI lag and excess battery drain (#492)
+- **Audio**: Fix a crash on recording start when the selected audio device index no longer matches the current system enumeration (#499)
+- **Installer**: Include `xsel` as a fallback for the Wayland clipboard path when `xclip` is unavailable (#496)
 
 ### 🔧 Improvements
 
-- **Performance** — Faster ydotool text injection via an explicit `--key-delay` (#488)
-- **Website** — New documentation pages for Remote API, Silero VAD, advanced whisper.cpp settings, and desktop reliability, plus responsive layout polish (#470)
-- **CI** — Automatic pull-request labeling by changed files (#473)
+- **Code style** — Removed an outdated long comment about whisper.cpp default thread counts (#505)
 
 ---
 
@@ -387,7 +384,7 @@ Vocalinux is part of a family of privacy-first, offline voice dictation tools. S
 
 | Platform | Project | Website | GitHub | Status |
 |----------|---------|---------|--------|--------|
-| 🐧 Linux | **VocaLinux** | [vocalinux.com](https://vocalinux.com) | [jatinkrmalik/vocalinux](https://github.com/jatinkrmalik/vocalinux) | ✅ Beta v0.13.0 |
+| 🐧 Linux | **VocaLinux** | [vocalinux.com](https://vocalinux.com) | [jatinkrmalik/vocalinux](https://github.com/jatinkrmalik/vocalinux) | ✅ Beta v0.14.0 |
 | 🍎 macOS | **VocaMac** | [vocamac.com](https://vocamac.com) | [jatinkrmalik/vocamac](https://github.com/jatinkrmalik/vocamac) | 🚀 Beta |
 | 🪟 Windows | **VocaWin** | [vocawin.com](https://vocawin.com) | [jatinkrmalik/vocawin](https://github.com/jatinkrmalik/vocawin) | 📋 Planned |
 

--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ No internet required. No data leaves your machine. Just speak and type.
 - **GNOME Wayland/IBus**: Restore text injection when only a bare `xkb` engine is configured; the engine restore fallback now picks the correct IM engine instead of silently dropping text (#506, #500)
 - **KDE Wayland/IBus**: Restore the KDE Plasma Wayland IBus text-injection path that was regressed in recent compositor-detection changes (#502)
 - **Wayland injection**: Wait for held modifiers (Ctrl/Alt/Shift/Super) to release before injecting text, preventing accidental shortcut triggers and garbled output on modifier-heavy workflows (#494)
+- **Shortcuts UI**: Keep preset and custom shortcut selection exclusive — selecting a preset now clears the custom field, and setting a custom combo selects the "Custom Shortcut" preset (#509)
 - **whisper.cpp**: Stop defaulting to all CPU cores on hybrid processors (Intel Performance + Efficient cores), which caused UI lag and excess battery drain (#492)
 - **Audio**: Fix a crash on recording start when the selected audio device index no longer matches the current system enumeration (#499)
 - **Installer**: Include `xsel` as a fallback for the Wayland clipboard path when `xclip` is unavailable (#496)

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,7 +4,8 @@
 
 | Version | Supported          |
 | ------- | ------------------ |
-| 0.13.x  | :white_check_mark: |
+| 0.14.x  | :white_check_mark: |
+| 0.13.x  | :x:                |
 | 0.12.x  | :x:                |
 | 0.11.x  | :x:                |
 | 0.10.x  | :x:                |

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,14 @@
+coverage:
+  status:
+    project:
+      default:
+        target: auto
+        threshold: 0.5%
+    patch:
+      default:
+        target: 80%
+
+comment:
+  layout: "diff, flags, files"
+  behavior: default
+  require_changes: false

--- a/docs/RELEASE_PROCESS.md
+++ b/docs/RELEASE_PROCESS.md
@@ -343,6 +343,7 @@ git push origin v0.5.1-beta
 | 0.10.2-beta | 2026-04-08 | Beta | Non-ASCII text injection, IBus Wayland detection, Pop!_OS deps, code quality refactor |
 | 0.11.0-beta | 2026-05-30 | Beta | Advanced Settings tab, IBus/recognition hardening, installer fixes, distro compatibility |
 | 0.12.0-beta | 2026-06-07 | Beta | Remote API engine, Silero VAD, threading/IBus hardening, settings and installer fixes |
+| 0.14.0-beta | 2026-07-13 | Beta | Configurable modifier+key hotkeys, FunASR/SenseVoice remote-API support, GNOME/KDE Wayland IBus reliability fixes, audio crash fix, hybrid-CPU efficiency fix |
 | 0.13.0-beta | 2026-06-30 | Beta | Guided whisper.cpp model variants, Wayland text-injection reliability, hotplug keyboard support, dictation spacing fix, website docs refresh |
 
 ## Questions?

--- a/docs/RELEASE_PROCESS.md
+++ b/docs/RELEASE_PROCESS.md
@@ -343,8 +343,8 @@ git push origin v0.5.1-beta
 | 0.10.2-beta | 2026-04-08 | Beta | Non-ASCII text injection, IBus Wayland detection, Pop!_OS deps, code quality refactor |
 | 0.11.0-beta | 2026-05-30 | Beta | Advanced Settings tab, IBus/recognition hardening, installer fixes, distro compatibility |
 | 0.12.0-beta | 2026-06-07 | Beta | Remote API engine, Silero VAD, threading/IBus hardening, settings and installer fixes |
-| 0.14.0-beta | 2026-07-13 | Beta | Configurable modifier+key hotkeys, FunASR/SenseVoice remote-API support, GNOME/KDE Wayland IBus reliability fixes, audio crash fix, hybrid-CPU efficiency fix |
 | 0.13.0-beta | 2026-06-30 | Beta | Guided whisper.cpp model variants, Wayland text-injection reliability, hotplug keyboard support, dictation spacing fix, website docs refresh |
+| 0.14.0-beta | 2026-07-13 | Beta | Configurable modifier+key hotkeys, FunASR/SenseVoice remote-API support, GNOME/KDE Wayland IBus reliability fixes, audio crash fix, hybrid-CPU efficiency fix |
 
 ## Questions?
 

--- a/docs/UPDATE.md
+++ b/docs/UPDATE.md
@@ -24,6 +24,7 @@ This guide explains how to update Vocalinux to the latest version.
 - **GNOME Wayland/IBus**: Restore text injection when only a bare `xkb` engine is configured; the engine restore fallback now picks the correct IM engine instead of silently dropping text (#506, #500)
 - **KDE Wayland/IBus**: Restore the KDE Plasma Wayland IBus text-injection path that was regressed in recent compositor-detection changes (#502)
 - **Wayland injection**: Wait for held modifiers (Ctrl/Alt/Shift/Super) to release before injecting text, preventing accidental shortcut triggers and garbled output on modifier-heavy workflows (#494)
+- **Shortcuts UI**: Keep preset and custom shortcut selection exclusive — selecting a preset now clears the custom field, and setting a custom combo selects the "Custom Shortcut" preset (#509)
 - **whisper.cpp**: Stop defaulting to all CPU cores on hybrid processors (Intel Performance + Efficient cores), which caused UI lag and excess battery drain (#492)
 - **Audio**: Fix a crash on recording start when the selected audio device index no longer matches the current system enumeration (#499)
 - **Installer**: Include `xsel` as a fallback for the Wayland clipboard path when `xclip` is unavailable (#496)

--- a/docs/UPDATE.md
+++ b/docs/UPDATE.md
@@ -2,6 +2,40 @@
 
 This guide explains how to update Vocalinux to the latest version.
 
+## What's New in v0.14.0-beta
+
+### 🚀 Highlights
+
+| Feature | Description |
+|---------|-------------|
+| **⌨️ Configurable Shortcuts** | Bind any modifier combination to a key — e.g. `Alt+R`, `Ctrl+Shift+V`, or `Super+F10` |
+| **🌐 FunASR / SenseVoice Remote API** | Remote-API engine now supports FunASR and SenseVoice models via OpenAI-compatible endpoints |
+| **🖥️ GNOME Wayland IBus Reliability** | Text injection works again on GNOME Wayland with bare `xkb` layouts and engine restore fallbacks are fixed |
+| **🎙️ Audio Crash Fix** | Recording no longer crashes when the system audio device index changes between sessions |
+| **⚡ Hybrid-CPU Efficiency** | whisper.cpp no longer defaults to all cores on hybrid Intel/AMD processors |
+
+### ✨ New Features
+
+- **Configurable modifier+key hotkeys** — The Settings dialog now lets you set custom shortcuts using any combination of Ctrl, Alt, Shift, and Super plus a letter/number key. The legacy defaults still work, and you can now bind combinations like `Alt+R` or `Ctrl+Shift+V` (#493)
+- **Remote API FunASR/SenseVoice support** — OpenAI-compatible remote endpoints can specify FunASR/SenseVoice model names (e.g. `sensevoice`) and return richer response shapes; SenseVoice metadata labels are stripped before text injection (#468)
+
+### 🐛 Bug Fixes
+
+- **GNOME Wayland/IBus**: Restore text injection when only a bare `xkb` engine is configured; the engine restore fallback now picks the correct IM engine instead of silently dropping text (#506, #500)
+- **KDE Wayland/IBus**: Restore the KDE Plasma Wayland IBus text-injection path that was regressed in recent compositor-detection changes (#502)
+- **Wayland injection**: Wait for held modifiers (Ctrl/Alt/Shift/Super) to release before injecting text, preventing accidental shortcut triggers and garbled output on modifier-heavy workflows (#494)
+- **whisper.cpp**: Stop defaulting to all CPU cores on hybrid processors (Intel Performance + Efficient cores), which caused UI lag and excess battery drain (#492)
+- **Audio**: Fix a crash on recording start when the selected audio device index no longer matches the current system enumeration (#499)
+- **Installer**: Include `xsel` as a fallback for the Wayland clipboard path when `xclip` is unavailable (#496)
+
+### 🔧 Improvements
+
+- **Code style** — Removed an outdated long comment about whisper.cpp default thread counts (#505)
+
+See the [full changelog](https://github.com/jatinkrmalik/vocalinux/releases/tag/v0.14.0-beta).
+
+---
+
 ## What's New in v0.13.0-beta
 
 ### 🚀 Highlights
@@ -238,7 +272,7 @@ The installer will:
 ```bash
 cd vocalinux
 git fetch origin
-git checkout v0.13.0-beta
+git checkout v0.14.0-beta
 ./install.sh
 ```
 

--- a/src/vocalinux/version.py
+++ b/src/vocalinux/version.py
@@ -2,8 +2,8 @@
 Version information for Vocalinux.
 """
 
-__version__ = "0.13.0-beta"
-__version_info__ = (0, 13, 0, "beta")
+__version__ = "0.14.0-beta"
+__version_info__ = (0, 14, 0, "beta")
 __author__ = "Jatin K Malik"
 __email__ = "jatinkrmalik@gmail.com"
 __license__ = "GPL-3.0"

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vocalinux-website",
-  "version": "0.13.0",
+  "version": "0.14.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vocalinux-website",
-      "version": "0.13.0",
+      "version": "0.14.0",
       "dependencies": {
         "@types/node": "^20.14.10",
         "@types/react": "^18.3.3",

--- a/web/package.json
+++ b/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vocalinux-website",
-  "version": "0.13.0",
+  "version": "0.14.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/web/src/app/changelog/page.tsx
+++ b/web/src/app/changelog/page.tsx
@@ -15,6 +15,22 @@ import { absoluteUrl, buildPageMetadata } from "@/lib/seo";
 
 const releases = [
   {
+    version: "v0.14.0-beta",
+    date: "2026-07-13",
+    type: "beta",
+    highlights: [
+      "Configurable modifier+key hotkeys: set custom shortcuts with any combination of Ctrl, Alt, Shift, and Super plus a letter/number key, e.g. Alt+R or Ctrl+Shift+V (PR #493)",
+      "Remote API engine now supports FunASR/SenseVoice models via OpenAI-compatible endpoints; SenseVoice metadata labels are stripped before text injection (PR #468)",
+      "GNOME Wayland IBus text injection restored when only a bare xkb engine is configured; engine restore fallback now picks the correct IM engine (PR #506, #500)",
+      "KDE Plasma Wayland IBus text-injection path restored after recent compositor-detection regressions (PR #502)",
+      "Wayland text injection now waits for held modifiers to release before typing, preventing accidental shortcut triggers and garbled output (PR #494)",
+      "whisper.cpp no longer defaults to all CPU cores on hybrid processors, improving UI responsiveness and battery life (PR #492)",
+      "Fixed a crash on recording start when the selected audio device index no longer matches the current system enumeration (PR #499)",
+      "Installer includes xsel as a fallback for the Wayland clipboard path when xclip is unavailable (PR #496)",
+      "Removed an outdated long comment about whisper.cpp default thread counts (PR #505)",
+    ],
+  },
+  {
     version: "v0.13.0-beta",
     date: "2026-06-30",
     type: "beta",

--- a/web/src/app/changelog/page.tsx
+++ b/web/src/app/changelog/page.tsx
@@ -24,6 +24,7 @@ const releases = [
       "GNOME Wayland IBus text injection restored when only a bare xkb engine is configured; engine restore fallback now picks the correct IM engine (PR #506, #500)",
       "KDE Plasma Wayland IBus text-injection path restored after recent compositor-detection regressions (PR #502)",
       "Wayland text injection now waits for held modifiers to release before typing, preventing accidental shortcut triggers and garbled output (PR #494)",
+      "Shortcuts UI keeps preset and custom shortcut selection exclusive: selecting a preset clears the custom field, and setting a custom combo selects the Custom Shortcut preset (PR #509)",
       "whisper.cpp no longer defaults to all CPU cores on hybrid processors, improving UI responsiveness and battery life (PR #492)",
       "Fixed a crash on recording start when the selected audio device index no longer matches the current system enumeration (PR #499)",
       "Installer includes xsel as a fallback for the Wayland clipboard path when xclip is unavailable (PR #496)",

--- a/web/src/app/page.tsx
+++ b/web/src/app/page.tsx
@@ -68,7 +68,7 @@ const homeJsonLd = [
     },
     description:
       "Offline voice dictation and speech-to-text for Linux with whisper.cpp and VOSK.",
-    softwareVersion: "0.13.0-beta",
+    softwareVersion: "0.14.0-beta",
     author: {
       "@type": "Person",
       name: "Jatin K Malik",
@@ -340,7 +340,7 @@ export default function HomePage() {
             />
             <span className="text-lg font-bold sm:text-xl">Vocalinux</span>
             <span className="from-primary/20 border-primary/30 shadow-primary/20 hidden rounded-full border bg-gradient-to-r to-green-500/20 px-2.5 py-1 text-xs font-semibold text-primary shadow-sm sm:inline-block">
-              v0.13.0 Beta
+              v0.14.0 Beta
             </span>
           </Link>
 


### PR DESCRIPTION
This PR prepares the repository for the v0.14.0-beta release.

## Version rationale

The delta since `v0.13.0-beta` contains backwards-compatible new features, so this is a **minor** bump to `0.14.0-beta`:

- **New features**
  - Configurable modifier+key hotkeys (e.g. `Alt+R`, `Ctrl+Shift+V`) (#493)
  - FunASR/SenseVoice support for the Remote API engine (#468)
- **Bug fixes**
  - Restore GNOME Wayland IBus text injection with bare `xkb` engine and fix engine-restore fallback (#506, #500)
  - Restore KDE Plasma Wayland IBus path (#502)
  - Wait for modifiers to release before Wayland text injection (#494)
  - Stop whisper.cpp from defaulting to all CPU cores on hybrid processors (#492)
  - Fix audio device index mismatch crash on recording start (#499)
  - Include `xsel` for Wayland clipboard fallback in installer (#496)

## Changes

- Bumped version to `0.14.0-beta`
- Refreshed README “What’s New” section and Voca ecosystem table
- Added `v0.14.0-beta` section to `docs/UPDATE.md`
- Updated `SECURITY.md` supported versions table
- Added release entry to `docs/RELEASE_PROCESS.md` version history
- Bumped website version metadata, schema, header badge, and changelog

## Verification

- [x] `make lint` — clean
- [x] Package build (`make build`) — succeeds, produces `vocalinux-0.14.0b0` wheel/sdist
- [x] Website build (`npm run build` in `web/`) — succeeds
- [x] Website lint/typecheck (`npm run check` in `web/`) — clean
- [ ] `make typecheck` — 55 pre-existing mypy errors in `main` (unchanged by this PR)
- [ ] `make test` — 1827 passed; 15 failures, all on `main` before this PR (Wayland-session/environmental IBus tests plus a `test_switch_engine_failure` side effect of the #506/#500 code path)

These test/type failures are pre-existing on `main` and are not introduced by the version-bump changes. CI is the authoritative run for the final merge decision.