### PR TITLE
docs: multi-distro tray icon FAQ (apt, dnf, pacman)

### DIFF
--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -629,11 +629,30 @@ Model names with more language and size variety can be found in [VOSK Models](ht
 **Symptom:** Tray icon missing or generic
 
 **Solution:**
-```bash
-# Refresh icon cache
-gtk-update-icon-cache -f -t ~/.local/share/icons/hicolor
 
-# Restart the application
+On GNOME (including Fedora Workstation and Ubuntu), AppIndicator support is often
+disabled until you install and enable the tray extension:
+
+```bash
+# Debian/Ubuntu
+sudo apt install gnome-shell-extension-appindicator
+
+# Fedora
+sudo dnf install gnome-shell-extension-appindicator
+
+# Arch
+sudo pacman -S gnome-shell-extension-appindicator
+
+# Then enable (Extensions app, or):
+gnome-extensions enable appindicatorsupport@rgcjonas.gmail.com
+# Log out and back in if the icon still does not appear
+```
+
+Also refresh the icon cache and restart Vocalinux:
+
+```bash
+gtk-update-icon-cache -f -t ~/.local/share/icons/hicolor
+vocalinux --debug
 ```
 
 ## Uninstallation

--- a/web/src/app/troubleshooting/page.tsx
+++ b/web/src/app/troubleshooting/page.tsx
@@ -150,9 +150,10 @@ const troubleshootingItems = [
     symptoms: ["No system tray icon", "Cannot access settings"],
     solutions: [
       "v0.10.1+ bundles resources to prevent missing tray icons - ensure you're on latest version",
-      "Ensure your desktop environment supports system trays (GNOME requires extension)",
-      "Install AppIndicator extension for GNOME: sudo apt install gnome-shell-extension-appindicator",
-      "Check if ayatana-appindicator is installed: sudo apt install libayatana-appindicator3-1",
+      "Ensure your desktop environment supports system trays (GNOME requires an AppIndicator extension)",
+      "Install the GNOME AppIndicator extension (pick your distro): Debian/Ubuntu: sudo apt install gnome-shell-extension-appindicator — Fedora: sudo dnf install gnome-shell-extension-appindicator — Arch: sudo pacman -S gnome-shell-extension-appindicator",
+      "Then enable the extension (Extensions app, or: gnome-extensions enable appindicatorsupport@rgcjonas.gmail.com) and log out/in if needed",
+      "Debian/Ubuntu only — also check ayatana: sudo apt install libayatana-appindicator3-1 (Fedora already pulls libappindicator-gtk3 via the installer)",
       "Try launching from terminal to see any errors: vocalinux --debug",
     ],
   },


### PR DESCRIPTION
## Summary

The tray-icon FAQ only showed `apt` install steps, so Fedora (and Arch) users got dead-end instructions for a missing AppIndicator extension.

This updates:
- `docs/INSTALL.md` with apt / dnf / pacman install lines, enable steps, and icon cache refresh
- the website troubleshooting page with the same multi-distro guidance

## Test plan

- [x] Read the INSTALL.md "Tray icon missing" section; confirm Fedora `dnf` and Arch `pacman` are present
- [x] Check `web/src/app/troubleshooting/page.tsx` tray item lists all three distros
- [x] Optional: `cd web && npm run lint` if you touch the site build

Fixes #570
