### PR TITLE
fix(ui): settings dialog opens taller than the monitor on 1080p displays

### DIFF
--- a/src/vocalinux/ui/settings_dialog.py
+++ b/src/vocalinux/ui/settings_dialog.py
@@ -1041,7 +1041,7 @@ class SettingsDialog(Gtk.Dialog):
         else:
             screen_height = 1080  # Default fallback
             screen_width = 1920
-        dialog_height = min(600, int(screen_height * 0.4))
+        dialog_height = min(800, int(screen_height * 0.75))
         dialog_width = min(700, int(screen_width * 0.8))
         self.set_default_size(dialog_width, dialog_height)
         self.get_style_context().add_class("settings-dialog")
@@ -1093,38 +1093,49 @@ class SettingsDialog(Gtk.Dialog):
         self.advanced_tab.set_margin_start(16)
         self.advanced_tab.set_margin_end(16)
 
-        # Add tabs to notebook (ordered by importance)
+        # Add tabs to notebook (ordered by importance). Each tab is wrapped in a
+        # vertical ScrolledWindow: without one, the notebook's minimum height is
+        # the tallest tab's full content (~1000px), which overrides
+        # set_default_size and makes the dialog taller than the monitor.
+        def _scrollable(tab):
+            scroller = Gtk.ScrolledWindow()
+            scroller.set_policy(Gtk.PolicyType.NEVER, Gtk.PolicyType.AUTOMATIC)
+            scroller.add(tab)
+            return scroller
+
         # Speech Engine tab - most important (what model/language to use)
         speech_engine_label = Gtk.Label(label="Speech Engine")
         speech_engine_label.set_tooltip_text("Speech recognition engine and model settings")
-        notebook.append_page(self.speech_engine_tab, speech_engine_label)
+        notebook.append_page(_scrollable(self.speech_engine_tab), speech_engine_label)
 
         # Recognition Settings tab - second most important (how to recognize)
         recognition_label = Gtk.Label(label="Recognition")
         recognition_label.set_tooltip_text("Recognition behavior and test settings")
-        notebook.append_page(self.recognition_settings_tab, recognition_label)
+        notebook.append_page(_scrollable(self.recognition_settings_tab), recognition_label)
 
         # Audio tab - third (hardware configuration)
         audio_label = Gtk.Label(label="Audio")
         audio_label.set_tooltip_text("Microphone and audio settings")
-        notebook.append_page(self.audio_tab, audio_label)
+        notebook.append_page(_scrollable(self.audio_tab), audio_label)
 
         # Shortcuts tab
         shortcuts_label = Gtk.Label(label="Shortcuts")
         shortcuts_label.set_tooltip_text("Keyboard shortcuts")
-        notebook.append_page(self.shortcuts_tab, shortcuts_label)
+        notebook.append_page(_scrollable(self.shortcuts_tab), shortcuts_label)
 
         # General tab - least important (application behavior)
         general_label = Gtk.Label(label="General")
         general_label.set_tooltip_text("General settings")
-        notebook.append_page(self.general_tab, general_label)
+        notebook.append_page(_scrollable(self.general_tab), general_label)
 
         # Advanced tab - whisper.cpp parameters and power-user features (remote API, etc.)
         advanced_label = Gtk.Label(label="Advanced")
         advanced_label.set_tooltip_text(
             "Advanced whisper.cpp parameters and settings for power users"
         )
-        self.advanced_page_num = notebook.append_page(self.advanced_tab, advanced_label)
+        self.advanced_page_num = notebook.append_page(
+            _scrollable(self.advanced_tab), advanced_label
+        )
         notebook.connect("switch-page", self._on_settings_page_switched)
 
         self.get_content_area().pack_start(notebook, True, True, 0)


### PR DESCRIPTION
## Description

Problem

Opening the Settings dialog from the tray icon produces a window ~1350px tall, which doesn't fit on a 1080p monitor. On a multi-monitor setup it spans two screens (photo below); on a single monitor the Close button ends up below the screen edge. It has to be manually resized every time it opens.

Root cause
SettingsDialog calls set_default_size(min(700, …), min(600, …)), but in GTK that's only a suggestion — a window can never be smaller than its content's minimum size, and none of the notebook tabs scroll. Gtk.Notebook requests the minimum height of its tallest page (including hidden ones). Measured with get_preferred_size(): the Speech Engine tab needs ~950px and the Recognition tab ~1080px, giving the dialog a minimum of 700×1351 — so GTK silently discards the requested default size.

Fix
- Wrap each notebook tab in a vertical-only Gtk.ScrolledWindow, collapsing the notebook's minimum height (~1000px → ~100px) so the default size actually takes effect. Tall content scrolls within its tab instead of stretching the window.
- Raise the default height from min(600, 40% of screen) to min(800, 75% of screen), since content that doesn't fit now scrolls — on 1080p the dialog opens at 700×800.

Only page widgets were wrapped; page indices (advanced_page_num, switch-page handling) are unchanged.

Verification
- Before: opens at 700×1351 (minimum 684×1161). After: opens at 700×800 (minimum 684×243), measured on a 1920×1080 monitor under Wayland.
- All 71 tests in test_settings_dialog.py, test_settings_mode_change.py, and test_settings_shortcuts.py pass.

## Type of Change

- [X ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 📖 Documentation update
- [ ] 🧹 Code refactoring
- [ ] ✅ Test update

## Checklist

- [ ]X My code follows the code style of this project (black, isort)
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests pass locally
- [ ] Pre-commit hooks pass

## Screenshots (if applicable)

See how the dialog is larger than a single screen and sizes it's self into the top monitor 😉
<img width="960" height="1280" alt="overlapping-settings-dialog" src="https://github.com/user-attachments/assets/03cf811e-1608-4298-a6dc-e9d33d716cde" />

## Additional Notes
Happens every time I open settings (it's annoying to resize).
Please check this FIX according to your standards, etc.