### PR TITLE
fix(aur): move clipboard and wtype tools to optdepends

### DIFF
--- a/packaging/aur/vocalinux/PKGBUILD
+++ b/packaging/aur/vocalinux/PKGBUILD
@@ -30,9 +30,6 @@ depends=(
   'python-pydub'
   'python-evdev'
   'python-xlib'
-  'xclip'
-  'wl-clipboard'
-  'wtype'
   'hicolor-icon-theme'
 )
 makedepends=(
@@ -47,6 +44,9 @@ optdepends=(
   'python-pywhispercpp-rocm: AMD GPU whisper.cpp backend'
   'python-onnxruntime: Silero VAD'
   'xdotool: X11 injection fallback'
+  'xclip: X11 clipboard tools (copy/paste injection fallbacks)'
+  'wl-clipboard: Wayland clipboard (wl-copy/wl-paste) injection fallbacks'
+  'wtype: Wayland keystroke injection fallback'
 )
 conflicts=('vocalinux-git')
 source=("${pkgname}-${_tag}.tar.gz::https://github.com/jatinkrmalik/vocalinux/archive/refs/tags/v${_tag}.tar.gz")


### PR DESCRIPTION
## Summary

- Move `xclip`, `wl-clipboard`, and `wtype` from hard `depends` to `optdepends` in `packaging/aur/vocalinux/PKGBUILD`.
- Aligns with existing `xdotool` (already an optdepend for X11 injection fallback).
- Responds to AUR package feedback from **Ataraxy** ([comment #1079450](https://aur.archlinux.org/packages/vocalinux#comment-1079450)).

#579 already landed the virtual `python-pywhispercpp` depends change; this PR is only the clipboard/injection demotion.

These tools are used as clipboard and Wayland keystroke injection fallbacks. The IBus / primary path may not need them on every install (e.g. pure IBus, or user-chosen backends). Users who want those paths can install the optdepends.

`pkgver`/`pkgrel` left unchanged; the next `v*` publish via `release.yml` will push the AUR package update.

## Test plan

- [x] Eye-check `depends` / `optdepends` array syntax in PKGBUILD
- [x] Reviewer: confirm no other packaging files need a matching note
- [x] AUR consumers pick this up on next tagged release publish