### PR TITLE
fix(text-injection): treat XIM none as unset

### DIFF
--- a/src/vocalinux/text_injection/ibus_engine.py
+++ b/src/vocalinux/text_injection/ibus_engine.py
@@ -196,7 +196,9 @@ def is_ibus_active_input_method() -> bool:
     ibus_via_env = ("ibus" in gtk_im) or ("ibus" in qt_im) or ("@im=ibus" in xmodifiers)
 
     # If another (non-IBus) input method is explicitly configured, respect it.
-    if not ibus_via_env and (gtk_im or qt_im or (xmodifiers and "@im=" in xmodifiers)):
+    if not ibus_via_env and (
+        gtk_im or qt_im or (xmodifiers not in ("", "@im=none") and "@im=" in xmodifiers)
+    ):
         logger.debug(
             "Another input method is explicitly configured "
             f"(GTK_IM_MODULE={gtk_im or 'not set'}, "

--- a/src/vocalinux/text_injection/text_injector.py
+++ b/src/vocalinux/text_injection/text_injector.py
@@ -250,7 +250,11 @@ class TextInjector:
             explicit_non_ibus_im = (
                 (gtk_im and "ibus" not in gtk_im)
                 or (qt_im and "ibus" not in qt_im)
-                or (xmodifiers and "@im=" in xmodifiers and "@im=ibus" not in xmodifiers)
+                or (
+                    xmodifiers not in ("", "@im=none")
+                    and "@im=" in xmodifiers
+                    and "@im=ibus" not in xmodifiers
+                )
             )
             # Bridging Wayland DEs (GNOME/KDE): inject_text() switches to the
             # real vocalinux engine for each commit, so a bare xkb:* baseline is

--- a/tests/test_ibus_engine_utils.py
+++ b/tests/test_ibus_engine_utils.py
@@ -155,6 +155,15 @@ class TestIsIBusActiveInputMethod(unittest.TestCase):
         result = is_ibus_active_input_method()
         self.assertFalse(result)
 
+    @patch("vocalinux.text_injection.ibus_engine.is_ibus_daemon_running", return_value=False)
+    @patch.dict("os.environ", {"XMODIFIERS": "@im=none"}, clear=True)
+    def test_xmodifiers_none_is_not_a_competing_input_method(self, mock_daemon):
+        """Treat the XIM 'none' sentinel like an unset input method."""
+        from vocalinux.text_injection.ibus_engine import is_ibus_active_input_method
+
+        self.assertFalse(is_ibus_active_input_method())
+        mock_daemon.assert_called_once_with()
+
 
 class TestStartIBusDaemon(unittest.TestCase):
     """Tests for start_ibus_daemon function."""

--- a/tests/test_text_injector_ext.py
+++ b/tests/test_text_injector_ext.py
@@ -159,7 +159,11 @@ class TestCheckDependencies(unittest.TestCase):
         with (
             patch.dict(
                 os.environ,
-                {"XDG_SESSION_TYPE": "wayland", "XDG_CURRENT_DESKTOP": "KDE"},
+                {
+                    "XDG_SESSION_TYPE": "wayland",
+                    "XDG_CURRENT_DESKTOP": "KDE",
+                    "XMODIFIERS": "@im=none",
+                },
                 clear=True,
             ),
             patch(


### PR DESCRIPTION
Fixes #511.

## What changed

- Treat `XMODIFIERS=@im=none` as an unset XIM value instead of a competing input method.
- Keep rejecting actual non-IBus input methods such as Fcitx.
- Cover the Fedora KDE Plasma environment reported in #511.

## Root cause

The Wayland IBus fallback treated every non-IBus `@im=` value as an explicitly configured alternative input method. Fedora KDE Plasma reported `XMODIFIERS=@im=none`, so Vocalinux skipped scoped IBus injection, selected `wtype`, and KWin rejected the unsupported virtual-keyboard protocol.

The previous regression tests covered an empty environment and a real Fcitx configuration, but not the `@im=none` sentinel.

## User impact

KDE Plasma Wayland users whose session exports `XMODIFIERS=@im=none` can use the selected IBus Wayland path instead of falling back to clipboard-only behavior.

## Validation

- 65 tests passed across `tests.test_text_injector_ext` and `tests.test_ibus_engine_utils`
- Focused regression and Fcitx guard tests passed
- Black check passed on changed files
- Flake8 fatal-error checks passed on changed files
- `git diff --check` passed