### PR TITLE
ci(flatpak): reuse builder cache and skip aarch64 on PRs

### DIFF
--- a/.github/workflows/flatpak.yml
+++ b/.github/workflows/flatpak.yml
@@ -24,6 +24,8 @@ concurrency:
 jobs:
   build:
     name: Build Flatpak (${{ matrix.arch }})
+    # PRs: x86_64 only. main / workflow_dispatch: both arches.
+    if: matrix.arch == 'x86_64' || github.event_name != 'pull_request'
     runs-on: ${{ matrix.runner }}
     strategy:
       fail-fast: false
@@ -45,15 +47,12 @@ jobs:
         with:
           bundle: vocalinux-${{ matrix.arch }}.flatpak
           manifest-path: packaging/flatpak/com.vocalinux.Vocalinux.yml
-          cache-key: flatpak-${{ matrix.arch }}-${{ github.sha }}
+          # Stable key so .flatpak-builder cache restores across commits.
+          # github.sha in the key forced a full rebuild every run.
+          # Arch is appended automatically by the action.
+          cache-key: flatpak-builder-${{ hashFiles('packaging/flatpak/**') }}
           arch: ${{ matrix.arch }}
+          artifact-name: vocalinux-flatpak-${{ matrix.arch }}
           # Flathub mirrors screenshots at submission time; mirror locally so the
           # builddir linter does not flag the external screenshot URL.
           mirror-screenshots-url: https://dl.flathub.org/media
-
-      - name: Upload bundle
-        uses: actions/upload-artifact@v4
-        with:
-          name: vocalinux-flatpak-${{ matrix.arch }}
-          path: vocalinux-${{ matrix.arch }}.flatpak
-          if-no-files-found: error


### PR DESCRIPTION
## Summary

Flatpak CI was spending ~13–16 minutes per PR arch because every run rebuilt the world.

- **Stable cache key** — `hashFiles('packaging/flatpak/**')` instead of `github.sha`, so GitHub can restore `.flatpak-builder` and flatpak-builder only rebuilds modules that changed.
- **PR matrix** — x86_64 only on pull requests; dual-arch (x86_64 + aarch64) still runs on `main` and `workflow_dispatch`.
- **One artifact upload** — use the action’s upload with `vocalinux-flatpak-${arch}` and drop the duplicate step.

After a warm cache on `main`, typical `src/`-only PRs should mostly rebuild the app module instead of pywhispercpp/numpy/etc.

## Test plan

- [x] Open this PR and confirm Flatpak runs **x86_64 only** (aarch64 skipped).
- [x] Confirm cache restore works on a second commit to the same PR (or a follow-up PR after merge).
- [ ] After merge to `main`, confirm both arches still run when packaging/src changes.
- [x] Confirm artifact name is still `vocalinux-flatpak-x86_64` (and aarch64 on main).