### PR TITLE
fix(hotkeys): layout-aware combo keys for non-US layouts (#513)

### DIFF
--- a/src/vocalinux/ui/keyboard_backends/evdev_backend.py
+++ b/src/vocalinux/ui/keyboard_backends/evdev_backend.py
@@ -8,6 +8,7 @@ input devices, which works on both X11 and Wayland (with proper permissions).
 import errno
 import logging
 import os
+import re
 import select
 import threading
 import time
@@ -26,7 +27,7 @@ except ImportError:
     EVDEV_AVAILABLE = False
 
 from .base import DEFAULT_SHORTCUT, DEFAULT_SHORTCUT_MODE, KeyboardBackend, parse_shortcut
-from .layout_key_map import get_active_char_to_evdev_map, resolve_token_to_evdev_code
+from .layout_key_map import get_active_char_to_evdev_map
 
 logger = logging.getLogger(__name__)
 
@@ -91,38 +92,27 @@ _NAMED_EVDEV_KEYS = {
 }
 
 
-def evdev_code_for_key(
-    token: str,
-    char_to_evdev: Optional[dict] = None,
-    *,
-    use_active_layout: bool = True,
-) -> Optional[int]:
+def evdev_code_for_key(token: str) -> Optional[int]:
     """Resolve a canonical main-key token (e.g. "r", "f5", "space") to an evdev code.
 
-    Letter/digit tokens are character-semantic (settings capture stores GDK
-    keyvals). On non-US layouts the physical key that types a letter is not
-    necessarily ``KEY_<LETTER>``. When ``use_active_layout`` is True (default),
-    single-character tokens are resolved through the active XKB layout map so
-    AZERTY Alt+A matches the key that produces A, not US-position KEY_A.
-
-    Args:
-        token: Canonical main-key token from the shortcut string.
-        char_to_evdev: Optional explicit char→evdev map (tests / override). When
-            provided, it is used instead of the detected active layout.
-        use_active_layout: When True and ``char_to_evdev`` is None, consult the
-            cached system layout map. Set False for pure US KEY_* resolution.
+    Letters are character-semantic (GDK keyval). Non-US layouts remap via the
+    active XKB map so AZERTY "a" hits KEY_Q, not US KEY_A.
     """
     if not EVDEV_AVAILABLE or not token:
         return None
-    layout_map = char_to_evdev
-    if layout_map is None and use_active_layout:
+    name = _NAMED_EVDEV_KEYS.get(token)
+    if name is not None:
+        return getattr(ecodes, name, None)
+    if len(token) == 1:
         layout_map = get_active_char_to_evdev_map()
-    return resolve_token_to_evdev_code(
-        token,
-        _NAMED_EVDEV_KEYS,
-        ecodes,
-        char_to_evdev=layout_map,
-    )
+        if layout_map and token in layout_map:
+            return layout_map[token]
+        if token.isalnum():
+            return getattr(ecodes, f"KEY_{token.upper()}", None)
+        return None
+    if re.fullmatch(r"f\d+", token):
+        return getattr(ecodes, f"KEY_{token.upper()}", None)
+    return None
 
 
 def find_keyboard_devices() -> list[str]:

--- a/src/vocalinux/ui/keyboard_backends/evdev_backend.py
+++ b/src/vocalinux/ui/keyboard_backends/evdev_backend.py
@@ -8,7 +8,6 @@ input devices, which works on both X11 and Wayland (with proper permissions).
 import errno
 import logging
 import os
-import re
 import select
 import threading
 import time
@@ -27,6 +26,7 @@ except ImportError:
     EVDEV_AVAILABLE = False
 
 from .base import DEFAULT_SHORTCUT, DEFAULT_SHORTCUT_MODE, KeyboardBackend, parse_shortcut
+from .layout_key_map import get_active_char_to_evdev_map, resolve_token_to_evdev_code
 
 logger = logging.getLogger(__name__)
 
@@ -91,19 +91,38 @@ _NAMED_EVDEV_KEYS = {
 }
 
 
-def evdev_code_for_key(token: str) -> Optional[int]:
-    """Resolve a canonical main-key token (e.g. "r", "f5", "space") to an evdev code."""
+def evdev_code_for_key(
+    token: str,
+    char_to_evdev: Optional[dict] = None,
+    *,
+    use_active_layout: bool = True,
+) -> Optional[int]:
+    """Resolve a canonical main-key token (e.g. "r", "f5", "space") to an evdev code.
+
+    Letter/digit tokens are character-semantic (settings capture stores GDK
+    keyvals). On non-US layouts the physical key that types a letter is not
+    necessarily ``KEY_<LETTER>``. When ``use_active_layout`` is True (default),
+    single-character tokens are resolved through the active XKB layout map so
+    AZERTY Alt+A matches the key that produces A, not US-position KEY_A.
+
+    Args:
+        token: Canonical main-key token from the shortcut string.
+        char_to_evdev: Optional explicit char→evdev map (tests / override). When
+            provided, it is used instead of the detected active layout.
+        use_active_layout: When True and ``char_to_evdev`` is None, consult the
+            cached system layout map. Set False for pure US KEY_* resolution.
+    """
     if not EVDEV_AVAILABLE or not token:
         return None
-    name = _NAMED_EVDEV_KEYS.get(token)
-    if name is None:
-        if len(token) == 1 and token.isalnum():
-            name = f"KEY_{token.upper()}"
-        elif re.fullmatch(r"f\d+", token):
-            name = f"KEY_{token.upper()}"
-    if name is None:
-        return None
-    return getattr(ecodes, name, None)
+    layout_map = char_to_evdev
+    if layout_map is None and use_active_layout:
+        layout_map = get_active_char_to_evdev_map()
+    return resolve_token_to_evdev_code(
+        token,
+        _NAMED_EVDEV_KEYS,
+        ecodes,
+        char_to_evdev=layout_map,
+    )
 
 
 def find_keyboard_devices() -> list[str]:

--- a/src/vocalinux/ui/keyboard_backends/layout_key_map.py
+++ b/src/vocalinux/ui/keyboard_backends/layout_key_map.py
@@ -1,29 +1,23 @@
 """
-Layout-aware mapping from character key tokens to Linux/evdev keycodes.
+Layout-aware char → Linux/evdev keycodes via libxkbcommon.
 
-Settings capture stores character-semantic tokens (GDK keyval names, e.g. "a").
-evdev listens for physical KEY_* codes. On non-US layouts those diverge: French
-AZERTY types "a" on KEY_Q. This module builds char→evdev maps from XKB (via
-libxkbcommon) so combo matching uses the same physical key the user pressed.
+Settings store character tokens (GDK keyval); evdev matches physical KEY_*.
+On AZERTY, "a" is KEY_Q not KEY_A. This builds the map for the active layout.
 """
 
 from __future__ import annotations
 
 import logging
-import os
 import re
 import subprocess
 from ctypes import CDLL, POINTER, Structure, byref, c_char_p, c_int, c_uint32, c_void_p
 from functools import lru_cache
-from typing import Mapping, Optional, Tuple
+from typing import Optional
 
 logger = logging.getLogger(__name__)
 
-# X11/xkbcommon keycodes are offset from Linux/evdev codes by this amount.
 _XKB_EVDEV_OFFSET = 8
-
-# Lazy libxkbcommon handle; None means "not tried", False means "unavailable".
-_xkb_lib: object = None
+_xkb_lib: object = None  # None = untried, False = missing, else CDLL
 
 
 class _XkbRuleNames(Structure):
@@ -37,7 +31,6 @@ class _XkbRuleNames(Structure):
 
 
 def _load_xkbcommon():
-    """Return a CDLL for libxkbcommon, or False if unavailable."""
     global _xkb_lib
     if _xkb_lib is not None:
         return _xkb_lib
@@ -74,20 +67,8 @@ def _load_xkbcommon():
     return _xkb_lib
 
 
-def build_char_to_evdev_map(
-    layout: str,
-    variant: str = "",
-) -> Optional[dict[str, int]]:
-    """
-    Build a mapping of lowercase characters → Linux/evdev keycodes for an XKB layout.
-
-    Uses unshifted (level 0) keysyms on the first layout group. First key that
-    produces a given character wins (matches typical "base letter" positions).
-
-    Returns:
-        dict mapping single-character strings to evdev codes, or None if the
-        layout cannot be loaded (missing libxkbcommon / invalid layout).
-    """
+def build_char_to_evdev_map(layout: str, variant: str = "") -> Optional[dict[str, int]]:
+    """Unshifted (level 0) char → evdev keycode for an XKB layout, or None."""
     if not layout:
         return None
     lib = _load_xkbcommon()
@@ -108,14 +89,14 @@ def build_char_to_evdev_map(
     keymap = lib.xkb_keymap_new_from_names(ctx, byref(names), 0)
     if not keymap:
         lib.xkb_context_unref(ctx)
-        logger.debug("Could not load XKB keymap for layout=%r variant=%r", layout, variant)
         return None
 
     char_map: dict[str, int] = {}
     try:
-        min_kc = lib.xkb_keymap_min_keycode(keymap)
-        max_kc = lib.xkb_keymap_max_keycode(keymap)
-        for xkb_code in range(min_kc, max_kc + 1):
+        for xkb_code in range(
+            lib.xkb_keymap_min_keycode(keymap),
+            lib.xkb_keymap_max_keycode(keymap) + 1,
+        ):
             if lib.xkb_keymap_num_layouts_for_key(keymap, xkb_code) == 0:
                 continue
             if lib.xkb_keymap_num_levels_for_key(keymap, xkb_code, 0) == 0:
@@ -125,16 +106,9 @@ def build_char_to_evdev_map(
             if n_syms <= 0:
                 continue
             utf32 = lib.xkb_keysym_to_utf32(syms_ptr[0])
-            # Printable BMP/plane-0 only; skip controls and non-characters.
             if utf32 < 32 or utf32 > 0x10FFFF:
                 continue
-            try:
-                ch = chr(utf32)
-            except ValueError:
-                continue
-            if len(ch) != 1:
-                continue
-            # Prefer lowercase letter slots; keep first mapping for each char.
+            ch = chr(utf32)
             key = ch.lower() if ch.isalpha() else ch
             if key not in char_map:
                 char_map[key] = int(xkb_code) - _XKB_EVDEV_OFFSET
@@ -145,32 +119,9 @@ def build_char_to_evdev_map(
     return char_map or None
 
 
-def detect_active_xkb_layout() -> Tuple[str, str]:
-    """
-    Best-effort detection of the active XKB layout and variant.
-
-    Order: GNOME gsettings (works on Wayland), setxkbmap (X11), localectl.
-    Returns ("", "") when nothing useful is found.
-    """
-    layout, variant = _detect_gnome_layout()
-    if layout:
-        return layout, variant
-
-    layout, variant = _detect_setxkbmap_layout()
-    if layout:
-        return layout, variant
-
-    layout, variant = _detect_localectl_layout()
-    if layout:
-        return layout, variant
-
-    return "", ""
-
-
-def _detect_gnome_layout() -> Tuple[str, str]:
-    """Read current source from org.gnome.desktop.input-sources when available."""
+def _detect_gnome_layout() -> tuple[str, str]:
+    """Current XKB source from GNOME gsettings (works on Wayland)."""
     try:
-        # Prefer mru-sources[0] (most recently used = current) over sources[0].
         for key in ("mru-sources", "sources"):
             result = subprocess.run(
                 ["gsettings", "get", "org.gnome.desktop.input-sources", key],
@@ -181,96 +132,22 @@ def _detect_gnome_layout() -> Tuple[str, str]:
             )
             if result.returncode != 0 or not result.stdout.strip():
                 continue
-            parsed = _parse_gnome_sources(result.stdout.strip())
-            if parsed:
-                return parsed
+            match = re.search(r"\(\s*'xkb'\s*,\s*'([^']+)'\s*\)", result.stdout)
+            if not match:
+                continue
+            layout, _, variant = match.group(1).partition("+")
+            return layout, variant
     except (OSError, subprocess.SubprocessError) as e:
         logger.debug("gsettings layout query failed: %s", e)
     return "", ""
 
 
-def _parse_gnome_sources(raw: str) -> Optional[Tuple[str, str]]:
-    """
-    Parse gsettings sources output like:
-      [('xkb', 'us'), ('xkb', 'fr')]
-      [('xkb', 'fr+azerty'), ('ibus', 'anthy')]
-    """
-    # First xkb entry wins (current / first configured).
-    match = re.search(r"\(\s*'xkb'\s*,\s*'([^']+)'\s*\)", raw)
-    if not match:
-        return None
-    source_id = match.group(1)
-    layout, _, variant = source_id.partition("+")
-    return layout, variant
-
-
-def _detect_setxkbmap_layout() -> Tuple[str, str]:
-    if os.environ.get("WAYLAND_DISPLAY") and not os.environ.get("DISPLAY"):
-        return "", ""
-    try:
-        result = subprocess.run(
-            ["setxkbmap", "-query"],
-            capture_output=True,
-            text=True,
-            timeout=2,
-            check=False,
-        )
-        if result.returncode != 0:
-            return "", ""
-        layout, variant = "", ""
-        for line in result.stdout.splitlines():
-            if line.startswith("layout:"):
-                # May be comma-separated multi-layout; take the first.
-                layout = line.split(":", 1)[1].strip().split(",")[0].strip()
-            elif line.startswith("variant:"):
-                variant = line.split(":", 1)[1].strip().split(",")[0].strip()
-        return layout, variant
-    except (OSError, subprocess.SubprocessError) as e:
-        logger.debug("setxkbmap layout query failed: %s", e)
-        return "", ""
-
-
-def _detect_localectl_layout() -> Tuple[str, str]:
-    try:
-        result = subprocess.run(
-            ["localectl", "status"],
-            capture_output=True,
-            text=True,
-            timeout=2,
-            check=False,
-        )
-        if result.returncode != 0:
-            return "", ""
-        layout, variant = "", ""
-        for line in result.stdout.splitlines():
-            stripped = line.strip()
-            if stripped.startswith("X11 Layout:"):
-                layout = stripped.split(":", 1)[1].strip().split(",")[0].strip()
-            elif stripped.startswith("X11 Variant:"):
-                variant = stripped.split(":", 1)[1].strip().split(",")[0].strip()
-                if variant in ("(unset)", "n/a", ""):
-                    variant = ""
-        return layout, variant
-    except (OSError, subprocess.SubprocessError) as e:
-        logger.debug("localectl layout query failed: %s", e)
-        return "", ""
-
-
 @lru_cache(maxsize=1)
-def get_active_char_to_evdev_map() -> Optional[Mapping[str, int]]:
-    """
-    Cached char→evdev map for the currently detected keyboard layout.
-
-    Returns None for US/empty layouts (caller should use KEY_* name fallback)
-    or when libxkbcommon / layout detection is unavailable.
-    """
-    layout, variant = detect_active_xkb_layout()
-    if not layout:
-        logger.debug("No XKB layout detected; using US keycode fallback for combos")
-        return None
-    # US QWERTY letter positions match KEY_A, KEY_Q, … — no remap needed.
-    if layout == "us" and not variant:
-        logger.debug("US layout active; using KEY_* name fallback for combos")
+def get_active_char_to_evdev_map() -> Optional[dict[str, int]]:
+    """Cached char→evdev map for the active layout; None → use US KEY_* names."""
+    layout, variant = _detect_gnome_layout()
+    # ponytail: GNOME gsettings only; add setxkbmap/localectl if non-GNOME reports land
+    if not layout or (layout == "us" and not variant):
         return None
     char_map = build_char_to_evdev_map(layout, variant)
     if char_map:
@@ -281,48 +158,3 @@ def get_active_char_to_evdev_map() -> Optional[Mapping[str, int]]:
             len(char_map),
         )
     return char_map
-
-
-def clear_layout_map_cache() -> None:
-    """Drop the cached active layout map (tests / layout change)."""
-    get_active_char_to_evdev_map.cache_clear()
-
-
-def resolve_token_to_evdev_code(
-    token: str,
-    named_keys: Mapping[str, str],
-    ecodes_module,
-    char_to_evdev: Optional[Mapping[str, int]] = None,
-) -> Optional[int]:
-    """
-    Resolve a canonical main-key token to a Linux/evdev keycode.
-
-    Args:
-        token: Canonical token (e.g. "a", "f5", "space").
-        named_keys: Map of irregular tokens → ecodes attribute names.
-        ecodes_module: The ``evdev.ecodes`` module (or compatible).
-        char_to_evdev: Optional layout map for single-character tokens. When
-            provided, letter/digit/punctuation chars are resolved from this map
-            before falling back to US ``KEY_<UPPER>`` names.
-
-    Returns:
-        evdev keycode int, or None if unresolvable.
-    """
-    if not token or ecodes_module is None:
-        return None
-
-    name = named_keys.get(token)
-    if name is not None:
-        return getattr(ecodes_module, name, None)
-
-    if len(token) == 1:
-        if char_to_evdev is not None and token in char_to_evdev:
-            return char_to_evdev[token]
-        if token.isalnum():
-            return getattr(ecodes_module, f"KEY_{token.upper()}", None)
-        return None
-
-    if re.fullmatch(r"f\d+", token):
-        return getattr(ecodes_module, f"KEY_{token.upper()}", None)
-
-    return None

--- a/src/vocalinux/ui/keyboard_backends/layout_key_map.py
+++ b/src/vocalinux/ui/keyboard_backends/layout_key_map.py
@@ -1,0 +1,328 @@
+"""
+Layout-aware mapping from character key tokens to Linux/evdev keycodes.
+
+Settings capture stores character-semantic tokens (GDK keyval names, e.g. "a").
+evdev listens for physical KEY_* codes. On non-US layouts those diverge: French
+AZERTY types "a" on KEY_Q. This module builds char→evdev maps from XKB (via
+libxkbcommon) so combo matching uses the same physical key the user pressed.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import re
+import subprocess
+from ctypes import CDLL, POINTER, Structure, byref, c_char_p, c_int, c_uint32, c_void_p
+from functools import lru_cache
+from typing import Mapping, Optional, Tuple
+
+logger = logging.getLogger(__name__)
+
+# X11/xkbcommon keycodes are offset from Linux/evdev codes by this amount.
+_XKB_EVDEV_OFFSET = 8
+
+# Lazy libxkbcommon handle; None means "not tried", False means "unavailable".
+_xkb_lib: object = None
+
+
+class _XkbRuleNames(Structure):
+    _fields_ = [
+        ("rules", c_char_p),
+        ("model", c_char_p),
+        ("layout", c_char_p),
+        ("variant", c_char_p),
+        ("options", c_char_p),
+    ]
+
+
+def _load_xkbcommon():
+    """Return a CDLL for libxkbcommon, or False if unavailable."""
+    global _xkb_lib
+    if _xkb_lib is not None:
+        return _xkb_lib
+    try:
+        lib = CDLL("libxkbcommon.so.0")
+        lib.xkb_context_new.argtypes = [c_int]
+        lib.xkb_context_new.restype = c_void_p
+        lib.xkb_keymap_new_from_names.argtypes = [c_void_p, POINTER(_XkbRuleNames), c_int]
+        lib.xkb_keymap_new_from_names.restype = c_void_p
+        lib.xkb_keymap_min_keycode.argtypes = [c_void_p]
+        lib.xkb_keymap_min_keycode.restype = c_uint32
+        lib.xkb_keymap_max_keycode.argtypes = [c_void_p]
+        lib.xkb_keymap_max_keycode.restype = c_uint32
+        lib.xkb_keymap_num_layouts_for_key.argtypes = [c_void_p, c_uint32]
+        lib.xkb_keymap_num_layouts_for_key.restype = c_uint32
+        lib.xkb_keymap_num_levels_for_key.argtypes = [c_void_p, c_uint32, c_uint32]
+        lib.xkb_keymap_num_levels_for_key.restype = c_uint32
+        lib.xkb_keymap_key_get_syms_by_level.argtypes = [
+            c_void_p,
+            c_uint32,
+            c_uint32,
+            c_uint32,
+            POINTER(POINTER(c_uint32)),
+        ]
+        lib.xkb_keymap_key_get_syms_by_level.restype = c_int
+        lib.xkb_keysym_to_utf32.argtypes = [c_uint32]
+        lib.xkb_keysym_to_utf32.restype = c_uint32
+        lib.xkb_keymap_unref.argtypes = [c_void_p]
+        lib.xkb_context_unref.argtypes = [c_void_p]
+        _xkb_lib = lib
+    except OSError as e:
+        logger.debug("libxkbcommon not available: %s", e)
+        _xkb_lib = False
+    return _xkb_lib
+
+
+def build_char_to_evdev_map(
+    layout: str,
+    variant: str = "",
+) -> Optional[dict[str, int]]:
+    """
+    Build a mapping of lowercase characters → Linux/evdev keycodes for an XKB layout.
+
+    Uses unshifted (level 0) keysyms on the first layout group. First key that
+    produces a given character wins (matches typical "base letter" positions).
+
+    Returns:
+        dict mapping single-character strings to evdev codes, or None if the
+        layout cannot be loaded (missing libxkbcommon / invalid layout).
+    """
+    if not layout:
+        return None
+    lib = _load_xkbcommon()
+    if not lib:
+        return None
+
+    ctx = lib.xkb_context_new(0)
+    if not ctx:
+        return None
+
+    names = _XkbRuleNames(
+        None,
+        None,
+        layout.encode("utf-8"),
+        variant.encode("utf-8") if variant else None,
+        None,
+    )
+    keymap = lib.xkb_keymap_new_from_names(ctx, byref(names), 0)
+    if not keymap:
+        lib.xkb_context_unref(ctx)
+        logger.debug("Could not load XKB keymap for layout=%r variant=%r", layout, variant)
+        return None
+
+    char_map: dict[str, int] = {}
+    try:
+        min_kc = lib.xkb_keymap_min_keycode(keymap)
+        max_kc = lib.xkb_keymap_max_keycode(keymap)
+        for xkb_code in range(min_kc, max_kc + 1):
+            if lib.xkb_keymap_num_layouts_for_key(keymap, xkb_code) == 0:
+                continue
+            if lib.xkb_keymap_num_levels_for_key(keymap, xkb_code, 0) == 0:
+                continue
+            syms_ptr = POINTER(c_uint32)()
+            n_syms = lib.xkb_keymap_key_get_syms_by_level(keymap, xkb_code, 0, 0, byref(syms_ptr))
+            if n_syms <= 0:
+                continue
+            utf32 = lib.xkb_keysym_to_utf32(syms_ptr[0])
+            # Printable BMP/plane-0 only; skip controls and non-characters.
+            if utf32 < 32 or utf32 > 0x10FFFF:
+                continue
+            try:
+                ch = chr(utf32)
+            except ValueError:
+                continue
+            if len(ch) != 1:
+                continue
+            # Prefer lowercase letter slots; keep first mapping for each char.
+            key = ch.lower() if ch.isalpha() else ch
+            if key not in char_map:
+                char_map[key] = int(xkb_code) - _XKB_EVDEV_OFFSET
+    finally:
+        lib.xkb_keymap_unref(keymap)
+        lib.xkb_context_unref(ctx)
+
+    return char_map or None
+
+
+def detect_active_xkb_layout() -> Tuple[str, str]:
+    """
+    Best-effort detection of the active XKB layout and variant.
+
+    Order: GNOME gsettings (works on Wayland), setxkbmap (X11), localectl.
+    Returns ("", "") when nothing useful is found.
+    """
+    layout, variant = _detect_gnome_layout()
+    if layout:
+        return layout, variant
+
+    layout, variant = _detect_setxkbmap_layout()
+    if layout:
+        return layout, variant
+
+    layout, variant = _detect_localectl_layout()
+    if layout:
+        return layout, variant
+
+    return "", ""
+
+
+def _detect_gnome_layout() -> Tuple[str, str]:
+    """Read current source from org.gnome.desktop.input-sources when available."""
+    try:
+        # Prefer mru-sources[0] (most recently used = current) over sources[0].
+        for key in ("mru-sources", "sources"):
+            result = subprocess.run(
+                ["gsettings", "get", "org.gnome.desktop.input-sources", key],
+                capture_output=True,
+                text=True,
+                timeout=2,
+                check=False,
+            )
+            if result.returncode != 0 or not result.stdout.strip():
+                continue
+            parsed = _parse_gnome_sources(result.stdout.strip())
+            if parsed:
+                return parsed
+    except (OSError, subprocess.SubprocessError) as e:
+        logger.debug("gsettings layout query failed: %s", e)
+    return "", ""
+
+
+def _parse_gnome_sources(raw: str) -> Optional[Tuple[str, str]]:
+    """
+    Parse gsettings sources output like:
+      [('xkb', 'us'), ('xkb', 'fr')]
+      [('xkb', 'fr+azerty'), ('ibus', 'anthy')]
+    """
+    # First xkb entry wins (current / first configured).
+    match = re.search(r"\(\s*'xkb'\s*,\s*'([^']+)'\s*\)", raw)
+    if not match:
+        return None
+    source_id = match.group(1)
+    layout, _, variant = source_id.partition("+")
+    return layout, variant
+
+
+def _detect_setxkbmap_layout() -> Tuple[str, str]:
+    if os.environ.get("WAYLAND_DISPLAY") and not os.environ.get("DISPLAY"):
+        return "", ""
+    try:
+        result = subprocess.run(
+            ["setxkbmap", "-query"],
+            capture_output=True,
+            text=True,
+            timeout=2,
+            check=False,
+        )
+        if result.returncode != 0:
+            return "", ""
+        layout, variant = "", ""
+        for line in result.stdout.splitlines():
+            if line.startswith("layout:"):
+                # May be comma-separated multi-layout; take the first.
+                layout = line.split(":", 1)[1].strip().split(",")[0].strip()
+            elif line.startswith("variant:"):
+                variant = line.split(":", 1)[1].strip().split(",")[0].strip()
+        return layout, variant
+    except (OSError, subprocess.SubprocessError) as e:
+        logger.debug("setxkbmap layout query failed: %s", e)
+        return "", ""
+
+
+def _detect_localectl_layout() -> Tuple[str, str]:
+    try:
+        result = subprocess.run(
+            ["localectl", "status"],
+            capture_output=True,
+            text=True,
+            timeout=2,
+            check=False,
+        )
+        if result.returncode != 0:
+            return "", ""
+        layout, variant = "", ""
+        for line in result.stdout.splitlines():
+            stripped = line.strip()
+            if stripped.startswith("X11 Layout:"):
+                layout = stripped.split(":", 1)[1].strip().split(",")[0].strip()
+            elif stripped.startswith("X11 Variant:"):
+                variant = stripped.split(":", 1)[1].strip().split(",")[0].strip()
+                if variant in ("(unset)", "n/a", ""):
+                    variant = ""
+        return layout, variant
+    except (OSError, subprocess.SubprocessError) as e:
+        logger.debug("localectl layout query failed: %s", e)
+        return "", ""
+
+
+@lru_cache(maxsize=1)
+def get_active_char_to_evdev_map() -> Optional[Mapping[str, int]]:
+    """
+    Cached char→evdev map for the currently detected keyboard layout.
+
+    Returns None for US/empty layouts (caller should use KEY_* name fallback)
+    or when libxkbcommon / layout detection is unavailable.
+    """
+    layout, variant = detect_active_xkb_layout()
+    if not layout:
+        logger.debug("No XKB layout detected; using US keycode fallback for combos")
+        return None
+    # US QWERTY letter positions match KEY_A, KEY_Q, … — no remap needed.
+    if layout == "us" and not variant:
+        logger.debug("US layout active; using KEY_* name fallback for combos")
+        return None
+    char_map = build_char_to_evdev_map(layout, variant)
+    if char_map:
+        logger.info(
+            "Loaded layout-aware key map for XKB layout=%s variant=%s (%d chars)",
+            layout,
+            variant or "(none)",
+            len(char_map),
+        )
+    return char_map
+
+
+def clear_layout_map_cache() -> None:
+    """Drop the cached active layout map (tests / layout change)."""
+    get_active_char_to_evdev_map.cache_clear()
+
+
+def resolve_token_to_evdev_code(
+    token: str,
+    named_keys: Mapping[str, str],
+    ecodes_module,
+    char_to_evdev: Optional[Mapping[str, int]] = None,
+) -> Optional[int]:
+    """
+    Resolve a canonical main-key token to a Linux/evdev keycode.
+
+    Args:
+        token: Canonical token (e.g. "a", "f5", "space").
+        named_keys: Map of irregular tokens → ecodes attribute names.
+        ecodes_module: The ``evdev.ecodes`` module (or compatible).
+        char_to_evdev: Optional layout map for single-character tokens. When
+            provided, letter/digit/punctuation chars are resolved from this map
+            before falling back to US ``KEY_<UPPER>`` names.
+
+    Returns:
+        evdev keycode int, or None if unresolvable.
+    """
+    if not token or ecodes_module is None:
+        return None
+
+    name = named_keys.get(token)
+    if name is not None:
+        return getattr(ecodes_module, name, None)
+
+    if len(token) == 1:
+        if char_to_evdev is not None and token in char_to_evdev:
+            return char_to_evdev[token]
+        if token.isalnum():
+            return getattr(ecodes_module, f"KEY_{token.upper()}", None)
+        return None
+
+    if re.fullmatch(r"f\d+", token):
+        return getattr(ecodes_module, f"KEY_{token.upper()}", None)
+
+    return None

--- a/tests/test_layout_key_map.py
+++ b/tests/test_layout_key_map.py
@@ -1,10 +1,4 @@
-"""Tests for layout-aware shortcut main-key resolution (issue #513).
-
-Capture stores character tokens (GDK keyval "a"); Wayland/evdev previously
-mapped letters to fixed US KEY_* positions. These tests drive the real shipped
-helpers with an AZERTY (or XKB-built) map so Alt+A resolves to the physical key
-that types A, not US KEY_A.
-"""
+"""Layout-aware combo main-key resolution (issue #513)."""
 
 from __future__ import annotations
 
@@ -13,208 +7,60 @@ import types
 
 import pytest
 
-from vocalinux.ui.keyboard_backends.layout_key_map import (
-    build_char_to_evdev_map,
-    resolve_token_to_evdev_code,
-)
+from vocalinux.ui.keyboard_backends.layout_key_map import build_char_to_evdev_map
 
 evdev_backend = pytest.importorskip("vocalinux.ui.keyboard_backends.evdev_backend")
 
-
-# French AZERTY (base) letter positions as Linux/evdev keycodes.
-# Built from XKB layout=fr level-0: character "a" is on KEY_Q (16), "q" on KEY_A (30).
-# Values match libxkbcommon / kernel input codes.
-AZERTY_FR_LETTER_TO_EVDEV = {
-    "a": 16,  # KEY_Q
-    "z": 17,  # KEY_W
-    "e": 18,  # KEY_E
-    "r": 19,  # KEY_R
-    "t": 20,  # KEY_T
-    "y": 21,  # KEY_Y
-    "u": 22,  # KEY_U
-    "i": 23,  # KEY_I
-    "o": 24,  # KEY_O
-    "p": 25,  # KEY_P
-    "q": 30,  # KEY_A
-    "s": 31,  # KEY_S
-    "d": 32,  # KEY_D
-    "f": 33,  # KEY_F
-    "g": 34,  # KEY_G
-    "h": 35,  # KEY_H
-    "j": 36,  # KEY_J
-    "k": 37,  # KEY_K
-    "l": 38,  # KEY_L
-    "m": 39,  # KEY_SEMICOLON (AZERTY M position)
-    "w": 44,  # KEY_Z
-    "x": 45,  # KEY_X
-    "c": 46,  # KEY_C
-    "v": 47,  # KEY_V
-    "b": 48,  # KEY_B
-    "n": 49,  # KEY_N
-}
+# Minimal AZERTY fr positions used by #513 (a/q swap; r unchanged).
+AZERTY = {"a": 16, "q": 30, "r": 19}  # KEY_Q, KEY_A, KEY_R
 
 
 @pytest.mark.skipif(not evdev_backend.EVDEV_AVAILABLE, reason="evdev not available")
-class TestResolveTokenToEvdevCode:
-    def test_us_fallback_letter_is_key_named(self):
-        from evdev import ecodes
-
-        code = resolve_token_to_evdev_code(
-            "a",
-            evdev_backend._NAMED_EVDEV_KEYS,
-            ecodes,
-            char_to_evdev=None,
-        )
-        assert code == ecodes.KEY_A
-
-    def test_azerty_letter_a_is_key_q_not_key_a(self):
-        from evdev import ecodes
-
-        code = resolve_token_to_evdev_code(
-            "a",
-            evdev_backend._NAMED_EVDEV_KEYS,
-            ecodes,
-            char_to_evdev=AZERTY_FR_LETTER_TO_EVDEV,
-        )
-        assert code == AZERTY_FR_LETTER_TO_EVDEV["a"]
-        assert code == ecodes.KEY_Q
-        assert code != ecodes.KEY_A
-
-    def test_azerty_letter_q_is_key_a(self):
-        from evdev import ecodes
-
-        code = resolve_token_to_evdev_code(
-            "q",
-            evdev_backend._NAMED_EVDEV_KEYS,
-            ecodes,
-            char_to_evdev=AZERTY_FR_LETTER_TO_EVDEV,
-        )
-        assert code == ecodes.KEY_A
-
-    def test_named_keys_ignore_layout_map(self):
-        from evdev import ecodes
-
-        code = resolve_token_to_evdev_code(
-            "space",
-            evdev_backend._NAMED_EVDEV_KEYS,
-            ecodes,
-            char_to_evdev=AZERTY_FR_LETTER_TO_EVDEV,
-        )
-        assert code == ecodes.KEY_SPACE
-
-    def test_function_keys_ignore_layout_map(self):
-        from evdev import ecodes
-
-        code = resolve_token_to_evdev_code(
-            "f5",
-            evdev_backend._NAMED_EVDEV_KEYS,
-            ecodes,
-            char_to_evdev=AZERTY_FR_LETTER_TO_EVDEV,
-        )
-        assert code == ecodes.KEY_F5
-
-
-@pytest.mark.skipif(not evdev_backend.EVDEV_AVAILABLE, reason="evdev not available")
-class TestEvdevCodeForKeyLayoutAware:
-    def test_explicit_azerty_map_for_token_a(self):
-        from evdev import ecodes
-
-        # Stored shortcut token "a" (as settings capture would store Alt+A)
-        # must resolve to KEY_Q under AZERTY, not KEY_A.
-        code = evdev_backend.evdev_code_for_key("a", char_to_evdev=AZERTY_FR_LETTER_TO_EVDEV)
-        assert code == ecodes.KEY_Q
-        assert code != ecodes.KEY_A
-
-    def test_use_active_layout_false_keeps_us_key_a(self):
-        from evdev import ecodes
-
-        code = evdev_backend.evdev_code_for_key("a", use_active_layout=False)
-        assert code == ecodes.KEY_A
-
-    def test_us_qwerty_r_unchanged_with_azerty_map(self):
-        from evdev import ecodes
-
-        # R is in the same physical place on AZERTY and QWERTY.
-        assert (
-            evdev_backend.evdev_code_for_key("r", char_to_evdev=AZERTY_FR_LETTER_TO_EVDEV)
-            == ecodes.KEY_R
-        )
-
-
-@pytest.mark.skipif(not evdev_backend.EVDEV_AVAILABLE, reason="evdev not available")
-class TestEvdevComboAzertyAltA:
-    """Shipped combo path: stored alt+a + AZERTY map fires on physical KEY_Q."""
-
+class TestAzertyCombo:
     def _event(self, code, value):
         return types.SimpleNamespace(code=code, value=value, type=1)
 
-    def _backend_with_azerty(self, monkeypatch, shortcut="alt+a", mode="toggle"):
-        """Build a real EvdevKeyboardBackend that resolves letters via AZERTY.
+    def _backend(self, monkeypatch, shortcut="alt+a"):
+        monkeypatch.setattr(evdev_backend, "get_active_char_to_evdev_map", lambda: AZERTY)
+        return evdev_backend.EvdevKeyboardBackend(shortcut=shortcut, mode="toggle")
 
-        Only layout detection is replaced; ``evdev_code_for_key`` /
-        ``_resolve_combo_targets`` / combo matching stay on the shipped path.
-        """
-        monkeypatch.setattr(
-            evdev_backend,
-            "get_active_char_to_evdev_map",
-            lambda: AZERTY_FR_LETTER_TO_EVDEV,
-        )
-        return evdev_backend.EvdevKeyboardBackend(shortcut=shortcut, mode=mode)
-
-    def test_resolve_combo_targets_maps_a_to_key_q(self, monkeypatch):
+    def test_alt_a_resolves_to_key_q(self, monkeypatch):
         from evdev import ecodes
 
-        backend = self._backend_with_azerty(monkeypatch, "alt+a")
+        backend = self._backend(monkeypatch)
         assert backend._combo_main_code == ecodes.KEY_Q
         assert backend._combo_main_code != ecodes.KEY_A
 
-    def test_alt_a_fires_on_physical_azerty_a_key(self, monkeypatch):
+    def test_alt_a_fires_on_physical_a(self, monkeypatch):
         from evdev import ecodes
 
         from vocalinux.ui.keyboard_backends.evdev_backend import KEY_LEFTALT
 
-        # Config stays character-semantic: "alt+a" (settings capture / #513).
-        backend = self._backend_with_azerty(monkeypatch, "alt+a", "toggle")
+        backend = self._backend(monkeypatch)
         fired = threading.Event()
         backend.register_toggle_callback(fired.set)
-
-        # Physical AZERTY "A" key is KEY_Q; with Alt held this must trigger.
         backend._handle_key_event(self._event(KEY_LEFTALT, 1), None)
         backend._handle_key_event(self._event(ecodes.KEY_Q, 1), None)
         assert fired.wait(1.0)
 
-    def test_alt_a_does_not_fire_on_us_key_a_under_azerty(self, monkeypatch):
+    def test_alt_a_does_not_fire_on_key_a(self, monkeypatch):
         from evdev import ecodes
 
         from vocalinux.ui.keyboard_backends.evdev_backend import KEY_LEFTALT
 
-        backend = self._backend_with_azerty(monkeypatch, "alt+a", "toggle")
+        backend = self._backend(monkeypatch)
         fired = threading.Event()
         backend.register_toggle_callback(fired.set)
-
-        # KEY_A is the key labeled Q on AZERTY; must NOT fire for stored alt+a.
         backend._handle_key_event(self._event(KEY_LEFTALT, 1), None)
         backend._handle_key_event(self._event(ecodes.KEY_A, 1), None)
         assert not fired.wait(0.2)
 
 
-class TestBuildCharMapFromXkb:
-    def test_french_azerty_a_maps_to_key_q(self):
-        char_map = build_char_to_evdev_map("fr")
-        if char_map is None:
-            pytest.skip("libxkbcommon or XKB data not available")
-        from evdev import ecodes
+def test_xkb_fr_a_is_key_q():
+    char_map = build_char_to_evdev_map("fr")
+    if char_map is None:
+        pytest.skip("libxkbcommon or XKB data not available")
+    from evdev import ecodes
 
-        assert char_map["a"] == ecodes.KEY_Q
-        assert char_map["q"] == ecodes.KEY_A
-        # Sanity: R stays put.
-        assert char_map["r"] == ecodes.KEY_R
-
-    def test_us_layout_letters_match_key_names(self):
-        char_map = build_char_to_evdev_map("us")
-        if char_map is None:
-            pytest.skip("libxkbcommon or XKB data not available")
-        from evdev import ecodes
-
-        assert char_map["a"] == ecodes.KEY_A
-        assert char_map["q"] == ecodes.KEY_Q
+    assert char_map["a"] == ecodes.KEY_Q
+    assert char_map["q"] == ecodes.KEY_A

--- a/tests/test_layout_key_map.py
+++ b/tests/test_layout_key_map.py
@@ -11,8 +11,8 @@ from vocalinux.ui.keyboard_backends.layout_key_map import build_char_to_evdev_ma
 
 evdev_backend = pytest.importorskip("vocalinux.ui.keyboard_backends.evdev_backend")
 
-# Minimal AZERTY fr positions used by #513 (a/q swap; r unchanged).
-AZERTY = {"a": 16, "q": 30, "r": 19}  # KEY_Q, KEY_A, KEY_R
+# Minimal AZERTY fr positions for #513 (a ↔ q swap).
+AZERTY = {"a": 16, "q": 30}  # KEY_Q, KEY_A
 
 
 @pytest.mark.skipif(not evdev_backend.EVDEV_AVAILABLE, reason="evdev not available")
@@ -24,19 +24,13 @@ class TestAzertyCombo:
         monkeypatch.setattr(evdev_backend, "get_active_char_to_evdev_map", lambda: AZERTY)
         return evdev_backend.EvdevKeyboardBackend(shortcut=shortcut, mode="toggle")
 
-    def test_alt_a_resolves_to_key_q(self, monkeypatch):
-        from evdev import ecodes
-
-        backend = self._backend(monkeypatch)
-        assert backend._combo_main_code == ecodes.KEY_Q
-        assert backend._combo_main_code != ecodes.KEY_A
-
     def test_alt_a_fires_on_physical_a(self, monkeypatch):
         from evdev import ecodes
 
         from vocalinux.ui.keyboard_backends.evdev_backend import KEY_LEFTALT
 
         backend = self._backend(monkeypatch)
+        assert backend._combo_main_code == ecodes.KEY_Q
         fired = threading.Event()
         backend.register_toggle_callback(fired.set)
         backend._handle_key_event(self._event(KEY_LEFTALT, 1), None)

--- a/tests/test_layout_key_map.py
+++ b/tests/test_layout_key_map.py
@@ -1,0 +1,220 @@
+"""Tests for layout-aware shortcut main-key resolution (issue #513).
+
+Capture stores character tokens (GDK keyval "a"); Wayland/evdev previously
+mapped letters to fixed US KEY_* positions. These tests drive the real shipped
+helpers with an AZERTY (or XKB-built) map so Alt+A resolves to the physical key
+that types A, not US KEY_A.
+"""
+
+from __future__ import annotations
+
+import threading
+import types
+
+import pytest
+
+from vocalinux.ui.keyboard_backends.layout_key_map import (
+    build_char_to_evdev_map,
+    resolve_token_to_evdev_code,
+)
+
+evdev_backend = pytest.importorskip("vocalinux.ui.keyboard_backends.evdev_backend")
+
+
+# French AZERTY (base) letter positions as Linux/evdev keycodes.
+# Built from XKB layout=fr level-0: character "a" is on KEY_Q (16), "q" on KEY_A (30).
+# Values match libxkbcommon / kernel input codes.
+AZERTY_FR_LETTER_TO_EVDEV = {
+    "a": 16,  # KEY_Q
+    "z": 17,  # KEY_W
+    "e": 18,  # KEY_E
+    "r": 19,  # KEY_R
+    "t": 20,  # KEY_T
+    "y": 21,  # KEY_Y
+    "u": 22,  # KEY_U
+    "i": 23,  # KEY_I
+    "o": 24,  # KEY_O
+    "p": 25,  # KEY_P
+    "q": 30,  # KEY_A
+    "s": 31,  # KEY_S
+    "d": 32,  # KEY_D
+    "f": 33,  # KEY_F
+    "g": 34,  # KEY_G
+    "h": 35,  # KEY_H
+    "j": 36,  # KEY_J
+    "k": 37,  # KEY_K
+    "l": 38,  # KEY_L
+    "m": 39,  # KEY_SEMICOLON (AZERTY M position)
+    "w": 44,  # KEY_Z
+    "x": 45,  # KEY_X
+    "c": 46,  # KEY_C
+    "v": 47,  # KEY_V
+    "b": 48,  # KEY_B
+    "n": 49,  # KEY_N
+}
+
+
+@pytest.mark.skipif(not evdev_backend.EVDEV_AVAILABLE, reason="evdev not available")
+class TestResolveTokenToEvdevCode:
+    def test_us_fallback_letter_is_key_named(self):
+        from evdev import ecodes
+
+        code = resolve_token_to_evdev_code(
+            "a",
+            evdev_backend._NAMED_EVDEV_KEYS,
+            ecodes,
+            char_to_evdev=None,
+        )
+        assert code == ecodes.KEY_A
+
+    def test_azerty_letter_a_is_key_q_not_key_a(self):
+        from evdev import ecodes
+
+        code = resolve_token_to_evdev_code(
+            "a",
+            evdev_backend._NAMED_EVDEV_KEYS,
+            ecodes,
+            char_to_evdev=AZERTY_FR_LETTER_TO_EVDEV,
+        )
+        assert code == AZERTY_FR_LETTER_TO_EVDEV["a"]
+        assert code == ecodes.KEY_Q
+        assert code != ecodes.KEY_A
+
+    def test_azerty_letter_q_is_key_a(self):
+        from evdev import ecodes
+
+        code = resolve_token_to_evdev_code(
+            "q",
+            evdev_backend._NAMED_EVDEV_KEYS,
+            ecodes,
+            char_to_evdev=AZERTY_FR_LETTER_TO_EVDEV,
+        )
+        assert code == ecodes.KEY_A
+
+    def test_named_keys_ignore_layout_map(self):
+        from evdev import ecodes
+
+        code = resolve_token_to_evdev_code(
+            "space",
+            evdev_backend._NAMED_EVDEV_KEYS,
+            ecodes,
+            char_to_evdev=AZERTY_FR_LETTER_TO_EVDEV,
+        )
+        assert code == ecodes.KEY_SPACE
+
+    def test_function_keys_ignore_layout_map(self):
+        from evdev import ecodes
+
+        code = resolve_token_to_evdev_code(
+            "f5",
+            evdev_backend._NAMED_EVDEV_KEYS,
+            ecodes,
+            char_to_evdev=AZERTY_FR_LETTER_TO_EVDEV,
+        )
+        assert code == ecodes.KEY_F5
+
+
+@pytest.mark.skipif(not evdev_backend.EVDEV_AVAILABLE, reason="evdev not available")
+class TestEvdevCodeForKeyLayoutAware:
+    def test_explicit_azerty_map_for_token_a(self):
+        from evdev import ecodes
+
+        # Stored shortcut token "a" (as settings capture would store Alt+A)
+        # must resolve to KEY_Q under AZERTY, not KEY_A.
+        code = evdev_backend.evdev_code_for_key("a", char_to_evdev=AZERTY_FR_LETTER_TO_EVDEV)
+        assert code == ecodes.KEY_Q
+        assert code != ecodes.KEY_A
+
+    def test_use_active_layout_false_keeps_us_key_a(self):
+        from evdev import ecodes
+
+        code = evdev_backend.evdev_code_for_key("a", use_active_layout=False)
+        assert code == ecodes.KEY_A
+
+    def test_us_qwerty_r_unchanged_with_azerty_map(self):
+        from evdev import ecodes
+
+        # R is in the same physical place on AZERTY and QWERTY.
+        assert (
+            evdev_backend.evdev_code_for_key("r", char_to_evdev=AZERTY_FR_LETTER_TO_EVDEV)
+            == ecodes.KEY_R
+        )
+
+
+@pytest.mark.skipif(not evdev_backend.EVDEV_AVAILABLE, reason="evdev not available")
+class TestEvdevComboAzertyAltA:
+    """Shipped combo path: stored alt+a + AZERTY map fires on physical KEY_Q."""
+
+    def _event(self, code, value):
+        return types.SimpleNamespace(code=code, value=value, type=1)
+
+    def _backend_with_azerty(self, monkeypatch, shortcut="alt+a", mode="toggle"):
+        """Build a real EvdevKeyboardBackend that resolves letters via AZERTY.
+
+        Only layout detection is replaced; ``evdev_code_for_key`` /
+        ``_resolve_combo_targets`` / combo matching stay on the shipped path.
+        """
+        monkeypatch.setattr(
+            evdev_backend,
+            "get_active_char_to_evdev_map",
+            lambda: AZERTY_FR_LETTER_TO_EVDEV,
+        )
+        return evdev_backend.EvdevKeyboardBackend(shortcut=shortcut, mode=mode)
+
+    def test_resolve_combo_targets_maps_a_to_key_q(self, monkeypatch):
+        from evdev import ecodes
+
+        backend = self._backend_with_azerty(monkeypatch, "alt+a")
+        assert backend._combo_main_code == ecodes.KEY_Q
+        assert backend._combo_main_code != ecodes.KEY_A
+
+    def test_alt_a_fires_on_physical_azerty_a_key(self, monkeypatch):
+        from evdev import ecodes
+
+        from vocalinux.ui.keyboard_backends.evdev_backend import KEY_LEFTALT
+
+        # Config stays character-semantic: "alt+a" (settings capture / #513).
+        backend = self._backend_with_azerty(monkeypatch, "alt+a", "toggle")
+        fired = threading.Event()
+        backend.register_toggle_callback(fired.set)
+
+        # Physical AZERTY "A" key is KEY_Q; with Alt held this must trigger.
+        backend._handle_key_event(self._event(KEY_LEFTALT, 1), None)
+        backend._handle_key_event(self._event(ecodes.KEY_Q, 1), None)
+        assert fired.wait(1.0)
+
+    def test_alt_a_does_not_fire_on_us_key_a_under_azerty(self, monkeypatch):
+        from evdev import ecodes
+
+        from vocalinux.ui.keyboard_backends.evdev_backend import KEY_LEFTALT
+
+        backend = self._backend_with_azerty(monkeypatch, "alt+a", "toggle")
+        fired = threading.Event()
+        backend.register_toggle_callback(fired.set)
+
+        # KEY_A is the key labeled Q on AZERTY; must NOT fire for stored alt+a.
+        backend._handle_key_event(self._event(KEY_LEFTALT, 1), None)
+        backend._handle_key_event(self._event(ecodes.KEY_A, 1), None)
+        assert not fired.wait(0.2)
+
+
+class TestBuildCharMapFromXkb:
+    def test_french_azerty_a_maps_to_key_q(self):
+        char_map = build_char_to_evdev_map("fr")
+        if char_map is None:
+            pytest.skip("libxkbcommon or XKB data not available")
+        from evdev import ecodes
+
+        assert char_map["a"] == ecodes.KEY_Q
+        assert char_map["q"] == ecodes.KEY_A
+        # Sanity: R stays put.
+        assert char_map["r"] == ecodes.KEY_R
+
+    def test_us_layout_letters_match_key_names(self):
+        char_map = build_char_to_evdev_map("us")
+        if char_map is None:
+            pytest.skip("libxkbcommon or XKB data not available")
+        from evdev import ecodes
+
+        assert char_map["a"] == ecodes.KEY_A
+        assert char_map["q"] == ecodes.KEY_Q

--- a/tests/test_layout_key_map.py
+++ b/tests/test_layout_key_map.py
@@ -7,12 +7,20 @@ import types
 
 import pytest
 
+from vocalinux.ui.keyboard_backends import layout_key_map as lkm
 from vocalinux.ui.keyboard_backends.layout_key_map import build_char_to_evdev_map
 
 evdev_backend = pytest.importorskip("vocalinux.ui.keyboard_backends.evdev_backend")
 
 # Minimal AZERTY fr positions for #513 (a ↔ q swap).
 AZERTY = {"a": 16, "q": 30}  # KEY_Q, KEY_A
+
+
+@pytest.fixture(autouse=True)
+def _clear_layout_cache():
+    lkm.get_active_char_to_evdev_map.cache_clear()
+    yield
+    lkm.get_active_char_to_evdev_map.cache_clear()
 
 
 @pytest.mark.skipif(not evdev_backend.EVDEV_AVAILABLE, reason="evdev not available")
@@ -58,3 +66,197 @@ def test_xkb_fr_a_is_key_q():
 
     assert char_map["a"] == ecodes.KEY_Q
     assert char_map["q"] == ecodes.KEY_A
+
+
+# --- layout_key_map coverage: detection, cache, error paths ---
+
+
+def test_build_empty_layout_returns_none():
+    assert build_char_to_evdev_map("") is None
+
+
+def test_build_without_libxkbcommon(monkeypatch):
+    monkeypatch.setattr(lkm, "_load_xkbcommon", lambda: False)
+    assert build_char_to_evdev_map("fr") is None
+
+
+def test_build_context_failure(monkeypatch):
+    class Lib:
+        def xkb_context_new(self, _flags):
+            return None
+
+    monkeypatch.setattr(lkm, "_load_xkbcommon", lambda: Lib())
+    assert build_char_to_evdev_map("fr") is None
+
+
+def test_build_keymap_failure(monkeypatch):
+    unref_called = []
+
+    class Lib:
+        def xkb_context_new(self, _flags):
+            return 1
+
+        def xkb_keymap_new_from_names(self, *_args):
+            return None
+
+        def xkb_context_unref(self, ctx):
+            unref_called.append(ctx)
+
+    monkeypatch.setattr(lkm, "_load_xkbcommon", lambda: Lib())
+    assert build_char_to_evdev_map("fr") is None
+    assert unref_called == [1]
+
+
+def test_load_xkbcommon_oserror(monkeypatch):
+    prev = lkm._xkb_lib
+
+    def boom(_name):
+        raise OSError("missing lib")
+
+    try:
+        lkm._xkb_lib = None
+        monkeypatch.setattr(lkm, "CDLL", boom)
+        assert lkm._load_xkbcommon() is False
+        assert lkm._xkb_lib is False
+        # second call hits the cached False branch
+        assert lkm._load_xkbcommon() is False
+    finally:
+        lkm._xkb_lib = prev
+
+
+def test_detect_gnome_layout_parses_variant(monkeypatch):
+    def fake_run(cmd, **_kwargs):
+        return types.SimpleNamespace(
+            returncode=0,
+            stdout="[('xkb', 'fr+oss'), ('xkb', 'us')]\n",
+        )
+
+    monkeypatch.setattr(lkm.subprocess, "run", fake_run)
+    assert lkm._detect_gnome_layout() == ("fr", "oss")
+
+
+def test_detect_gnome_layout_falls_back_to_sources(monkeypatch):
+    calls = []
+
+    def fake_run(cmd, **_kwargs):
+        key = cmd[-1]
+        calls.append(key)
+        if key == "mru-sources":
+            return types.SimpleNamespace(returncode=0, stdout="@as []\n")
+        return types.SimpleNamespace(
+            returncode=0,
+            stdout="[('xkb', 'de')]\n",
+        )
+
+    monkeypatch.setattr(lkm.subprocess, "run", fake_run)
+    assert lkm._detect_gnome_layout() == ("de", "")
+    assert calls == ["mru-sources", "sources"]
+
+
+def test_detect_gnome_layout_gsettings_missing(monkeypatch):
+    def boom(*_a, **_k):
+        raise OSError("no gsettings")
+
+    monkeypatch.setattr(lkm.subprocess, "run", boom)
+    assert lkm._detect_gnome_layout() == ("", "")
+
+
+def test_detect_gnome_layout_nonzero_exit(monkeypatch):
+    monkeypatch.setattr(
+        lkm.subprocess,
+        "run",
+        lambda *_a, **_k: types.SimpleNamespace(returncode=1, stdout=""),
+    )
+    assert lkm._detect_gnome_layout() == ("", "")
+
+
+def test_get_active_map_us_is_none(monkeypatch):
+    monkeypatch.setattr(lkm, "_detect_gnome_layout", lambda: ("us", ""))
+    assert lkm.get_active_char_to_evdev_map() is None
+
+
+def test_get_active_map_empty_layout(monkeypatch):
+    monkeypatch.setattr(lkm, "_detect_gnome_layout", lambda: ("", ""))
+    assert lkm.get_active_char_to_evdev_map() is None
+
+
+def test_get_active_map_loads_fr(monkeypatch):
+    monkeypatch.setattr(lkm, "_detect_gnome_layout", lambda: ("fr", ""))
+    char_map = lkm.get_active_char_to_evdev_map()
+    if char_map is None:
+        pytest.skip("libxkbcommon or XKB data not available")
+    from evdev import ecodes
+
+    assert char_map["a"] == ecodes.KEY_Q
+
+
+def test_get_active_map_when_build_fails(monkeypatch):
+    monkeypatch.setattr(lkm, "_detect_gnome_layout", lambda: ("fr", ""))
+    monkeypatch.setattr(lkm, "build_char_to_evdev_map", lambda *_a, **_k: None)
+    assert lkm.get_active_char_to_evdev_map() is None
+
+
+def test_build_skips_keys_with_no_levels(monkeypatch):
+    """Keys with zero levels are skipped (line covered via stub lib)."""
+
+    class Lib:
+        def xkb_context_new(self, _f):
+            return 1
+
+        def xkb_keymap_new_from_names(self, *_a):
+            return 2
+
+        def xkb_keymap_min_keycode(self, _km):
+            return 10
+
+        def xkb_keymap_max_keycode(self, _km):
+            return 10
+
+        def xkb_keymap_num_layouts_for_key(self, _km, _kc):
+            return 1
+
+        def xkb_keymap_num_levels_for_key(self, _km, _kc, _layout):
+            return 0
+
+        def xkb_keymap_unref(self, _km):
+            pass
+
+        def xkb_context_unref(self, _ctx):
+            pass
+
+    monkeypatch.setattr(lkm, "_load_xkbcommon", lambda: Lib())
+    assert build_char_to_evdev_map("fr") is None
+
+
+# --- evdev_code_for_key branches on the new layout path ---
+
+
+@pytest.mark.skipif(not evdev_backend.EVDEV_AVAILABLE, reason="evdev not available")
+def test_evdev_code_uses_active_layout_map(monkeypatch):
+    from evdev import ecodes
+
+    monkeypatch.setattr(evdev_backend, "get_active_char_to_evdev_map", lambda: AZERTY)
+    assert evdev_backend.evdev_code_for_key("a") == ecodes.KEY_Q
+    assert evdev_backend.evdev_code_for_key("q") == ecodes.KEY_A
+
+
+@pytest.mark.skipif(not evdev_backend.EVDEV_AVAILABLE, reason="evdev not available")
+def test_evdev_code_us_fallback_letter(monkeypatch):
+    from evdev import ecodes
+
+    monkeypatch.setattr(evdev_backend, "get_active_char_to_evdev_map", lambda: None)
+    assert evdev_backend.evdev_code_for_key("a") == ecodes.KEY_A
+
+
+@pytest.mark.skipif(not evdev_backend.EVDEV_AVAILABLE, reason="evdev not available")
+def test_evdev_code_named_and_function_keys(monkeypatch):
+    from evdev import ecodes
+
+    monkeypatch.setattr(evdev_backend, "get_active_char_to_evdev_map", lambda: AZERTY)
+    assert evdev_backend.evdev_code_for_key("space") == ecodes.KEY_SPACE
+    assert evdev_backend.evdev_code_for_key("f5") == ecodes.KEY_F5
+    assert evdev_backend.evdev_code_for_key("") is None
+    assert evdev_backend.evdev_code_for_key("notakey") is None
+    # single non-alnum char with no layout entry → None (not KEY_*)
+    monkeypatch.setattr(evdev_backend, "get_active_char_to_evdev_map", lambda: None)
+    assert evdev_backend.evdev_code_for_key("@") is None


### PR DESCRIPTION
## Summary

Custom shortcuts on Wayland were broken on non-US layouts: settings capture stores the character you typed (GDK keyval), but the evdev listener mapped letters to fixed US `KEY_*` positions. On AZERTY, recording Alt+A stored `alt+a` while the listener watched for the physical key labeled Q.

This keeps character-semantic tokens in config and resolves them through the active XKB layout (libxkbcommon) so the same physical key works when listening.

Fixes #513

## Root cause

| Path | What it used |
|------|----------------|
| Capture (`_gdk_event_to_shortcut`) | Layout-aware keyval → token `a` |
| Listen (`evdev_code_for_key`) | US `KEY_A` (30), not AZERTY A's physical `KEY_Q` (16) |

## Changes

- Add `layout_key_map.py`: read layout from GNOME gsettings, build char→evdev map via libxkbcommon
- Wire `evdev_code_for_key` / combo resolve through that map (US stays on the old `KEY_*` path)
- Tests for AZERTY Alt+A on the real combo path + XKB `fr` map when available

## Compatibility

Works for **Latin letter combos on GNOME Wayland** when the letter exists unshifted on the layout: AZERTY (`fr`/`be`), QWERTZ, Dvorak, Colemak, Workman, Bépo, Neo, and plain QWERTY. Named keys (`space`, `f5`, …) are unchanged.

Does **not** cover everything:

- Layout detection is **GNOME gsettings only**. KDE/Sway/etc. fall back to US `KEY_*` (same class of bug can still appear there).
- Non-Latin base layouts (`ru`, `ara`, …) have no level-0 `a`–`z`; Latin tokens fall back to US codes.
- Map is cached for the process lifetime (layout switch mid-session needs a restart).
- Evdev/Wayland path only; pynput/X11 is separate.

## Test plan

- [x] `PYTHONPATH=src pytest tests/test_layout_key_map.py tests/test_shortcut_capture.py tests/test_configurable_hotkeys.py`
- [ ] On AZERTY Wayland: record Alt+A, confirm Alt+A toggles (not only Alt+Q)
- [ ] On US QWERTY: existing combos (e.g. Alt+R) still work