### PR TITLE
fix(ui): first-run dialog response without Gtk.Dialog.do_response

### DIFF
--- a/src/vocalinux/ui/first_run_dialog.py
+++ b/src/vocalinux/ui/first_run_dialog.py
@@ -39,6 +39,11 @@ class FirstRunDialog(Gtk.Dialog):
             Gtk.ResponseType.DELETE_EVENT: None,
         }
         self.result = None
+        # Use the response signal instead of overriding do_response.
+        # Calling Gtk.Dialog.do_response() from Python raises
+        # "Class GtkDialog doesn't implement response" on modern PyGObject
+        # (see #566). dialog.run() still returns normally after the signal.
+        self.connect("response", self._on_response)
 
         box = self.get_content_area()
         box.set_spacing(16)
@@ -105,11 +110,9 @@ class FirstRunDialog(Gtk.Dialog):
 
         self.show_all()
 
-    def do_response(self, response_id):
-        """Handle dialog response - override default handler to set result."""
+    def _on_response(self, dialog, response_id):
+        """Record the user's choice when a response button is clicked."""
         self.result = self._response_map.get(response_id, None)
-        # Call parent to actually close the dialog
-        Gtk.Dialog.do_response(self, response_id)
 
 
 def show_first_run_dialog(parent: Optional[Gtk.Window] = None) -> Optional[str]:

--- a/tests/test_first_run_dialog_ext.py
+++ b/tests/test_first_run_dialog_ext.py
@@ -4,7 +4,6 @@ Final execution-based tests for FirstRunDialog.
 These tests focus on actually exercising the code with proper mocking.
 """
 
-import importlib
 import sys
 import unittest
 from types import SimpleNamespace
@@ -21,28 +20,6 @@ mock_repo.Gtk = mock_gtk
 sys.modules["gi"] = mock_gi
 sys.modules["gi.repository"] = mock_repo
 sys.modules["gi.repository.Gtk"] = mock_gtk
-
-
-def _install_gi_mocks():
-    """Ensure Gtk.Dialog is a real base type for FirstRunDialog."""
-    mock_gi_local = MagicMock()
-    mock_gtk_local = MagicMock()
-    mock_gtk_local.Dialog = type("GtkDialog", (), {})
-    mock_repo_local = MagicMock()
-    mock_repo_local.Gtk = mock_gtk_local
-    sys.modules["gi"] = mock_gi_local
-    sys.modules["gi.repository"] = mock_repo_local
-    sys.modules["gi.repository.Gtk"] = mock_gtk_local
-
-
-def _first_run_dialog_class():
-    """Return FirstRunDialog as a real class (reload if suite left a MagicMock)."""
-    import vocalinux.ui.first_run_dialog as mod
-
-    if not isinstance(mod.FirstRunDialog, type):
-        _install_gi_mocks()
-        mod = importlib.reload(mod)
-    return mod.FirstRunDialog
 
 
 class TestFirstRunDialogConstants(unittest.TestCase):
@@ -77,10 +54,11 @@ class TestFirstRunDialogConstants(unittest.TestCase):
 class TestFirstRunDialogResponseHandler(unittest.TestCase):
     """Tests for _on_response mapping without constructing Gtk.Dialog."""
 
-    def _handler_target(self):
-        from vocalinux.ui.first_run_dialog import RESPONSE_LATER, RESPONSE_NO, RESPONSE_YES
+    def test_on_response_maps_yes(self):
+        """YES response maps to 'yes'."""
+        from vocalinux.ui.first_run_dialog import RESPONSE_LATER, RESPONSE_NO, RESPONSE_YES, FirstRunDialog
 
-        return SimpleNamespace(
+        obj = SimpleNamespace(
             _response_map={
                 RESPONSE_YES: "yes",
                 RESPONSE_NO: "no",
@@ -88,36 +66,52 @@ class TestFirstRunDialogResponseHandler(unittest.TestCase):
             },
             result=None,
         )
-
-    def test_on_response_maps_yes(self):
-        """YES response maps to 'yes'."""
-        from vocalinux.ui.first_run_dialog import RESPONSE_YES
-
-        obj = self._handler_target()
-        _first_run_dialog_class()._on_response(obj, obj, RESPONSE_YES)
+        FirstRunDialog._on_response(obj, obj, RESPONSE_YES)
         self.assertEqual(obj.result, "yes")
 
     def test_on_response_maps_no(self):
         """NO response maps to 'no'."""
-        from vocalinux.ui.first_run_dialog import RESPONSE_NO
+        from vocalinux.ui.first_run_dialog import RESPONSE_LATER, RESPONSE_NO, RESPONSE_YES, FirstRunDialog
 
-        obj = self._handler_target()
-        _first_run_dialog_class()._on_response(obj, obj, RESPONSE_NO)
+        obj = SimpleNamespace(
+            _response_map={
+                RESPONSE_YES: "yes",
+                RESPONSE_NO: "no",
+                RESPONSE_LATER: "later",
+            },
+            result=None,
+        )
+        FirstRunDialog._on_response(obj, obj, RESPONSE_NO)
         self.assertEqual(obj.result, "no")
 
     def test_on_response_maps_later(self):
         """LATER response maps to 'later'."""
-        from vocalinux.ui.first_run_dialog import RESPONSE_LATER
+        from vocalinux.ui.first_run_dialog import RESPONSE_LATER, RESPONSE_NO, RESPONSE_YES, FirstRunDialog
 
-        obj = self._handler_target()
-        _first_run_dialog_class()._on_response(obj, obj, RESPONSE_LATER)
+        obj = SimpleNamespace(
+            _response_map={
+                RESPONSE_YES: "yes",
+                RESPONSE_NO: "no",
+                RESPONSE_LATER: "later",
+            },
+            result=None,
+        )
+        FirstRunDialog._on_response(obj, obj, RESPONSE_LATER)
         self.assertEqual(obj.result, "later")
 
     def test_on_response_unknown_id_is_none(self):
         """Unknown response IDs map to None via dict.get default."""
-        obj = self._handler_target()
-        obj.result = "yes"
-        _first_run_dialog_class()._on_response(obj, obj, 99999)
+        from vocalinux.ui.first_run_dialog import RESPONSE_LATER, RESPONSE_NO, RESPONSE_YES, FirstRunDialog
+
+        obj = SimpleNamespace(
+            _response_map={
+                RESPONSE_YES: "yes",
+                RESPONSE_NO: "no",
+                RESPONSE_LATER: "later",
+            },
+            result="yes",
+        )
+        FirstRunDialog._on_response(obj, obj, 99999)
         self.assertIsNone(obj.result)
 
 

--- a/tests/test_first_run_dialog_ext.py
+++ b/tests/test_first_run_dialog_ext.py
@@ -4,15 +4,21 @@ Final execution-based tests for FirstRunDialog.
 These tests focus on actually exercising the code with proper mocking.
 """
 
+import importlib.util
 import sys
+import types
 import unittest
+from pathlib import Path
 from unittest.mock import MagicMock, patch
 
-# Mock gi and Gtk before importing first_run_dialog.
-# Gtk.Dialog must be a real type so FirstRunDialog can subclass it and so
-# __init__ / _on_response can be exercised under mocks (codecov/patch).
+# Mock gi and Gtk before importing first_run_dialog (constants / show_* tests).
+# Response-handler tests reinstall a real Dialog base and reload the module so
+# they stay correct even when earlier tests left FirstRunDialog as a MagicMock.
 mock_gi = MagicMock()
 mock_gtk = MagicMock()
+sys.modules["gi"] = mock_gi
+sys.modules["gi.repository"] = MagicMock()
+sys.modules["gi.repository.Gtk"] = mock_gtk
 
 
 class _FakeGtkDialog:
@@ -41,22 +47,55 @@ class _FakeGtkDialog:
         pass
 
 
-mock_gtk.Dialog = _FakeGtkDialog
-mock_gtk.DialogFlags.MODAL = 1
-mock_gtk.ResponseType.DELETE_EVENT = -4
-mock_gtk.Justification.CENTER = 0
-mock_gtk.Justification.LEFT = 1
-mock_gtk.Orientation.HORIZONTAL = 0
-mock_gtk.Align.CENTER = 0
-mock_gtk.Label = MagicMock
-mock_gtk.Box = MagicMock
-mock_gtk.Window = MagicMock
+_ISOLATED_MODULE_NAME = "vocalinux_test_first_run_dialog_isolated"
 
-mock_repo = MagicMock()
-mock_repo.Gtk = mock_gtk
-sys.modules["gi"] = mock_gi
-sys.modules["gi.repository"] = mock_repo
-sys.modules["gi.repository.Gtk"] = mock_gtk
+
+def _load_first_run_dialog_with_fake_gtk():
+    """Load first_run_dialog.py under an isolated module name with a real Dialog base.
+
+    Other test modules often leave gi/Gtk/FirstRunDialog as MagicMocks. Loading
+    the source file under a unique name (and restoring gi afterward) lets
+    __init__ / _on_response run without clobbering the suite's import graph.
+    Coverage still attributes execution to first_run_dialog.py by file path.
+    """
+    mock_gi_local = MagicMock()
+    mock_gtk_local = MagicMock()
+    mock_gtk_local.Dialog = _FakeGtkDialog
+    mock_gtk_local.DialogFlags.MODAL = 1
+    mock_gtk_local.ResponseType.DELETE_EVENT = -4
+    mock_gtk_local.Justification.CENTER = 0
+    mock_gtk_local.Justification.LEFT = 1
+    mock_gtk_local.Orientation.HORIZONTAL = 0
+    mock_gtk_local.Align.CENTER = 0
+    mock_gtk_local.Label = MagicMock
+    mock_gtk_local.Box = MagicMock
+    mock_gtk_local.Window = MagicMock
+
+    mock_repo = types.ModuleType("gi.repository")
+    mock_repo.Gtk = mock_gtk_local
+
+    gi_keys = ("gi", "gi.repository", "gi.repository.Gtk")
+    saved = {key: sys.modules.get(key) for key in gi_keys}
+    try:
+        sys.modules["gi"] = mock_gi_local
+        sys.modules["gi.repository"] = mock_repo
+        sys.modules["gi.repository.Gtk"] = mock_gtk_local
+
+        path = (
+            Path(__file__).resolve().parents[1] / "src" / "vocalinux" / "ui" / "first_run_dialog.py"
+        )
+        spec = importlib.util.spec_from_file_location(_ISOLATED_MODULE_NAME, path)
+        module = importlib.util.module_from_spec(spec)
+        sys.modules[_ISOLATED_MODULE_NAME] = module
+        assert spec.loader is not None
+        spec.loader.exec_module(module)
+        return module
+    finally:
+        for key, previous in saved.items():
+            if previous is None:
+                sys.modules.pop(key, None)
+            else:
+                sys.modules[key] = previous
 
 
 class TestFirstRunDialogConstants(unittest.TestCase):
@@ -91,20 +130,17 @@ class TestFirstRunDialogConstants(unittest.TestCase):
 class TestFirstRunDialogResponseHandler(unittest.TestCase):
     """Tests for response signal wiring and _on_response mapping."""
 
-    def setUp(self):
-        from vocalinux.ui import first_run_dialog
-        from vocalinux.ui.first_run_dialog import (
-            RESPONSE_LATER,
-            RESPONSE_NO,
-            RESPONSE_YES,
-            FirstRunDialog,
-        )
+    @classmethod
+    def setUpClass(cls):
+        cls.mod = _load_first_run_dialog_with_fake_gtk()
+        cls.FirstRunDialog = cls.mod.FirstRunDialog
+        cls.RESPONSE_YES = cls.mod.RESPONSE_YES
+        cls.RESPONSE_NO = cls.mod.RESPONSE_NO
+        cls.RESPONSE_LATER = cls.mod.RESPONSE_LATER
 
-        self.mod = first_run_dialog
-        self.FirstRunDialog = FirstRunDialog
-        self.RESPONSE_YES = RESPONSE_YES
-        self.RESPONSE_NO = RESPONSE_NO
-        self.RESPONSE_LATER = RESPONSE_LATER
+    @classmethod
+    def tearDownClass(cls):
+        sys.modules.pop(_ISOLATED_MODULE_NAME, None)
 
     def test_connects_response_signal_to_handler(self):
         """Constructor wires the response signal instead of do_response."""

--- a/tests/test_first_run_dialog_ext.py
+++ b/tests/test_first_run_dialog_ext.py
@@ -8,11 +8,54 @@ import sys
 import unittest
 from unittest.mock import MagicMock, patch
 
-# Mock gi and Gtk before importing first_run_dialog
+# Mock gi and Gtk before importing first_run_dialog.
+# Gtk.Dialog must be a real type so FirstRunDialog can subclass it and so
+# __init__ / _on_response can be exercised under mocks (codecov/patch).
 mock_gi = MagicMock()
 mock_gtk = MagicMock()
+
+
+class _FakeGtkDialog:
+    """Minimal Gtk.Dialog stand-in for unit tests."""
+
+    def __init__(self, *args, **kwargs):
+        self._connect_calls = []
+
+    def set_default_size(self, *args, **kwargs):
+        pass
+
+    def connect(self, *args, **kwargs):
+        self._connect_calls.append((args, kwargs))
+        return 0
+
+    def get_content_area(self):
+        return MagicMock()
+
+    def add_button(self, *args, **kwargs):
+        return MagicMock()
+
+    def get_action_area(self):
+        return MagicMock()
+
+    def show_all(self):
+        pass
+
+
+mock_gtk.Dialog = _FakeGtkDialog
+mock_gtk.DialogFlags.MODAL = 1
+mock_gtk.ResponseType.DELETE_EVENT = -4
+mock_gtk.Justification.CENTER = 0
+mock_gtk.Justification.LEFT = 1
+mock_gtk.Orientation.HORIZONTAL = 0
+mock_gtk.Align.CENTER = 0
+mock_gtk.Label = MagicMock
+mock_gtk.Box = MagicMock
+mock_gtk.Window = MagicMock
+
+mock_repo = MagicMock()
+mock_repo.Gtk = mock_gtk
 sys.modules["gi"] = mock_gi
-sys.modules["gi.repository"] = MagicMock()
+sys.modules["gi.repository"] = mock_repo
 sys.modules["gi.repository.Gtk"] = mock_gtk
 
 
@@ -43,6 +86,76 @@ class TestFirstRunDialogConstants(unittest.TestCase):
 
         constants = [RESPONSE_YES, RESPONSE_NO, RESPONSE_LATER]
         self.assertEqual(len(constants), len(set(constants)))
+
+
+class TestFirstRunDialogResponseHandler(unittest.TestCase):
+    """Tests for response signal wiring and _on_response mapping."""
+
+    def setUp(self):
+        from vocalinux.ui import first_run_dialog
+        from vocalinux.ui.first_run_dialog import (
+            RESPONSE_LATER,
+            RESPONSE_NO,
+            RESPONSE_YES,
+            FirstRunDialog,
+        )
+
+        self.mod = first_run_dialog
+        self.FirstRunDialog = FirstRunDialog
+        self.RESPONSE_YES = RESPONSE_YES
+        self.RESPONSE_NO = RESPONSE_NO
+        self.RESPONSE_LATER = RESPONSE_LATER
+
+    def test_connects_response_signal_to_handler(self):
+        """Constructor wires the response signal instead of do_response."""
+        dialog = self.FirstRunDialog()
+
+        self.assertTrue(dialog._connect_calls)
+        signal_name, handler = dialog._connect_calls[0][0][:2]
+        self.assertEqual(signal_name, "response")
+        self.assertTrue(callable(handler))
+        # Bound method of this instance (each attribute access makes a new object)
+        self.assertIs(handler.__self__, dialog)
+        self.assertIs(handler.__func__, self.FirstRunDialog._on_response)
+
+    def test_on_response_maps_yes(self):
+        """YES response maps to 'yes'."""
+        dialog = self.FirstRunDialog()
+        dialog._on_response(dialog, self.RESPONSE_YES)
+        self.assertEqual(dialog.result, "yes")
+
+    def test_on_response_maps_no(self):
+        """NO response maps to 'no'."""
+        dialog = self.FirstRunDialog()
+        dialog._on_response(dialog, self.RESPONSE_NO)
+        self.assertEqual(dialog.result, "no")
+
+    def test_on_response_maps_later(self):
+        """LATER response maps to 'later'."""
+        dialog = self.FirstRunDialog()
+        dialog._on_response(dialog, self.RESPONSE_LATER)
+        self.assertEqual(dialog.result, "later")
+
+    def test_on_response_maps_delete_event_to_none(self):
+        """DELETE_EVENT maps to None (dialog closed without a choice)."""
+        dialog = self.FirstRunDialog()
+        dialog.result = "yes"  # ensure handler overwrites prior value
+        dialog._on_response(dialog, self.mod.Gtk.ResponseType.DELETE_EVENT)
+        self.assertIsNone(dialog.result)
+
+    def test_on_response_unknown_id_is_none(self):
+        """Unknown response IDs map to None via dict.get default."""
+        dialog = self.FirstRunDialog()
+        dialog.result = "yes"
+        dialog._on_response(dialog, 99999)
+        self.assertIsNone(dialog.result)
+
+    def test_on_response_matches_response_map(self):
+        """Each entry in _response_map is applied by _on_response."""
+        dialog = self.FirstRunDialog()
+        for response_id, expected in dialog._response_map.items():
+            dialog._on_response(dialog, response_id)
+            self.assertEqual(dialog.result, expected)
 
 
 class TestShowFirstRunDialogFunction(unittest.TestCase):

--- a/tests/test_first_run_dialog_ext.py
+++ b/tests/test_first_run_dialog_ext.py
@@ -4,98 +4,45 @@ Final execution-based tests for FirstRunDialog.
 These tests focus on actually exercising the code with proper mocking.
 """
 
-import importlib.util
+import importlib
 import sys
-import types
 import unittest
-from pathlib import Path
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
-# Mock gi and Gtk before importing first_run_dialog (constants / show_* tests).
-# Response-handler tests reinstall a real Dialog base and reload the module so
-# they stay correct even when earlier tests left FirstRunDialog as a MagicMock.
+# Mock gi and Gtk before importing first_run_dialog.
+# Gtk.Dialog must be a real type so FirstRunDialog is a real class (needed to
+# call FirstRunDialog._on_response without constructing a dialog).
 mock_gi = MagicMock()
 mock_gtk = MagicMock()
+mock_gtk.Dialog = type("GtkDialog", (), {})
+mock_repo = MagicMock()
+mock_repo.Gtk = mock_gtk
 sys.modules["gi"] = mock_gi
-sys.modules["gi.repository"] = MagicMock()
+sys.modules["gi.repository"] = mock_repo
 sys.modules["gi.repository.Gtk"] = mock_gtk
 
 
-class _FakeGtkDialog:
-    """Minimal Gtk.Dialog stand-in for unit tests."""
-
-    def __init__(self, *args, **kwargs):
-        self._connect_calls = []
-
-    def set_default_size(self, *args, **kwargs):
-        pass
-
-    def connect(self, *args, **kwargs):
-        self._connect_calls.append((args, kwargs))
-        return 0
-
-    def get_content_area(self):
-        return MagicMock()
-
-    def add_button(self, *args, **kwargs):
-        return MagicMock()
-
-    def get_action_area(self):
-        return MagicMock()
-
-    def show_all(self):
-        pass
-
-
-_ISOLATED_MODULE_NAME = "vocalinux_test_first_run_dialog_isolated"
-
-
-def _load_first_run_dialog_with_fake_gtk():
-    """Load first_run_dialog.py under an isolated module name with a real Dialog base.
-
-    Other test modules often leave gi/Gtk/FirstRunDialog as MagicMocks. Loading
-    the source file under a unique name (and restoring gi afterward) lets
-    __init__ / _on_response run without clobbering the suite's import graph.
-    Coverage still attributes execution to first_run_dialog.py by file path.
-    """
+def _install_gi_mocks():
+    """Ensure Gtk.Dialog is a real base type for FirstRunDialog."""
     mock_gi_local = MagicMock()
     mock_gtk_local = MagicMock()
-    mock_gtk_local.Dialog = _FakeGtkDialog
-    mock_gtk_local.DialogFlags.MODAL = 1
-    mock_gtk_local.ResponseType.DELETE_EVENT = -4
-    mock_gtk_local.Justification.CENTER = 0
-    mock_gtk_local.Justification.LEFT = 1
-    mock_gtk_local.Orientation.HORIZONTAL = 0
-    mock_gtk_local.Align.CENTER = 0
-    mock_gtk_local.Label = MagicMock
-    mock_gtk_local.Box = MagicMock
-    mock_gtk_local.Window = MagicMock
+    mock_gtk_local.Dialog = type("GtkDialog", (), {})
+    mock_repo_local = MagicMock()
+    mock_repo_local.Gtk = mock_gtk_local
+    sys.modules["gi"] = mock_gi_local
+    sys.modules["gi.repository"] = mock_repo_local
+    sys.modules["gi.repository.Gtk"] = mock_gtk_local
 
-    mock_repo = types.ModuleType("gi.repository")
-    mock_repo.Gtk = mock_gtk_local
 
-    gi_keys = ("gi", "gi.repository", "gi.repository.Gtk")
-    saved = {key: sys.modules.get(key) for key in gi_keys}
-    try:
-        sys.modules["gi"] = mock_gi_local
-        sys.modules["gi.repository"] = mock_repo
-        sys.modules["gi.repository.Gtk"] = mock_gtk_local
+def _first_run_dialog_class():
+    """Return FirstRunDialog as a real class (reload if suite left a MagicMock)."""
+    import vocalinux.ui.first_run_dialog as mod
 
-        path = (
-            Path(__file__).resolve().parents[1] / "src" / "vocalinux" / "ui" / "first_run_dialog.py"
-        )
-        spec = importlib.util.spec_from_file_location(_ISOLATED_MODULE_NAME, path)
-        module = importlib.util.module_from_spec(spec)
-        sys.modules[_ISOLATED_MODULE_NAME] = module
-        assert spec.loader is not None
-        spec.loader.exec_module(module)
-        return module
-    finally:
-        for key, previous in saved.items():
-            if previous is None:
-                sys.modules.pop(key, None)
-            else:
-                sys.modules[key] = previous
+    if not isinstance(mod.FirstRunDialog, type):
+        _install_gi_mocks()
+        mod = importlib.reload(mod)
+    return mod.FirstRunDialog
 
 
 class TestFirstRunDialogConstants(unittest.TestCase):
@@ -128,70 +75,50 @@ class TestFirstRunDialogConstants(unittest.TestCase):
 
 
 class TestFirstRunDialogResponseHandler(unittest.TestCase):
-    """Tests for response signal wiring and _on_response mapping."""
+    """Tests for _on_response mapping without constructing Gtk.Dialog."""
 
-    @classmethod
-    def setUpClass(cls):
-        cls.mod = _load_first_run_dialog_with_fake_gtk()
-        cls.FirstRunDialog = cls.mod.FirstRunDialog
-        cls.RESPONSE_YES = cls.mod.RESPONSE_YES
-        cls.RESPONSE_NO = cls.mod.RESPONSE_NO
-        cls.RESPONSE_LATER = cls.mod.RESPONSE_LATER
+    def _handler_target(self):
+        from vocalinux.ui.first_run_dialog import RESPONSE_LATER, RESPONSE_NO, RESPONSE_YES
 
-    @classmethod
-    def tearDownClass(cls):
-        sys.modules.pop(_ISOLATED_MODULE_NAME, None)
-
-    def test_connects_response_signal_to_handler(self):
-        """Constructor wires the response signal instead of do_response."""
-        dialog = self.FirstRunDialog()
-
-        self.assertTrue(dialog._connect_calls)
-        signal_name, handler = dialog._connect_calls[0][0][:2]
-        self.assertEqual(signal_name, "response")
-        self.assertTrue(callable(handler))
-        # Bound method of this instance (each attribute access makes a new object)
-        self.assertIs(handler.__self__, dialog)
-        self.assertIs(handler.__func__, self.FirstRunDialog._on_response)
+        return SimpleNamespace(
+            _response_map={
+                RESPONSE_YES: "yes",
+                RESPONSE_NO: "no",
+                RESPONSE_LATER: "later",
+            },
+            result=None,
+        )
 
     def test_on_response_maps_yes(self):
         """YES response maps to 'yes'."""
-        dialog = self.FirstRunDialog()
-        dialog._on_response(dialog, self.RESPONSE_YES)
-        self.assertEqual(dialog.result, "yes")
+        from vocalinux.ui.first_run_dialog import RESPONSE_YES
+
+        obj = self._handler_target()
+        _first_run_dialog_class()._on_response(obj, obj, RESPONSE_YES)
+        self.assertEqual(obj.result, "yes")
 
     def test_on_response_maps_no(self):
         """NO response maps to 'no'."""
-        dialog = self.FirstRunDialog()
-        dialog._on_response(dialog, self.RESPONSE_NO)
-        self.assertEqual(dialog.result, "no")
+        from vocalinux.ui.first_run_dialog import RESPONSE_NO
+
+        obj = self._handler_target()
+        _first_run_dialog_class()._on_response(obj, obj, RESPONSE_NO)
+        self.assertEqual(obj.result, "no")
 
     def test_on_response_maps_later(self):
         """LATER response maps to 'later'."""
-        dialog = self.FirstRunDialog()
-        dialog._on_response(dialog, self.RESPONSE_LATER)
-        self.assertEqual(dialog.result, "later")
+        from vocalinux.ui.first_run_dialog import RESPONSE_LATER
 
-    def test_on_response_maps_delete_event_to_none(self):
-        """DELETE_EVENT maps to None (dialog closed without a choice)."""
-        dialog = self.FirstRunDialog()
-        dialog.result = "yes"  # ensure handler overwrites prior value
-        dialog._on_response(dialog, self.mod.Gtk.ResponseType.DELETE_EVENT)
-        self.assertIsNone(dialog.result)
+        obj = self._handler_target()
+        _first_run_dialog_class()._on_response(obj, obj, RESPONSE_LATER)
+        self.assertEqual(obj.result, "later")
 
     def test_on_response_unknown_id_is_none(self):
         """Unknown response IDs map to None via dict.get default."""
-        dialog = self.FirstRunDialog()
-        dialog.result = "yes"
-        dialog._on_response(dialog, 99999)
-        self.assertIsNone(dialog.result)
-
-    def test_on_response_matches_response_map(self):
-        """Each entry in _response_map is applied by _on_response."""
-        dialog = self.FirstRunDialog()
-        for response_id, expected in dialog._response_map.items():
-            dialog._on_response(dialog, response_id)
-            self.assertEqual(dialog.result, expected)
+        obj = self._handler_target()
+        obj.result = "yes"
+        _first_run_dialog_class()._on_response(obj, obj, 99999)
+        self.assertIsNone(obj.result)
 
 
 class TestShowFirstRunDialogFunction(unittest.TestCase):

--- a/tests/test_first_run_dialog_ext.py
+++ b/tests/test_first_run_dialog_ext.py
@@ -4,22 +4,98 @@ Final execution-based tests for FirstRunDialog.
 These tests focus on actually exercising the code with proper mocking.
 """
 
+import importlib.util
 import sys
+import types
 import unittest
-from types import SimpleNamespace
+from pathlib import Path
 from unittest.mock import MagicMock, patch
 
-# Mock gi and Gtk before importing first_run_dialog.
-# Gtk.Dialog must be a real type so FirstRunDialog is a real class (needed to
-# call FirstRunDialog._on_response without constructing a dialog).
+# Mock gi and Gtk before importing first_run_dialog (constants / show_* tests).
+# Response-handler tests reinstall a real Dialog base and reload the module so
+# they stay correct even when earlier tests left FirstRunDialog as a MagicMock.
 mock_gi = MagicMock()
 mock_gtk = MagicMock()
-mock_gtk.Dialog = type("GtkDialog", (), {})
-mock_repo = MagicMock()
-mock_repo.Gtk = mock_gtk
 sys.modules["gi"] = mock_gi
-sys.modules["gi.repository"] = mock_repo
+sys.modules["gi.repository"] = MagicMock()
 sys.modules["gi.repository.Gtk"] = mock_gtk
+
+
+class _FakeGtkDialog:
+    """Minimal Gtk.Dialog stand-in for unit tests."""
+
+    def __init__(self, *args, **kwargs):
+        self._connect_calls = []
+
+    def set_default_size(self, *args, **kwargs):
+        pass
+
+    def connect(self, *args, **kwargs):
+        self._connect_calls.append((args, kwargs))
+        return 0
+
+    def get_content_area(self):
+        return MagicMock()
+
+    def add_button(self, *args, **kwargs):
+        return MagicMock()
+
+    def get_action_area(self):
+        return MagicMock()
+
+    def show_all(self):
+        pass
+
+
+_ISOLATED_MODULE_NAME = "vocalinux_test_first_run_dialog_isolated"
+
+
+def _load_first_run_dialog_with_fake_gtk():
+    """Load first_run_dialog.py under an isolated module name with a real Dialog base.
+
+    Other test modules often leave gi/Gtk/FirstRunDialog as MagicMocks. Loading
+    the source file under a unique name (and restoring gi afterward) lets
+    __init__ / _on_response run without clobbering the suite's import graph.
+    Coverage still attributes execution to first_run_dialog.py by file path.
+    """
+    mock_gi_local = MagicMock()
+    mock_gtk_local = MagicMock()
+    mock_gtk_local.Dialog = _FakeGtkDialog
+    mock_gtk_local.DialogFlags.MODAL = 1
+    mock_gtk_local.ResponseType.DELETE_EVENT = -4
+    mock_gtk_local.Justification.CENTER = 0
+    mock_gtk_local.Justification.LEFT = 1
+    mock_gtk_local.Orientation.HORIZONTAL = 0
+    mock_gtk_local.Align.CENTER = 0
+    mock_gtk_local.Label = MagicMock
+    mock_gtk_local.Box = MagicMock
+    mock_gtk_local.Window = MagicMock
+
+    mock_repo = types.ModuleType("gi.repository")
+    mock_repo.Gtk = mock_gtk_local
+
+    gi_keys = ("gi", "gi.repository", "gi.repository.Gtk")
+    saved = {key: sys.modules.get(key) for key in gi_keys}
+    try:
+        sys.modules["gi"] = mock_gi_local
+        sys.modules["gi.repository"] = mock_repo
+        sys.modules["gi.repository.Gtk"] = mock_gtk_local
+
+        path = (
+            Path(__file__).resolve().parents[1] / "src" / "vocalinux" / "ui" / "first_run_dialog.py"
+        )
+        spec = importlib.util.spec_from_file_location(_ISOLATED_MODULE_NAME, path)
+        module = importlib.util.module_from_spec(spec)
+        sys.modules[_ISOLATED_MODULE_NAME] = module
+        assert spec.loader is not None
+        spec.loader.exec_module(module)
+        return module
+    finally:
+        for key, previous in saved.items():
+            if previous is None:
+                sys.modules.pop(key, None)
+            else:
+                sys.modules[key] = previous
 
 
 class TestFirstRunDialogConstants(unittest.TestCase):
@@ -52,31 +128,70 @@ class TestFirstRunDialogConstants(unittest.TestCase):
 
 
 class TestFirstRunDialogResponseHandler(unittest.TestCase):
-    """Tests for _on_response mapping without constructing Gtk.Dialog."""
+    """Tests for response signal wiring and _on_response mapping."""
 
-    def test_on_response_maps_ids(self):
-        """YES/NO/LATER map to strings; unknown ids map to None."""
-        from vocalinux.ui.first_run_dialog import (
-            RESPONSE_LATER,
-            RESPONSE_NO,
-            RESPONSE_YES,
-            FirstRunDialog,
-        )
+    @classmethod
+    def setUpClass(cls):
+        cls.mod = _load_first_run_dialog_with_fake_gtk()
+        cls.FirstRunDialog = cls.mod.FirstRunDialog
+        cls.RESPONSE_YES = cls.mod.RESPONSE_YES
+        cls.RESPONSE_NO = cls.mod.RESPONSE_NO
+        cls.RESPONSE_LATER = cls.mod.RESPONSE_LATER
 
-        response_map = {
-            RESPONSE_YES: "yes",
-            RESPONSE_NO: "no",
-            RESPONSE_LATER: "later",
-        }
-        for response_id, expected in (
-            (RESPONSE_YES, "yes"),
-            (RESPONSE_NO, "no"),
-            (RESPONSE_LATER, "later"),
-            (99999, None),
-        ):
-            obj = SimpleNamespace(_response_map=response_map, result=None)
-            FirstRunDialog._on_response(obj, obj, response_id)
-            self.assertEqual(obj.result, expected)
+    @classmethod
+    def tearDownClass(cls):
+        sys.modules.pop(_ISOLATED_MODULE_NAME, None)
+
+    def test_connects_response_signal_to_handler(self):
+        """Constructor wires the response signal instead of do_response."""
+        dialog = self.FirstRunDialog()
+
+        self.assertTrue(dialog._connect_calls)
+        signal_name, handler = dialog._connect_calls[0][0][:2]
+        self.assertEqual(signal_name, "response")
+        self.assertTrue(callable(handler))
+        # Bound method of this instance (each attribute access makes a new object)
+        self.assertIs(handler.__self__, dialog)
+        self.assertIs(handler.__func__, self.FirstRunDialog._on_response)
+
+    def test_on_response_maps_yes(self):
+        """YES response maps to 'yes'."""
+        dialog = self.FirstRunDialog()
+        dialog._on_response(dialog, self.RESPONSE_YES)
+        self.assertEqual(dialog.result, "yes")
+
+    def test_on_response_maps_no(self):
+        """NO response maps to 'no'."""
+        dialog = self.FirstRunDialog()
+        dialog._on_response(dialog, self.RESPONSE_NO)
+        self.assertEqual(dialog.result, "no")
+
+    def test_on_response_maps_later(self):
+        """LATER response maps to 'later'."""
+        dialog = self.FirstRunDialog()
+        dialog._on_response(dialog, self.RESPONSE_LATER)
+        self.assertEqual(dialog.result, "later")
+
+    def test_on_response_maps_delete_event_to_none(self):
+        """DELETE_EVENT maps to None (dialog closed without a choice)."""
+        dialog = self.FirstRunDialog()
+        dialog.result = "yes"  # ensure handler overwrites prior value
+        dialog._on_response(dialog, self.mod.Gtk.ResponseType.DELETE_EVENT)
+        self.assertIsNone(dialog.result)
+
+    def test_on_response_unknown_id_is_none(self):
+        """Unknown response IDs map to None via dict.get default."""
+        dialog = self.FirstRunDialog()
+        dialog.result = "yes"
+        dialog._on_response(dialog, 99999)
+        self.assertIsNone(dialog.result)
+
+    def test_on_response_matches_response_map(self):
+        """Each entry in _response_map is applied by _on_response."""
+        dialog = self.FirstRunDialog()
+        for response_id, expected in dialog._response_map.items():
+            dialog._on_response(dialog, response_id)
+            self.assertEqual(dialog.result, expected)
 
 
 class TestShowFirstRunDialogFunction(unittest.TestCase):

--- a/tests/test_first_run_dialog_ext.py
+++ b/tests/test_first_run_dialog_ext.py
@@ -54,65 +54,29 @@ class TestFirstRunDialogConstants(unittest.TestCase):
 class TestFirstRunDialogResponseHandler(unittest.TestCase):
     """Tests for _on_response mapping without constructing Gtk.Dialog."""
 
-    def test_on_response_maps_yes(self):
-        """YES response maps to 'yes'."""
-        from vocalinux.ui.first_run_dialog import RESPONSE_LATER, RESPONSE_NO, RESPONSE_YES, FirstRunDialog
-
-        obj = SimpleNamespace(
-            _response_map={
-                RESPONSE_YES: "yes",
-                RESPONSE_NO: "no",
-                RESPONSE_LATER: "later",
-            },
-            result=None,
+    def test_on_response_maps_ids(self):
+        """YES/NO/LATER map to strings; unknown ids map to None."""
+        from vocalinux.ui.first_run_dialog import (
+            RESPONSE_LATER,
+            RESPONSE_NO,
+            RESPONSE_YES,
+            FirstRunDialog,
         )
-        FirstRunDialog._on_response(obj, obj, RESPONSE_YES)
-        self.assertEqual(obj.result, "yes")
 
-    def test_on_response_maps_no(self):
-        """NO response maps to 'no'."""
-        from vocalinux.ui.first_run_dialog import RESPONSE_LATER, RESPONSE_NO, RESPONSE_YES, FirstRunDialog
-
-        obj = SimpleNamespace(
-            _response_map={
-                RESPONSE_YES: "yes",
-                RESPONSE_NO: "no",
-                RESPONSE_LATER: "later",
-            },
-            result=None,
-        )
-        FirstRunDialog._on_response(obj, obj, RESPONSE_NO)
-        self.assertEqual(obj.result, "no")
-
-    def test_on_response_maps_later(self):
-        """LATER response maps to 'later'."""
-        from vocalinux.ui.first_run_dialog import RESPONSE_LATER, RESPONSE_NO, RESPONSE_YES, FirstRunDialog
-
-        obj = SimpleNamespace(
-            _response_map={
-                RESPONSE_YES: "yes",
-                RESPONSE_NO: "no",
-                RESPONSE_LATER: "later",
-            },
-            result=None,
-        )
-        FirstRunDialog._on_response(obj, obj, RESPONSE_LATER)
-        self.assertEqual(obj.result, "later")
-
-    def test_on_response_unknown_id_is_none(self):
-        """Unknown response IDs map to None via dict.get default."""
-        from vocalinux.ui.first_run_dialog import RESPONSE_LATER, RESPONSE_NO, RESPONSE_YES, FirstRunDialog
-
-        obj = SimpleNamespace(
-            _response_map={
-                RESPONSE_YES: "yes",
-                RESPONSE_NO: "no",
-                RESPONSE_LATER: "later",
-            },
-            result="yes",
-        )
-        FirstRunDialog._on_response(obj, obj, 99999)
-        self.assertIsNone(obj.result)
+        response_map = {
+            RESPONSE_YES: "yes",
+            RESPONSE_NO: "no",
+            RESPONSE_LATER: "later",
+        }
+        for response_id, expected in (
+            (RESPONSE_YES, "yes"),
+            (RESPONSE_NO, "no"),
+            (RESPONSE_LATER, "later"),
+            (99999, None),
+        ):
+            obj = SimpleNamespace(_response_map=response_map, result=None)
+            FirstRunDialog._on_response(obj, obj, response_id)
+            self.assertEqual(obj.result, expected)
 
 
 class TestShowFirstRunDialogFunction(unittest.TestCase):


### PR DESCRIPTION
## Summary

On newer PyGObject, overriding `do_response` and calling `Gtk.Dialog.do_response()` raises:

`TypeError: Class GtkDialog doesn't implement response`

That breaks the first-run dialog, so users never get a clean choice after install.

This switches the handler to the normal `response` signal. We still record the button result; `dialog.run()` closes the dialog as usual.

## Test plan

- [x] `PYTHONPATH=src pytest tests/test_first_run_dialog_ext.py`
- [ ] Manual: launch a fresh profile / force first-run dialog and click Yes / No / Later

Fixes #566
