### PR TITLE
fix(vosk): add missing Italian and English-India entries to medium/large model tables

### DIFF
--- a/src/vocalinux/speech_recognition/recognition_manager.py
+++ b/src/vocalinux/speech_recognition/recognition_manager.py
@@ -1824,6 +1824,13 @@ class SpeechRecognitionManager:
         """Get the path to the VOSK model based on the selected size and language."""
         model_name = self.vosk_model_map.get(self.model_size, self.vosk_model_map["small"])
 
+        if not model_name:
+            vosk_language = "en-us" if self.language == "auto" else self.language
+            raise ValueError(
+                f"No VOSK '{self.model_size}' model available for language '{vosk_language}'. "
+                "Try the 'small' model size or a different language."
+            )
+
         # First, check user's local models directory
         user_model_path = os.path.join(MODELS_DIR, model_name)
         if os.path.exists(user_model_path):

--- a/src/vocalinux/utils/vosk_model_info.py
+++ b/src/vocalinux/utils/vosk_model_info.py
@@ -78,8 +78,10 @@ VOSK_MODEL_INFO = {
         "desc": "Balanced accuracy/speed",
         "languages": {
             "en-us": "vosk-model-en-us-0.22",
+            "en-in": "vosk-model-en-in-0.5",
             "fr": "vosk-model-fr-0.22",
             "de": "vosk-model-de-0.21",
+            "it": "vosk-model-it-0.22",
             "ru": "vosk-model-ru-0.22",
             "hi": "vosk-model-hi-0.22",
             "es": "vosk-model-es-0.42",
@@ -92,8 +94,10 @@ VOSK_MODEL_INFO = {
         "desc": "Same as medium (best available)",
         "languages": {
             "en-us": "vosk-model-en-us-0.22",
+            "en-in": "vosk-model-en-in-0.5",
             "fr": "vosk-model-fr-0.22",
             "de": "vosk-model-de-0.21",
+            "it": "vosk-model-it-0.22",
             "ru": "vosk-model-ru-0.22",
             "hi": "vosk-model-hi-0.22",
             "es": "vosk-model-es-0.42",

--- a/tests/test_speech_recognition.py
+++ b/tests/test_speech_recognition.py
@@ -69,6 +69,7 @@ from conftest import mock_audio_feedback  # noqa: E402
 # Update import paths to use the new package structure
 from vocalinux.common_types import RecognitionState  # noqa: E402
 from vocalinux.speech_recognition.recognition_manager import SpeechRecognitionManager  # noqa: E402
+from vocalinux.utils.vosk_model_info import VOSK_MODEL_INFO  # noqa: E402
 
 
 class TestSpeechRecognition(unittest.TestCase):
@@ -250,6 +251,62 @@ class TestSpeechRecognition(unittest.TestCase):
 
             # Verify the large model path is constructed correctly
             mock_get_path.assert_called_with()
+
+    def test_vosk_medium_and_large_cover_all_small_languages(self):
+        """Regression test for issue #550.
+
+        The 'medium' and 'large' VOSK model tables must map every language
+        that 'small' supports. Italian ('it') and English-India ('en-in')
+        were previously missing from 'medium'/'large', which caused
+        vosk_model_map[size] to resolve to None and crash later with
+        "join() argument must be str, bytes, or os.PathLike object, not
+        'NoneType'" instead of downloading the (existing) big model.
+        """
+        small_languages = set(VOSK_MODEL_INFO["small"]["languages"])
+        for size in ("medium", "large"):
+            size_languages = set(VOSK_MODEL_INFO[size]["languages"])
+            missing = small_languages - size_languages
+            self.assertEqual(
+                missing,
+                set(),
+                f"VOSK_MODEL_INFO['{size}']['languages'] is missing languages "
+                f"that 'small' supports: {missing}. Any language present in "
+                "'small' must also resolve to a model for 'medium'/'large', "
+                "otherwise initialization crashes with a NoneType path error.",
+            )
+
+    def test_vosk_init_italian_medium_model_resolves_correctly(self):
+        """Selecting Italian + the 'medium' VOSK model must not crash (issue #550)."""
+        manager = SpeechRecognitionManager(engine="vosk", language="it", model_size="medium")
+
+        self.assertEqual(
+            manager.vosk_model_map["medium"],
+            VOSK_MODEL_INFO["medium"]["languages"]["it"],
+        )
+        self.assertIn("vosk-model-it-0.22", manager.vosk_model_path)
+
+    def test_get_vosk_model_path_raises_clear_error_for_unmapped_language(self):
+        """An unmapped (size, language) combination should raise a clear,
+        actionable error instead of crashing deep inside os.path.join with a
+        cryptic TypeError (the actual failure mode reported in issue #550,
+        before the VOSK_MODEL_INFO data gap was fixed)."""
+        manager = SpeechRecognitionManager(engine="vosk", language="en-us", model_size="small")
+
+        # Simulate a language that has no mapping for the requested size,
+        # mirroring what happened for "it"/"medium" prior to the data fix.
+        manager.model_size = "medium"
+        manager.language = "it"
+        manager.vosk_model_map = {
+            "small": "vosk-model-small-it-0.22",
+            "medium": None,
+            "large": None,
+        }
+
+        with self.assertRaises(ValueError) as ctx:
+            manager._get_vosk_model_path()
+
+        self.assertIn("medium", str(ctx.exception))
+        self.assertIn("it", str(ctx.exception))
 
     def test_download_vosk_model(self):
         """Test downloading VOSK model."""


### PR DESCRIPTION
## Bug

Fixes #550.

The reporter selected Italian (`it`) as language and the **medium** VOSK model in Settings → Speech Engine and clicked download. Instead of downloading, the app crashed. The debug log they attached shows the exact failure, happening *before* any network request:

```
2026-07-19 21:40:12,316 - vocalinux.main - ERROR - Failed to initialize Vocalinux: join() argument must be str, bytes, or os.PathLike object, not 'NoneType'
```

## Root cause

`VOSK_MODEL_INFO["medium"]["languages"]` and `VOSK_MODEL_INFO["large"]["languages"]` in `src/vocalinux/utils/vosk_model_info.py` were missing entries for `"it"` (Italian) and `"en-in"` (English-India), even though both languages *are* present in the `"small"` table, and VOSK actually publishes bigger models for them: `vosk-model-it-0.22` (1.2G) and `vosk-model-en-in-0.5` (1G), per https://alphacephei.com/vosk/models.

Trace of the crash:
1. `_init_vosk()` in `recognition_manager.py` builds `self.vosk_model_map["medium"] = VOSK_MODEL_INFO["medium"]["languages"].get("it")`. Since `"it"` isn't a key in that dict, `.get()` returns `None`.
2. `_get_vosk_model_path()` then does `model_name = self.vosk_model_map.get(self.model_size, ...)`. Since `"medium"` *is* a key in `vosk_model_map` (with value `None`), the `.get(..., default)` fallback never kicks in — `model_name` stays `None`.
3. `os.path.join(MODELS_DIR, None)` raises `TypeError: join() argument must be str, bytes, or os.PathLike object, not 'NoneType'`.
4. This propagates up through `SpeechRecognitionManager.__init__` → the settings dialog's `download_and_apply()` background thread → caught generically and shown to the user as the truncated error in the reporter's screenshot, and (on the next app launch, since the bad config had already been saved) as the fatal startup error in their debug log.

This is a data-completeness bug (missing rows in a language table), not a network/streaming/download-robustness issue — the download logic itself (`_download_vosk_model`, timeout/retry, progress reporting) is unaffected and was never reached in this failure.

I confirmed no existing PR addresses this: searched `vosk`/`download`/`model`/`medium` PRs and the issue's timeline for linked/cross-referenced PRs — none found. PR #453 (merged well before this issue was filed) touched `vosk_model_info.py` but only corrected `size_mb` display values, not language coverage.

## Fix

1. **`src/vocalinux/utils/vosk_model_info.py`**: add the missing `"it": "vosk-model-it-0.22"` and `"en-in": "vosk-model-en-in-0.5"` entries to both `medium` and `large`. All 10 supported languages now resolve consistently across `small`/`medium`/`large`.
2. **`src/vocalinux/speech_recognition/recognition_manager.py`** (`_get_vosk_model_path`): add a guard that raises a clear `ValueError` (`No VOSK '<size>' model available for language '<lang>'...`) if a `(size, language)` combination is ever unmapped again, instead of crashing deep inside `os.path.join` with a cryptic `TypeError`. This hardens the exact code path that broke against any future data gaps.

## Testing

Added three tests to `tests/test_speech_recognition.py` (all use the existing mocked-vosk test harness in that file — no real model download):

- `test_vosk_medium_and_large_cover_all_small_languages`: asserts `medium`/`large` language tables are a superset of `small`'s, so this class of bug can't silently reappear.
- `test_vosk_init_italian_medium_model_resolves_correctly`: instantiates `SpeechRecognitionManager(engine="vosk", language="it", model_size="medium")` and asserts it resolves to `vosk-model-it-0.22` without raising.
- `test_get_vosk_model_path_raises_clear_error_for_unmapped_language`: forces an unmapped combination and asserts the new guard raises a clear `ValueError` mentioning the size and language, instead of the old cryptic `TypeError`.

**Verified before/after:**
- Reverted only the data fix (kept the guard) and reran the new tests: `test_vosk_medium_and_large_cover_all_small_languages` and `test_vosk_init_italian_medium_model_resolves_correctly` both fail as expected, reproducing the underlying bug (the second now surfaces as the new clear `ValueError` rather than the old bare `TypeError`, since the guard was still present).
- Restored the fix: all 17 tests in `tests/test_speech_recognition.py` pass.
- Ran the full test suite locally (macOS, Python 3.14, venv with GTK/PyGObject/evdev-only deps stubbed out since they're Linux-only): `10 failed, 1847 passed, 16 skipped in 54.64s`. The 10 failures are pre-existing and unrelated to this change — confirmed by running the same tests against unmodified `main`: 5 in `test_ibus_engine_core.py` (require a Linux IBus/GTK engine) and 5 in `test_installer_cuda_diagnostics_behavioral.py` (bash functions from `install.sh` that assume a Linux CUDA toolkit layout). None touch VOSK, model info, or recognition manager.
- Ran `black`, `isort`, `flake8` on all three changed files; only pre-existing flake8 warnings remain in `recognition_manager.py` (two unused imports, one f-string) that are present on unmodified `main` and unrelated to the lines this PR touches.

**What I did *not* test:** an actual 1.5GB download over the network. That code path (`_download_vosk_model`) is unchanged by this PR — the bug occurred entirely before any HTTP request was made, so a real download wasn't necessary to reproduce, fix, or verify this issue. I did verify via a live fetch of https://alphacephei.com/vosk/models that `vosk-model-it-0.22` and `vosk-model-en-in-0.5` are real, currently-published model filenames, so the URLs the existing (unmodified) download code will construct from these new table entries are valid.