### PR TITLE
chore(release): prepare v0.14.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,11 +52,7 @@ No internet required. No data leaves your machine. Just speak and type.
 - **IBus**: Restore engine process launch after the Flatpak XDG path import change (no silent ydotool fallback when IBus should work) (#534)
 - **IBus**: Wait for FocusIn before commit on scoped injection so the first dictation of a session is not dropped on GNOME Wayland (#533, fixes #523)
 
-See [docs/UPDATE.md](docs/UPDATE.md) and the [full changelog](https://github.com/jatinkrmalik/vocalinux/releases/tag/v0.14.2).
-
-### Previous: v0.14.1 / v0.14.0-beta
-
-Flatpak/AUR packaging, layout-aware hotkeys, installer fixes, configurable shortcuts, FunASR/SenseVoice, hybrid-CPU and audio crash fixes. Details in [UPDATE.md](docs/UPDATE.md).
+See [docs/UPDATE.md](docs/UPDATE.md) and the [full changelog](https://github.com/jatinkrmalik/vocalinux/releases/tag/v0.14.2). Earlier 0.14.x notes are in UPDATE.md.
 
 ---
 
@@ -433,7 +429,7 @@ Vocalinux is part of a family of privacy-first, offline voice dictation tools. S
 
 | Platform | Project | Website | GitHub | Status |
 |----------|---------|---------|--------|--------|
-| 🐧 Linux | **VocaLinux** | [vocalinux.com](https://vocalinux.com) | [jatinkrmalik/vocalinux](https://github.com/jatinkrmalik/vocalinux) | ✅ Beta v0.14.2 |
+| 🐧 Linux | **VocaLinux** | [vocalinux.com](https://vocalinux.com) | [jatinkrmalik/vocalinux](https://github.com/jatinkrmalik/vocalinux) | ✅ Stable v0.14.2 |
 | 🍎 macOS | **VocaMac** | [vocamac.com](https://vocamac.com) | [jatinkrmalik/vocamac](https://github.com/jatinkrmalik/vocamac) | 🚀 Beta |
 | 🪟 Windows | **VocaWin** | [vocawin.com](https://vocawin.com) | [jatinkrmalik/vocawin](https://github.com/jatinkrmalik/vocawin) | 📋 Planned |
 

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ No internet required. No data leaves your machine. Just speak and type.
 
 ## 📚 What's New in v0.14.2
 
-> **0.14.2 is a stability patch on the 0.14 series.** Feature set is the same as 0.14.x; this release fixes two IBus reliability bugs.
+> **0.14.2 is a stability patch on the 0.14 series.** Feature set is the same as 0.14.x; this release fixes IBus reliability and settings dialog sizing.
 
 ### 0.14 series highlights
 
@@ -51,6 +51,7 @@ No internet required. No data leaves your machine. Just speak and type.
 
 - **IBus**: Restore engine process launch after the Flatpak XDG path import change (no silent ydotool fallback when IBus should work) (#534)
 - **IBus**: Wait for FocusIn before commit on scoped injection so the first dictation of a session is not dropped on GNOME Wayland (#533, fixes #523)
+- **Settings UI**: Tabs scroll so the dialog fits the monitor; wheel events from unfocused combos/spins reach the tab scroller (#538, #541)
 
 See [docs/UPDATE.md](docs/UPDATE.md) and the [full changelog](https://github.com/jatinkrmalik/vocalinux/releases/tag/v0.14.2). Earlier 0.14.x notes are in UPDATE.md.
 

--- a/README.md
+++ b/README.md
@@ -32,24 +32,31 @@ It's a free, GPLv3-licensed desktop app that lets you dictate text into *any* ap
 
 No internet required. No data leaves your machine. Just speak and type.
 
-## 📚 What's New in v0.14.1
+## 📚 What's New in v0.14.2
 
-> **Release: Flatpak packaging, AUR package, layout-aware hotkeys, and installer/text-injection fixes.**
+> **0.14.2 is a stability patch on the 0.14 series.** Feature set is the same as 0.14.x; this release fixes two IBus reliability bugs.
 
-### Highlights
+### 0.14 series highlights
 
 | Feature | Description |
 |---------|-------------|
-| **Flatpak packaging** | Distro-independent install with whisper.cpp, global hotkeys (evdev), and Wayland text injection (wl-copy + ydotool) |
+| **Configurable hotkeys** | Bind any modifier combination to a key (e.g. `Alt+R`, `Ctrl+Shift+V`) |
+| **FunASR / SenseVoice** | Remote-API engine supports FunASR and SenseVoice models |
+| **Flatpak packaging** | Distro-independent install with whisper.cpp, global hotkeys (evdev), and Wayland paste (wl-copy + ydotool) |
 | **AUR package** | Arch users can install via `yay -S vocalinux` |
 | **Layout-aware hotkeys** | Combo keys work correctly on non-US keyboard layouts |
-| **Installer / text injection** | `sg` fix for Ubuntu 26.04/Debian 13; treat XIM `none` as unset |
+| **Wayland / IBus reliability** | GNOME and KDE injection fixes, first-dictation FocusIn gate, engine process launch restored |
 
-See [docs/UPDATE.md](docs/UPDATE.md) and the [full changelog](https://github.com/jatinkrmalik/vocalinux/releases/tag/v0.14.1).
+### Bug fixes in v0.14.2
 
-### Previous: v0.14.0-beta
+- **IBus**: Restore engine process launch after the Flatpak XDG path import change (no silent ydotool fallback when IBus should work) (#534)
+- **IBus**: Wait for FocusIn before commit on scoped injection so the first dictation of a session is not dropped on GNOME Wayland (#533, fixes #523)
 
-Configurable shortcuts, FunASR/SenseVoice remote API, Wayland IBus reliability, audio crash fix, hybrid-CPU efficiency. Details in [UPDATE.md](docs/UPDATE.md).
+See [docs/UPDATE.md](docs/UPDATE.md) and the [full changelog](https://github.com/jatinkrmalik/vocalinux/releases/tag/v0.14.2).
+
+### Previous: v0.14.1 / v0.14.0-beta
+
+Flatpak/AUR packaging, layout-aware hotkeys, installer fixes, configurable shortcuts, FunASR/SenseVoice, hybrid-CPU and audio crash fixes. Details in [UPDATE.md](docs/UPDATE.md).
 
 ---
 
@@ -426,7 +433,7 @@ Vocalinux is part of a family of privacy-first, offline voice dictation tools. S
 
 | Platform | Project | Website | GitHub | Status |
 |----------|---------|---------|--------|--------|
-| 🐧 Linux | **VocaLinux** | [vocalinux.com](https://vocalinux.com) | [jatinkrmalik/vocalinux](https://github.com/jatinkrmalik/vocalinux) | ✅ Beta v0.14.1 |
+| 🐧 Linux | **VocaLinux** | [vocalinux.com](https://vocalinux.com) | [jatinkrmalik/vocalinux](https://github.com/jatinkrmalik/vocalinux) | ✅ Beta v0.14.2 |
 | 🍎 macOS | **VocaMac** | [vocamac.com](https://vocamac.com) | [jatinkrmalik/vocamac](https://github.com/jatinkrmalik/vocamac) | 🚀 Beta |
 | 🪟 Windows | **VocaWin** | [vocawin.com](https://vocawin.com) | [jatinkrmalik/vocawin](https://github.com/jatinkrmalik/vocawin) | 📋 Planned |
 

--- a/docs/RELEASE_PROCESS.md
+++ b/docs/RELEASE_PROCESS.md
@@ -357,7 +357,7 @@ git push origin v0.5.1-beta
 | 0.13.0-beta | 2026-06-30 | Beta | Guided whisper.cpp model variants, Wayland text-injection reliability, hotplug keyboard support, dictation spacing fix, website docs refresh |
 | 0.14.0-beta | 2026-07-13 | Beta | Configurable modifier+key hotkeys, FunASR/SenseVoice remote-API support, GNOME/KDE Wayland IBus reliability fixes, audio crash fix, hybrid-CPU efficiency fix |
 | 0.14.1 | 2026-07-17 | Stable | Flatpak packaging, AUR package, layout-aware hotkeys, installer/text-injection fixes |
-| 0.14.2 | 2026-07-17 | Stable | IBus engine process launch restore after XDG import; first-dictation FocusIn gate on GNOME Wayland |
+| 0.14.2 | 2026-07-17 | Stable | IBus engine launch + FocusIn gate; settings tabs scroll to fit monitor |
 
 ## Questions?
 

--- a/docs/RELEASE_PROCESS.md
+++ b/docs/RELEASE_PROCESS.md
@@ -97,6 +97,15 @@ Change the Development Status classifier:
 "Development Status :: 5 - Production/Stable",
 ```
 
+### Patch releases within a minor line (e.g. 0.14.x)
+
+When shipping bug fixes only (PATCH bump, same MINOR):
+
+- **README / `docs/UPDATE.md` "What's New"** keeps the **minor-series feature list** (everything introduced in that 0.Y line) and adds a short **Bug fixes in this patch** subsection for the delta only. Do not make the marketing highlight table look featureless because this tag only contains fixes.
+- **Website changelog** (`web/src/app/changelog/page.tsx`) may list only the delta for the new entry; older entries stay historical.
+- **AppStream** (`packaging/flatpak/com.vocalinux.Vocalinux.metainfo.xml`): add a `<release>` note for the patch; leave the long product feature `<ul>` as series/product-level.
+- **SECURITY.md** supported versions table usually stays on the minor line (`0.14.x`) without a row per patch.
+
 ### Step 3: Update Documentation
 
 #### 3.1 Update `README.md`
@@ -346,6 +355,7 @@ git push origin v0.5.1-beta
 | 0.13.0-beta | 2026-06-30 | Beta | Guided whisper.cpp model variants, Wayland text-injection reliability, hotplug keyboard support, dictation spacing fix, website docs refresh |
 | 0.14.0-beta | 2026-07-13 | Beta | Configurable modifier+key hotkeys, FunASR/SenseVoice remote-API support, GNOME/KDE Wayland IBus reliability fixes, audio crash fix, hybrid-CPU efficiency fix |
 | 0.14.1 | 2026-07-17 | Stable | Flatpak packaging, AUR package, layout-aware hotkeys, installer/text-injection fixes |
+| 0.14.2 | 2026-07-16 | Stable | IBus engine process launch restore after XDG import; first-dictation FocusIn gate on GNOME Wayland |
 
 ## Questions?
 

--- a/docs/RELEASE_PROCESS.md
+++ b/docs/RELEASE_PROCESS.md
@@ -103,8 +103,10 @@ When shipping bug fixes only (PATCH bump, same MINOR):
 
 - **README / `docs/UPDATE.md` "What's New"** keeps the **minor-series feature list** (everything introduced in that 0.Y line) and adds a short **Bug fixes in this patch** subsection for the delta only. Do not make the marketing highlight table look featureless because this tag only contains fixes.
 - **Website changelog** (`web/src/app/changelog/page.tsx`) may list only the delta for the new entry; older entries stay historical.
-- **AppStream** (`packaging/flatpak/com.vocalinux.Vocalinux.metainfo.xml`): add a `<release>` note for the patch; leave the long product feature `<ul>` as series/product-level.
+- **AppStream** (`packaging/flatpak/com.vocalinux.Vocalinux.metainfo.xml`): add a short `<release>` note for the patch delta only; leave the long product feature `<ul>` as series/product-level.
 - **SECURITY.md** supported versions table usually stays on the minor line (`0.14.x`) without a row per patch.
+- **AUR PKGBUILD**: bump `pkgver` / `_tag`; leave `sha256sums=('SKIP')` until the tag tarball exists. The release workflow runs `updpkgsums` when publishing to the AUR.
+- **Dates**: patch release dates must not predate the previous release in changelog / AppStream / version history.
 
 ### Step 3: Update Documentation
 
@@ -355,7 +357,7 @@ git push origin v0.5.1-beta
 | 0.13.0-beta | 2026-06-30 | Beta | Guided whisper.cpp model variants, Wayland text-injection reliability, hotplug keyboard support, dictation spacing fix, website docs refresh |
 | 0.14.0-beta | 2026-07-13 | Beta | Configurable modifier+key hotkeys, FunASR/SenseVoice remote-API support, GNOME/KDE Wayland IBus reliability fixes, audio crash fix, hybrid-CPU efficiency fix |
 | 0.14.1 | 2026-07-17 | Stable | Flatpak packaging, AUR package, layout-aware hotkeys, installer/text-injection fixes |
-| 0.14.2 | 2026-07-16 | Stable | IBus engine process launch restore after XDG import; first-dictation FocusIn gate on GNOME Wayland |
+| 0.14.2 | 2026-07-17 | Stable | IBus engine process launch restore after XDG import; first-dictation FocusIn gate on GNOME Wayland |
 
 ## Questions?
 

--- a/docs/UPDATE.md
+++ b/docs/UPDATE.md
@@ -4,7 +4,7 @@ This guide explains how to update Vocalinux to the latest version.
 
 ## What's New in v0.14.2
 
-0.14.2 is a stability patch on the **0.14 series**. The feature set is the same as 0.14.x; this release only fixes IBus reliability.
+0.14.2 is a stability patch on the **0.14 series**. The feature set is the same as 0.14.x; this release fixes IBus reliability and settings dialog sizing.
 
 ### 0.14 series highlights
 
@@ -22,6 +22,7 @@ This guide explains how to update Vocalinux to the latest version.
 
 - **IBus**: Restore engine process launch after the Flatpak XDG path import change. `start_engine_process` and the IBus component exec run `ibus_engine.py` by path, so the relative import failed with `ImportError` and Vocalinux fell back to ydotool/clipboard paste (#534)
 - **IBus**: Wait for FocusIn before commit on scoped injection. Cold first activation on GNOME Wayland could commit before mutter bound a client context, so the first dictation of a session was dropped while logs still reported success (#533, fixes #523)
+- **Settings UI**: Wrap each notebook tab in a vertical ScrolledWindow so the dialog fits 1080p monitors instead of growing past the screen; forward wheel events from unfocused combos/spins to the tab scroller and drop nested Advanced ScrolledWindow shadows (#538, #541)
 
 See the [full changelog](https://github.com/jatinkrmalik/vocalinux/releases/tag/v0.14.2).
 

--- a/docs/UPDATE.md
+++ b/docs/UPDATE.md
@@ -23,11 +23,6 @@ This guide explains how to update Vocalinux to the latest version.
 - **IBus**: Restore engine process launch after the Flatpak XDG path import change. `start_engine_process` and the IBus component exec run `ibus_engine.py` by path, so the relative import failed with `ImportError` and Vocalinux fell back to ydotool/clipboard paste (#534)
 - **IBus**: Wait for FocusIn before commit on scoped injection. Cold first activation on GNOME Wayland could commit before mutter bound a client context, so the first dictation of a session was dropped while logs still reported success (#533, fixes #523)
 
-### Also in 0.14.x (unchanged this patch)
-
-- Flatpak packaging, AUR package, layout-aware hotkeys, installer/`sg` and XIM fixes (0.14.1)
-- Configurable hotkeys, FunASR/SenseVoice, GNOME/KDE Wayland IBus paths, modifier-release wait, hybrid-CPU and audio crash fixes (0.14.0)
-
 See the [full changelog](https://github.com/jatinkrmalik/vocalinux/releases/tag/v0.14.2).
 
 ---

--- a/docs/UPDATE.md
+++ b/docs/UPDATE.md
@@ -2,6 +2,36 @@
 
 This guide explains how to update Vocalinux to the latest version.
 
+## What's New in v0.14.2
+
+0.14.2 is a stability patch on the **0.14 series**. The feature set is the same as 0.14.x; this release only fixes IBus reliability.
+
+### 0.14 series highlights
+
+| Feature | Description |
+|---------|-------------|
+| **Configurable Shortcuts** | Bind any modifier combination to a key — e.g. `Alt+R`, `Ctrl+Shift+V`, or `Super+F10` |
+| **FunASR / SenseVoice Remote API** | Remote-API engine supports FunASR and SenseVoice via OpenAI-compatible endpoints |
+| **Flatpak packaging** | Universal Flatpak (whisper.cpp) with sandbox-aware paths, global hotkeys, and Wayland paste injection |
+| **AUR package** | Official Arch packaging and CI publish path |
+| **Layout-aware hotkeys** | Combo keys respect non-US layouts |
+| **Wayland / IBus reliability** | GNOME and KDE injection fixes, first-dictation FocusIn gate, engine process launch restored |
+| **Audio / hybrid-CPU** | Recording device-index crash fixed; whisper.cpp no longer defaults to all cores on hybrid CPUs |
+
+### Bug fixes in v0.14.2
+
+- **IBus**: Restore engine process launch after the Flatpak XDG path import change. `start_engine_process` and the IBus component exec run `ibus_engine.py` by path, so the relative import failed with `ImportError` and Vocalinux fell back to ydotool/clipboard paste (#534)
+- **IBus**: Wait for FocusIn before commit on scoped injection. Cold first activation on GNOME Wayland could commit before mutter bound a client context, so the first dictation of a session was dropped while logs still reported success (#533, fixes #523)
+
+### Also in 0.14.x (unchanged this patch)
+
+- Flatpak packaging, AUR package, layout-aware hotkeys, installer/`sg` and XIM fixes (0.14.1)
+- Configurable hotkeys, FunASR/SenseVoice, GNOME/KDE Wayland IBus paths, modifier-release wait, hybrid-CPU and audio crash fixes (0.14.0)
+
+See the [full changelog](https://github.com/jatinkrmalik/vocalinux/releases/tag/v0.14.2).
+
+---
+
 ## What's New in v0.14.1
 
 ### Highlights
@@ -305,7 +335,7 @@ The installer will:
 ```bash
 cd vocalinux
 git fetch origin
-git checkout v0.14.1
+git checkout v0.14.2
 ./install.sh
 ```
 

--- a/packaging/aur/vocalinux/PKGBUILD
+++ b/packaging/aur/vocalinux/PKGBUILD
@@ -3,8 +3,8 @@
 
 pkgname=vocalinux
 # AUR pkgver cannot contain hyphens (v0.14.0-beta -> 0.14.0beta).
-pkgver=0.14.1
-_tag=0.14.1
+pkgver=0.14.2
+_tag=0.14.2
 pkgrel=1
 pkgdesc="Free, offline voice dictation for Linux"
 arch=('any')

--- a/packaging/aur/vocalinux/PKGBUILD
+++ b/packaging/aur/vocalinux/PKGBUILD
@@ -48,7 +48,8 @@ optdepends=(
 )
 conflicts=('vocalinux-git')
 source=("${pkgname}-${_tag}.tar.gz::https://github.com/jatinkrmalik/vocalinux/archive/refs/tags/v${_tag}.tar.gz")
-sha256sums=('030dfe1ddbc51672c7bfb0f471c256a998fe871bd190028dd882e4507d00af58')
+# SKIP until the v${_tag} tarball exists. release.yml sets updpkgsums=true on publish.
+sha256sums=('SKIP')
 
 build() {
   cd "${pkgname}-${_tag}"

--- a/packaging/flatpak/README.md
+++ b/packaging/flatpak/README.md
@@ -78,7 +78,7 @@ pipx run flatpak-pip-generator \
    sources:
      - type: git
        url: https://github.com/jatinkrmalik/vocalinux.git
-       tag: v0.14.1
+       tag: v0.14.2
        commit: <release-commit-sha>
    ```
 

--- a/packaging/flatpak/com.vocalinux.Vocalinux.metainfo.xml
+++ b/packaging/flatpak/com.vocalinux.Vocalinux.metainfo.xml
@@ -107,7 +107,7 @@
   <releases>
     <release version="0.14.2" date="2026-07-17">
       <description>
-        <p>IBus stability: restore engine process launch after XDG path import; do not drop the first dictation of a session on GNOME Wayland (FocusIn gate).</p>
+        <p>IBus stability (engine process launch after XDG path import; first-dictation FocusIn gate on GNOME Wayland) and settings dialog tabs that scroll so the window fits the monitor.</p>
       </description>
     </release>
     <release version="0.14.1" date="2026-07-16">

--- a/packaging/flatpak/com.vocalinux.Vocalinux.metainfo.xml
+++ b/packaging/flatpak/com.vocalinux.Vocalinux.metainfo.xml
@@ -105,6 +105,11 @@
   </content_rating>
 
   <releases>
+    <release version="0.14.2" date="2026-07-16">
+      <description>
+        <p>Stability patch on the 0.14 series: IBus engine process launch restored after XDG path import, and first dictation of a session no longer dropped on GNOME Wayland. Feature set unchanged (Flatpak, AUR, configurable hotkeys, FunASR/SenseVoice, layout-aware shortcuts).</p>
+      </description>
+    </release>
     <release version="0.14.1" date="2026-07-16">
       <description>
         <p>First Flathub-oriented packaging release: Flatpak with whisper.cpp + Vulkan, wl-copy/ydotool Wayland paste, evdev global hotkeys, AUR package, layout-aware shortcuts, and installer fixes.</p>

--- a/packaging/flatpak/com.vocalinux.Vocalinux.metainfo.xml
+++ b/packaging/flatpak/com.vocalinux.Vocalinux.metainfo.xml
@@ -105,9 +105,9 @@
   </content_rating>
 
   <releases>
-    <release version="0.14.2" date="2026-07-16">
+    <release version="0.14.2" date="2026-07-17">
       <description>
-        <p>Stability patch on the 0.14 series: IBus engine process launch restored after XDG path import, and first dictation of a session no longer dropped on GNOME Wayland. Feature set unchanged (Flatpak, AUR, configurable hotkeys, FunASR/SenseVoice, layout-aware shortcuts).</p>
+        <p>IBus stability: restore engine process launch after XDG path import; do not drop the first dictation of a session on GNOME Wayland (FocusIn gate).</p>
       </description>
     </release>
     <release version="0.14.1" date="2026-07-16">

--- a/src/vocalinux/__init__.py
+++ b/src/vocalinux/__init__.py
@@ -7,13 +7,14 @@ This is important for pip/pipx installations where PyGObject is installed
 but system typelibs (AppIndicator3, etc.) may not be accessible.
 """
 
-__version__ = "0.1.0"
-
 # Import common types first to avoid circular imports
 from .common_types import RecognitionState  # noqa: F401
 
 # Import non-GTK modules that are safe to import at package level
 from .utils import ResourceManager
+
+# Single source of truth lives in version.py (also used by pyproject dynamic version).
+from .version import __version__  # noqa: F401
 
 # Note: speech_recognition, text_injection, and ui.tray_indicator
 # are imported lazily in main.py to handle missing GTK gracefully

--- a/src/vocalinux/speech_recognition/recognition_manager.py
+++ b/src/vocalinux/speech_recognition/recognition_manager.py
@@ -23,6 +23,7 @@ from ..ui.audio_feedback import play_error_sound, play_start_sound, play_stop_so
 from ..utils.paths import models_dir
 from ..utils.vosk_model_info import VOSK_MODEL_INFO
 from ..utils.whispercpp_model_info import WHISPERCPP_MODEL_INFO, get_model_path, is_model_downloaded
+from ..version import __version__
 from .command_processor import CommandProcessor
 from .silero_vad import SILERO_CHUNK_SIZE, load_silero_vad
 
@@ -1700,7 +1701,7 @@ class SpeechRecognitionManager:
             url,
             stream=True,
             timeout=self._MODEL_DOWNLOAD_TIMEOUT,
-            headers={"User-Agent": "vocalinux/0.14.2"},
+            headers={"User-Agent": f"vocalinux/{__version__}"},
         )
         response.raise_for_status()
 

--- a/src/vocalinux/speech_recognition/recognition_manager.py
+++ b/src/vocalinux/speech_recognition/recognition_manager.py
@@ -1700,7 +1700,7 @@ class SpeechRecognitionManager:
             url,
             stream=True,
             timeout=self._MODEL_DOWNLOAD_TIMEOUT,
-            headers={"User-Agent": "vocalinux/0.14.1"},
+            headers={"User-Agent": "vocalinux/0.14.2"},
         )
         response.raise_for_status()
 

--- a/src/vocalinux/version.py
+++ b/src/vocalinux/version.py
@@ -2,8 +2,8 @@
 Version information for Vocalinux.
 """
 
-__version__ = "0.14.1"
-__version_info__ = (0, 14, 1)
+__version__ = "0.14.2"
+__version_info__ = (0, 14, 2)
 __author__ = "Jatin K Malik"
 __email__ = "jatinkrmalik@gmail.com"
 __license__ = "GPL-3.0"

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -18,6 +18,13 @@ class TestVersion(unittest.TestCase):
         parts = __version__.replace("-", ".").split(".")
         self.assertTrue(len(parts) >= 3)
 
+    def test_package_version_matches_version_module(self):
+        """Package root re-exports version.py so import vocalinux.__version__ is correct."""
+        import vocalinux
+        from vocalinux.version import __version__
+
+        self.assertEqual(vocalinux.__version__, __version__)
+
     def test_version_info_tuple(self):
         """Test that version info tuple exists and is valid."""
         from vocalinux.version import __version_info__

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vocalinux-website",
-  "version": "0.14.1",
+  "version": "0.14.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vocalinux-website",
-      "version": "0.14.1",
+      "version": "0.14.2",
       "dependencies": {
         "@types/node": "^20.14.10",
         "@types/react": "^18.3.3",

--- a/web/package.json
+++ b/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vocalinux-website",
-  "version": "0.14.1",
+  "version": "0.14.2",
   "private": true,
   "type": "module",
   "scripts": {

--- a/web/src/app/changelog/page.tsx
+++ b/web/src/app/changelog/page.tsx
@@ -16,12 +16,11 @@ import { absoluteUrl, buildPageMetadata } from "@/lib/seo";
 const releases = [
   {
     version: "v0.14.2",
-    date: "2026-07-16",
+    date: "2026-07-17",
     type: "stable",
     highlights: [
       "IBus: restore engine process launch after Flatpak XDG path import so the engine no longer dies with ImportError and falls back to ydotool/clipboard paste (PR #534)",
       "IBus: wait for FocusIn before commit on scoped injection so the first dictation of a session is not dropped on GNOME Wayland (PR #533, fixes #523)",
-      "0.14 series feature set unchanged: Flatpak, AUR, configurable hotkeys, FunASR/SenseVoice, layout-aware shortcuts, Wayland IBus reliability",
     ],
   },
   {

--- a/web/src/app/changelog/page.tsx
+++ b/web/src/app/changelog/page.tsx
@@ -15,6 +15,16 @@ import { absoluteUrl, buildPageMetadata } from "@/lib/seo";
 
 const releases = [
   {
+    version: "v0.14.2",
+    date: "2026-07-16",
+    type: "stable",
+    highlights: [
+      "IBus: restore engine process launch after Flatpak XDG path import so the engine no longer dies with ImportError and falls back to ydotool/clipboard paste (PR #534)",
+      "IBus: wait for FocusIn before commit on scoped injection so the first dictation of a session is not dropped on GNOME Wayland (PR #533, fixes #523)",
+      "0.14 series feature set unchanged: Flatpak, AUR, configurable hotkeys, FunASR/SenseVoice, layout-aware shortcuts, Wayland IBus reliability",
+    ],
+  },
+  {
     version: "v0.14.1",
     date: "2026-07-17",
     type: "stable",

--- a/web/src/app/changelog/page.tsx
+++ b/web/src/app/changelog/page.tsx
@@ -21,6 +21,7 @@ const releases = [
     highlights: [
       "IBus: restore engine process launch after Flatpak XDG path import so the engine no longer dies with ImportError and falls back to ydotool/clipboard paste (PR #534)",
       "IBus: wait for FocusIn before commit on scoped injection so the first dictation of a session is not dropped on GNOME Wayland (PR #533, fixes #523)",
+      "Settings UI: notebook tabs scroll so the dialog fits the monitor; wheel events from unfocused combos/spins reach the tab scroller (PR #538, #541)",
     ],
   },
   {

--- a/web/src/app/page.tsx
+++ b/web/src/app/page.tsx
@@ -68,7 +68,7 @@ const homeJsonLd = [
     },
     description:
       "Offline voice dictation and speech-to-text for Linux with whisper.cpp and VOSK.",
-    softwareVersion: "0.14.1",
+    softwareVersion: "0.14.2",
     author: {
       "@type": "Person",
       name: "Jatin K Malik",
@@ -341,7 +341,7 @@ export default function HomePage() {
             />
             <span className="text-lg font-bold sm:text-xl">Vocalinux</span>
             <span className="from-primary/20 border-primary/30 shadow-primary/20 hidden rounded-full border bg-gradient-to-r to-green-500/20 px-2.5 py-1 text-xs font-semibold text-primary shadow-sm sm:inline-block">
-              v0.14.1
+              v0.14.2
             </span>
           </Link>
 


### PR DESCRIPTION
## Summary

Prepares **v0.14.2**, a stability patch on the 0.14 series (no new features).

### Product fixes included (already on main)

- **#534** — Restore IBus engine process launch after Flatpak XDG path import (no silent ydotool fallback)
- **#533** — Wait for FocusIn before commit on scoped injection so the first dictation of a session is not dropped on GNOME Wayland (fixes #523)
- **#538** — Make settings notebook tabs scrollable so the dialog fits the monitor (was taller than 1080p)
- **#541** — Polish settings tab scrolling: forward wheel events from unfocused combos/spins, drop nested Advanced ScrolledWindow, clear scroller shadows

Also rides along (CI-only, not user-facing):

- **#535** / **#536** — Flatpak CI cache and arch matrix fixes

### Release prep in this PR

- Bump version to `0.14.2` (`version.py`, package `__init__` re-export, web package, AUR PKGBUILD with `sha256sums=SKIP`)
- Download User-Agent uses `__version__` (no hardcoded string)
- **Series-aware docs**: README / UPDATE keep the full 0.14 feature set and add a short "bug fixes in this patch" section
- Website badge, schema version, and changelog entry for the delta
- Flatpak AppStream release note + packaging README tag example
- Document the patch-release docs rule (and AUR SKIP / date rules) in `docs/RELEASE_PROCESS.md`

### Branch note

Rebased onto latest `main` so #538 and #541 are included in the release line.

## After merge

1. Tag: `git tag -a v0.14.2 -m "Release 0.14.2"` and `git push origin v0.14.2`
2. Confirm GitHub Release / PyPI / website / AUR automation
3. Re-pin or update [Flathub PR #9368](https://github.com/flathub/flathub/pull/9368) to `v0.14.2` (currently still on `v0.14.1-beta`)

## Checklist

- [x] Version files updated
- [x] Series-aware README / UPDATE
- [x] Website + changelog
- [x] Flatpak metainfo
- [x] Pre-commit (black/isort/flake8) clean on commit
- [x] Rebased onto latest main (#538 and #541 included)
- [ ] CI green after rebase
- [ ] Tag after merge (do not tag from this branch alone)
