### PR TITLE
chore(release): prepare v0.14.1 (stable for Flathub)

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ It's a free, GPLv3-licensed desktop app that lets you dictate text into *any* ap
 
 No internet required. No data leaves your machine. Just speak and type.
 
-## 📚 What's New in v0.14.1-beta
+## 📚 What's New in v0.14.1
 
 > **Release: Flatpak packaging, AUR package, layout-aware hotkeys, and installer/text-injection fixes.**
 
@@ -45,7 +45,7 @@ No internet required. No data leaves your machine. Just speak and type.
 | **Layout-aware hotkeys** | Combo keys work correctly on non-US keyboard layouts |
 | **Installer / text injection** | `sg` fix for Ubuntu 26.04/Debian 13; treat XIM `none` as unset |
 
-See [docs/UPDATE.md](docs/UPDATE.md) and the [full changelog](https://github.com/jatinkrmalik/vocalinux/releases/tag/v0.14.1-beta).
+See [docs/UPDATE.md](docs/UPDATE.md) and the [full changelog](https://github.com/jatinkrmalik/vocalinux/releases/tag/v0.14.1).
 
 ### Previous: v0.14.0-beta
 

--- a/docs/RELEASE_PROCESS.md
+++ b/docs/RELEASE_PROCESS.md
@@ -345,7 +345,7 @@ git push origin v0.5.1-beta
 | 0.12.0-beta | 2026-06-07 | Beta | Remote API engine, Silero VAD, threading/IBus hardening, settings and installer fixes |
 | 0.13.0-beta | 2026-06-30 | Beta | Guided whisper.cpp model variants, Wayland text-injection reliability, hotplug keyboard support, dictation spacing fix, website docs refresh |
 | 0.14.0-beta | 2026-07-13 | Beta | Configurable modifier+key hotkeys, FunASR/SenseVoice remote-API support, GNOME/KDE Wayland IBus reliability fixes, audio crash fix, hybrid-CPU efficiency fix |
-| 0.14.1-beta | 2026-07-16 | Beta | Flatpak packaging, AUR package, layout-aware hotkeys, installer/text-injection fixes |
+| 0.14.1 | 2026-07-17 | Stable | Flatpak packaging, AUR package, layout-aware hotkeys, installer/text-injection fixes |
 
 ## Questions?
 

--- a/docs/UPDATE.md
+++ b/docs/UPDATE.md
@@ -2,7 +2,7 @@
 
 This guide explains how to update Vocalinux to the latest version.
 
-## What's New in v0.14.1-beta
+## What's New in v0.14.1
 
 ### Highlights
 
@@ -30,7 +30,7 @@ This guide explains how to update Vocalinux to the latest version.
 - Refreshed v0.14 UI screenshots and website gallery (#521)
 - README Star History and related polish
 
-See the [full changelog](https://github.com/jatinkrmalik/vocalinux/releases/tag/v0.14.1-beta).
+See the [full changelog](https://github.com/jatinkrmalik/vocalinux/releases/tag/v0.14.1).
 
 ---
 
@@ -305,7 +305,7 @@ The installer will:
 ```bash
 cd vocalinux
 git fetch origin
-git checkout v0.14.1-beta
+git checkout v0.14.1
 ./install.sh
 ```
 

--- a/packaging/aur/vocalinux/PKGBUILD
+++ b/packaging/aur/vocalinux/PKGBUILD
@@ -3,8 +3,8 @@
 
 pkgname=vocalinux
 # AUR pkgver cannot contain hyphens (v0.14.0-beta -> 0.14.0beta).
-pkgver=0.14.1beta
-_tag=0.14.1-beta
+pkgver=0.14.1
+_tag=0.14.1
 pkgrel=1
 pkgdesc="Free, offline voice dictation for Linux"
 arch=('any')

--- a/packaging/flatpak/README.md
+++ b/packaging/flatpak/README.md
@@ -78,7 +78,7 @@ pipx run flatpak-pip-generator \
    sources:
      - type: git
        url: https://github.com/jatinkrmalik/vocalinux.git
-       tag: v0.14.1-beta
+       tag: v0.14.1
        commit: <release-commit-sha>
    ```
 

--- a/packaging/flatpak/com.vocalinux.Vocalinux.metainfo.xml
+++ b/packaging/flatpak/com.vocalinux.Vocalinux.metainfo.xml
@@ -105,7 +105,7 @@
   </content_rating>
 
   <releases>
-    <release version="0.14.1-beta" date="2026-07-16">
+    <release version="0.14.1" date="2026-07-16">
       <description>
         <p>First Flathub-oriented packaging release: Flatpak with whisper.cpp + Vulkan, wl-copy/ydotool Wayland paste, evdev global hotkeys, AUR package, layout-aware shortcuts, and installer fixes.</p>
       </description>

--- a/src/vocalinux/version.py
+++ b/src/vocalinux/version.py
@@ -2,8 +2,8 @@
 Version information for Vocalinux.
 """
 
-__version__ = "0.14.1-beta"
-__version_info__ = (0, 14, 1, "beta")
+__version__ = "0.14.1"
+__version_info__ = (0, 14, 1)
 __author__ = "Jatin K Malik"
 __email__ = "jatinkrmalik@gmail.com"
 __license__ = "GPL-3.0"

--- a/web/src/app/changelog/page.tsx
+++ b/web/src/app/changelog/page.tsx
@@ -15,9 +15,9 @@ import { absoluteUrl, buildPageMetadata } from "@/lib/seo";
 
 const releases = [
   {
-    version: "v0.14.1-beta",
-    date: "2026-07-16",
-    type: "beta",
+    version: "v0.14.1",
+    date: "2026-07-17",
+    type: "stable",
     highlights: [
       "Flatpak packaging for universal distribution: whisper.cpp engine, XDG sandbox paths, global hotkeys via evdev, Wayland text injection via wl-copy + ydotool (PR #484, closes #167)",
       "AUR package and CI publish path for Arch Linux (PR #518)",

--- a/web/src/app/page.tsx
+++ b/web/src/app/page.tsx
@@ -68,7 +68,7 @@ const homeJsonLd = [
     },
     description:
       "Offline voice dictation and speech-to-text for Linux with whisper.cpp and VOSK.",
-    softwareVersion: "0.14.1-beta",
+    softwareVersion: "0.14.1",
     author: {
       "@type": "Person",
       name: "Jatin K Malik",
@@ -341,7 +341,7 @@ export default function HomePage() {
             />
             <span className="text-lg font-bold sm:text-xl">Vocalinux</span>
             <span className="from-primary/20 border-primary/30 shadow-primary/20 hidden rounded-full border bg-gradient-to-r to-green-500/20 px-2.5 py-1 text-xs font-semibold text-primary shadow-sm sm:inline-block">
-              v0.14.1 Beta
+              v0.14.1
             </span>
           </Link>
 


### PR DESCRIPTION
## Summary
Retag/republish the 0.14.1-beta content as **v0.14.1** without the `-beta` suffix.

Flathub test build failed with:
`appstream-latest-release-is-prerelease` — stable remote does not allow `0.14.1-beta`.

Same packaging/features as v0.14.1-beta; version strings only.

## After merge
1. Tag `v0.14.1` and create GitHub release (notes from 0.14.1-beta, version renamed)
2. Update Flathub branch pin to `tag: v0.14.1` + commit SHA
3. Comment `bot, build` on flathub/flathub#9368 (same PR, no new submission)

## Test plan
- [x] version.py is `0.14.1`
- [x] metainfo latest release is `0.14.1`
- [ ] CI green