### PR TITLE
feat(cli): add --version option 🤖🤖🤖

### DIFF
--- a/src/vocalinux/main.py
+++ b/src/vocalinux/main.py
@@ -222,6 +222,10 @@ def check_appindicator_support():
 
 def main():
     """Main entry point for the application."""
+    # Parse arguments first so flags like --version work even when
+    # another instance already holds the single-instance lock
+    args = parse_arguments()
+
     # Check for single instance BEFORE any initialization
     from . import single_instance
 
@@ -248,8 +252,6 @@ def main():
 
     # Register cleanup to release lock on exit
     atexit.register(single_instance.release_lock)
-
-    args = parse_arguments()
 
     # Configure debug logging if requested
     if args.debug:

--- a/src/vocalinux/main.py
+++ b/src/vocalinux/main.py
@@ -8,6 +8,8 @@ import atexit
 import logging
 import sys
 
+from .version import __version__
+
 # Configure logging
 logging.basicConfig(
     level=logging.INFO,
@@ -21,7 +23,13 @@ logger = logging.getLogger(__name__)
 
 def parse_arguments():
     """Parse command line arguments."""
-    parser = argparse.ArgumentParser(description="Vocalinux")
+    parser = argparse.ArgumentParser(prog="vocalinux", description="Vocalinux")
+    parser.add_argument(
+        "--version",
+        action="version",
+        version=f"%(prog)s {__version__}",
+        help="Show the installed Vocalinux version and exit",
+    )
     parser.add_argument("--debug", action="store_true", help="Enable debug logging")
     # default model, language and engine are loaded from default config
     # due to priority of args over config

--- a/tests/test_main_args_deps.py
+++ b/tests/test_main_args_deps.py
@@ -8,6 +8,8 @@ Covers normal startup, debug mode, version flag, keyboard interrupt, and excepti
 import os
 import sys
 import unittest
+from contextlib import redirect_stdout
+from io import StringIO
 from unittest.mock import MagicMock, call, patch
 
 import pytest
@@ -49,6 +51,20 @@ class TestParseArguments(unittest.TestCase):
 
             args = parse_arguments()
             assert args.debug is True
+
+    def test_parse_args_version_flag(self):
+        """Test that --version prints the package version and exits."""
+        from vocalinux.version import __version__
+
+        output = StringIO()
+        with patch.object(sys, "argv", ["vocalinux", "--version"]):
+            from vocalinux.main import parse_arguments
+
+            with redirect_stdout(output), self.assertRaises(SystemExit) as exit_context:
+                parse_arguments()
+
+        assert exit_context.exception.code == 0
+        assert output.getvalue() == f"vocalinux {__version__}\n"
 
     def test_parse_args_model_argument(self):
         """Test parsing with model argument."""

--- a/tests/test_main_args_deps.py
+++ b/tests/test_main_args_deps.py
@@ -23,6 +23,14 @@ def _restore_sys_modules():
     added = set(sys.modules.keys()) - set(saved.keys())
     for k in added:
         del sys.modules[k]
+        # Also drop the stale attribute from the parent package so that
+        # mock.patch and a later re-import resolve to the same fresh module
+        parent, _, child = k.rpartition(".")
+        if parent and parent in sys.modules:
+            try:
+                delattr(sys.modules[parent], child)
+            except AttributeError:
+                pass
     for k, v in saved.items():
         if k not in sys.modules or sys.modules[k] is not v:
             sys.modules[k] = v
@@ -297,6 +305,25 @@ class TestMainFunction(unittest.TestCase):
             with pytest.raises(SystemExit) as exc_info:
                 main()
             assert exc_info.value.code == 1
+
+    def test_main_version_flag_with_lock_held(self):
+        """Test that --version works even when another instance holds the lock."""
+        from vocalinux.main import main
+        from vocalinux.version import __version__
+
+        mock_single_instance = MagicMock()
+        mock_single_instance.acquire_lock.return_value = False
+
+        output = StringIO()
+        with patch.dict(sys.modules, {"vocalinux.single_instance": mock_single_instance}):
+            with patch.object(sys, "argv", ["vocalinux", "--version"]):
+                with redirect_stdout(output):
+                    with pytest.raises(SystemExit) as exc_info:
+                        main()
+
+        assert exc_info.value.code == 0
+        assert output.getvalue() == f"vocalinux {__version__}\n"
+        mock_single_instance.acquire_lock.assert_not_called()
 
     @patch("vocalinux.main.check_display_available")
     @patch("vocalinux.main.logging")


### PR DESCRIPTION
## Description

Add a standard `vocalinux --version` option backed by the package's existing `__version__` value. The parser now also uses a stable program name so help and version output remain consistent across Python versions.

Closes #555

## Type of Change

- [x] ✨ New feature
- [x] ✅ Test update

## Validation

- `PYTHONPATH=src python3 -m pytest tests/test_main_args_deps.py -q` (25 passed)
- `python3 -m py_compile src/vocalinux/main.py tests/test_main_args_deps.py`

## Checklist

- [x] Code follows the existing project style
- [x] Tests cover the new behavior
- [x] Focused tests pass locally