### PR TITLE
ci(flatpak): fix invalid matrix if in workflow

### DIFF
--- a/.github/workflows/flatpak.yml
+++ b/.github/workflows/flatpak.yml
@@ -22,19 +22,30 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  # matrix is not available in job-level if; build the arch list here instead.
+  # PRs: x86_64 only. main / workflow_dispatch: both arches.
+  matrix:
+    name: Resolve build matrix
+    runs-on: ubuntu-latest
+    outputs:
+      include: ${{ steps.set.outputs.include }}
+    steps:
+      - id: set
+        run: |
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            echo 'include=[{"arch":"x86_64","runner":"ubuntu-latest"}]' >> "$GITHUB_OUTPUT"
+          else
+            echo 'include=[{"arch":"x86_64","runner":"ubuntu-latest"},{"arch":"aarch64","runner":"ubuntu-24.04-arm"}]' >> "$GITHUB_OUTPUT"
+          fi
+
   build:
     name: Build Flatpak (${{ matrix.arch }})
-    # PRs: x86_64 only. main / workflow_dispatch: both arches.
-    if: matrix.arch == 'x86_64' || github.event_name != 'pull_request'
+    needs: matrix
     runs-on: ${{ matrix.runner }}
     strategy:
       fail-fast: false
       matrix:
-        include:
-          - arch: x86_64
-            runner: ubuntu-latest
-          - arch: aarch64
-            runner: ubuntu-24.04-arm
+        include: ${{ fromJSON(needs.matrix.outputs.include) }}
     container:
       image: ghcr.io/flathub-infra/flatpak-github-actions:gnome-50
       options: --privileged


### PR DESCRIPTION
## Summary

#535 broke Flatpak CI with:

```
Invalid workflow file: Unrecognized named-value: 'matrix'
```

Job-level `if` is evaluated before the matrix expands, so `matrix.arch` is not allowed there.

This switches to a small setup job that emits the arch include list (x86_64 only on PRs; both arches on main / `workflow_dispatch`). Cache-key fix from #535 is unchanged.

## Test plan

- [x] PR run: workflow parses; only x86_64 build job runs.
- [x] After merge to main: both x86_64 and aarch64 build.