### PR TITLE
fix(aur): depend on virtual python-pywhispercpp so the documented GPU swap works

### DIFF
--- a/packaging/aur/vocalinux/PKGBUILD
+++ b/packaging/aur/vocalinux/PKGBUILD
@@ -19,7 +19,7 @@ depends=(
   'gobject-introspection'
   'python-cairo'
   'python-pynput'
-  'python-pywhispercpp-cpu'
+  'python-pywhispercpp'
   'python-pyaudio'
   'portaudio'
   'python-numpy'
@@ -42,7 +42,9 @@ makedepends=(
   'python-setuptools'
 )
 optdepends=(
-  'python-pywhispercpp-cuda: NVIDIA GPU (replace python-pywhispercpp-cpu)'
+  'python-pywhispercpp-cpu: CPU-only whisper.cpp backend (default provider)'
+  'python-pywhispercpp-cuda: NVIDIA GPU whisper.cpp backend'
+  'python-pywhispercpp-rocm: AMD GPU whisper.cpp backend'
   'python-onnxruntime: Silero VAD'
   'xdotool: X11 injection fallback'
 )


### PR DESCRIPTION
Fixes #578

## Problem

The AUR PKGBUILD hard-depends on `python-pywhispercpp-cpu` by exact name, while its own optdepends tells NVIDIA users to *"replace python-pywhispercpp-cpu"* with `python-pywhispercpp-cuda`. That replacement is impossible in a normal pacman transaction: the `-cuda` package conflicts with `-cpu` but only provides the virtual `python-pywhispercpp` name, so removing `-cpu` breaks vocalinux's dependency and pacman aborts. The only workaround is `pacman -Rdd`, which leaves a broken dependency record that re-breaks on every vocalinux upgrade. Full details and repro output in #578.

## Fix

- `depends`: `python-pywhispercpp-cpu` → `python-pywhispercpp` (virtual name; all three AUR backend packages `-cpu`/`-cuda`/`-rocm` declare `provides=('python-pywhispercpp')`)
- `optdepends`: list all three concrete providers so users can discover the GPU variants

Any installed backend variant now satisfies the dependency, the GPU swap becomes a normal conflict-resolution transaction, and upgrades stop fighting the user's backend choice. AUR helpers (paru/yay) prompt for a provider on fresh installs — the standard Arch pattern for swappable backends (`pipewire-jack`/`jack2`, etc.).

Since `packaging/aur/vocalinux/PKGBUILD` is auto-pushed to the AUR by `release.yml` on the next `v*` tag, merging this fixes the published AUR package with no extra steps.

## Verified

On CachyOS (Arch) with an RTX 3060 Ti: with the dependency on the virtual name, installing `python-pywhispercpp-cuda` over `-cpu` resolves cleanly and vocalinux loads the CUDA backend (`whisper_backend_init_gpu: using CUDA0 backend`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XAF9BkcSzwcMjTzkBxdx6k