### PR TITLE
fix(xdotool): preserve input focus after injection 🤖🤖🤖

### DIFF
--- a/src/vocalinux/text_injection/text_injector.py
+++ b/src/vocalinux/text_injection/text_injector.py
@@ -1004,10 +1004,23 @@ class TextInjector:
                         logger.error("Text injection timed out on final attempt")
                         raise
 
-            # Try to reset any stuck modifiers
+            # Release modifiers without sending Escape, which applications may
+            # interpret as a request to cancel or leave the focused input.
             try:
                 subprocess.run(
-                    ["xdotool", "key", "--clearmodifiers", "Escape"],
+                    [
+                        "xdotool",
+                        "keyup",
+                        "--clearmodifiers",
+                        "Control_L",
+                        "Control_R",
+                        "Shift_L",
+                        "Shift_R",
+                        "Alt_L",
+                        "Alt_R",
+                        "Super_L",
+                        "Super_R",
+                    ],
                     env=env,
                     stdout=subprocess.DEVNULL,
                     stderr=subprocess.DEVNULL,

--- a/tests/test_text_injector.py
+++ b/tests/test_text_injector.py
@@ -1141,6 +1141,32 @@ class TestTextInjectorEdgeCases(unittest.TestCase):
                 if env_backup is not None:
                     os.environ["DISPLAY"] = env_backup
 
+    def test_inject_with_xdotool_releases_modifiers_without_escape(self):
+        """The xdotool path must keep the target input focused after injection."""
+        injector = TextInjector.__new__(TextInjector)
+        injector.environment = DesktopEnvironment.X11
+
+        injector._inject_with_xdotool("test")
+
+        commands = [call.args[0] for call in self.mock_subprocess.call_args_list]
+        self.assertIn(
+            [
+                "xdotool",
+                "keyup",
+                "--clearmodifiers",
+                "Control_L",
+                "Control_R",
+                "Shift_L",
+                "Shift_R",
+                "Alt_L",
+                "Alt_R",
+                "Super_L",
+                "Super_R",
+            ],
+            commands,
+        )
+        self.assertFalse(any("Escape" in command for command in commands))
+
     def test_inject_with_wayland_tool_ydotool(self):
         """Test text injection with ydotool."""
         with patch.dict("os.environ", {"XDG_SESSION_TYPE": "wayland"}):


### PR DESCRIPTION
## Description

Release potentially stuck modifier keys after xdotool text injection instead of sending Escape. This prevents the post-injection cleanup from dismissing menus, dialogs, or focused fields while still avoiding modifier leakage.

Closes #549

## Type of Change

- [x] 🐛 Bug fix
- [x] ✅ Test update

## Validation

- Focused injector and argument tests: 96 passed
- Regression coverage verifies the modifier `keyup --clearmodifiers` command and ensures Escape is never sent

## Checklist

- [x] Code follows the existing project style
- [x] Tests cover the regression
- [x] Focused tests pass locally