### PR TITLE
fix(web): stop robots.txt from blocking indexable pages

### DIFF
--- a/web/public/robots.txt
+++ b/web/public/robots.txt
@@ -1,13 +1,15 @@
 # Robots.txt for Vocalinux
 # https://vocalinux.com
+#
+# Intentionally permissive for marketing pages. Do not blanket-block
+# query-string URLs or /_next/static — those caused Google Search Console
+# "Indexed, though blocked by robots.txt" for otherwise valid pages.
+# Duplicate/param URLs are handled via canonical tags instead.
 
 User-agent: *
 Allow: /
 Disallow: /api/
-Disallow: /_next/
 Disallow: /out/
-Disallow: /*?*
 
 # Sitemap location
 Sitemap: https://vocalinux.com/sitemap.xml
-Host: vocalinux.com

--- a/web/src/app/__tests__/seo-assets.test.ts
+++ b/web/src/app/__tests__/seo-assets.test.ts
@@ -21,8 +21,20 @@ describe("SEO Assets", () => {
 
   it("blocks crawler access to technical paths", () => {
     expect(robotsContent).toContain("Disallow: /api/");
-    expect(robotsContent).toContain("Disallow: /_next/");
     expect(robotsContent).toContain("Disallow: /out/");
+  });
+
+  it("does not block Next.js static assets needed for rendering", () => {
+    expect(robotsContent).not.toContain("Disallow: /_next/");
+  });
+
+  it("does not blanket-block query-string URLs", () => {
+    // Blocking all query strings causes GSC "Indexed, though blocked by robots.txt"
+    // for pages discovered with UTM/tracking params. Use canonicals instead.
+    const disallowRules = robotsContent
+      .split("\n")
+      .filter((line) => line.trimStart().startsWith("Disallow:"));
+    expect(disallowRules.some((line) => /\/\*\?\*/.test(line))).toBe(false);
   });
 
   it("includes core landing pages in sitemap", () => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Google Search Console reported **Indexed, though blocked by robots.txt**. On latest `main`, `web/public/robots.txt` had:

```
Disallow: /*?*
Disallow: /_next/
```

`Disallow: /*?*` blocks every URL with a query string (UTM params, shared links, etc.). Google can still index those URLs from links/sitemaps, but cannot crawl them — which is exactly this GSC status.

## Fix
- Remove the blanket query-string Disallow (canonical tags already consolidate param variants)
- Remove `/_next/` Disallow so Google can fetch static JS/CSS for rendering
- Keep `/api/` and `/out/` blocked
- Drop the non-standard `Host:` directive (Yandex-only)
- Update SEO asset tests to lock this in

## After merge
In Search Console: Settings → robots.txt → request a recrawl, then re-check affected URLs in the indexing report.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d5eb8057-a55d-495e-b622-e39c9b070aa6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d5eb8057-a55d-495e-b622-e39c9b070aa6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

