### PR TITLE
fix(ci): clear website pipeline lint and action warnings

### DIFF
--- a/.github/workflows/codeberg-mirror.yml
+++ b/.github/workflows/codeberg-mirror.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     if: github.repository == 'jatinkrmalik/vocalinux'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
 

--- a/.github/workflows/distro-test-matrix.yml
+++ b/.github/workflows/distro-test-matrix.yml
@@ -37,7 +37,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Install basic dependencies
         run: |

--- a/.github/workflows/flatpak.yml
+++ b/.github/workflows/flatpak.yml
@@ -51,7 +51,7 @@ jobs:
       options: --privileged
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Build and bundle
         uses: flatpak/flatpak-github-actions/flatpak-builder@v6

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Label PR
-        uses: actions/labeler@v5
+        uses: actions/labeler@v6
         with:
           repo-token: "${{ secrets.GITHUB_TOKEN }}"
           sync-labels: true

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -18,7 +18,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: main
           fetch-depth: 0
@@ -264,7 +264,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: main
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
@@ -145,7 +145,7 @@ jobs:
     runs-on: ubuntu-24.04-arm
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set up Python
         uses: actions/setup-python@v5
@@ -210,7 +210,7 @@ jobs:
       url: https://pypi.org/project/vocalinux/
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set up Python
         uses: actions/setup-python@v5
@@ -260,7 +260,7 @@ jobs:
 
       - name: Checkout code
         if: steps.aur.outputs.configured == 'true'
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Bump PKGBUILD version
         if: steps.aur.outputs.configured == 'true'
@@ -287,14 +287,12 @@ jobs:
     name: Deploy Website
     runs-on: ubuntu-latest
     needs: [build-and-release, publish-pypi]
-    env:
-      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: '24'
           cache: 'npm'
@@ -308,15 +306,15 @@ jobs:
         run: |
           VERSION=$(grep -oP '__version__\s*=\s*"\K[^"]+' src/vocalinux/version.py)
           echo "Syncing version: $VERSION"
-          # Update softwareVersion where JSON-LD currently lives
-          if grep -q '"softwareVersion": "' web/src/app/page.tsx; then
-            sed -i 's/"softwareVersion": "[^"]*"/"softwareVersion": "'"$VERSION"'"/' web/src/app/page.tsx
+          # JSON-LD uses unquoted JS keys: softwareVersion: "x.y.z"
+          if grep -qE 'softwareVersion:\s*"' web/src/app/page.tsx; then
+            sed -i 's/softwareVersion: "[^"]*"/softwareVersion: "'"$VERSION"'"/' web/src/app/page.tsx
             echo "Updated page.tsx version:"
-            grep -oP '"softwareVersion":\s*"\K[^"]+' web/src/app/page.tsx
-          elif grep -q '"softwareVersion": "' web/src/app/layout.tsx; then
-            sed -i 's/"softwareVersion": "[^"]*"/"softwareVersion": "'"$VERSION"'"/' web/src/app/layout.tsx
+            grep -oP 'softwareVersion:\s*"\K[^"]+' web/src/app/page.tsx
+          elif grep -qE 'softwareVersion:\s*"' web/src/app/layout.tsx; then
+            sed -i 's/softwareVersion: "[^"]*"/softwareVersion: "'"$VERSION"'"/' web/src/app/layout.tsx
             echo "Updated layout.tsx version:"
-            grep -oP '"softwareVersion":\s*"\K[^"]+' web/src/app/layout.tsx
+            grep -oP 'softwareVersion:\s*"\K[^"]+' web/src/app/layout.tsx
           else
             echo "::warning::No softwareVersion field found in page.tsx or layout.tsx; skipping sync"
           fi

--- a/.github/workflows/unified-pipeline.yml
+++ b/.github/workflows/unified-pipeline.yml
@@ -25,7 +25,7 @@ jobs:
       python: ${{ steps.filter.outputs.python }}
       deploy_website: ${{ steps.deploy_check.outputs.deploy }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: dorny/paths-filter@v3
         id: filter
         with:
@@ -68,7 +68,7 @@ jobs:
     needs: changes
     if: needs.changes.outputs.python == 'true'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Set up Python
         uses: actions/setup-python@v5
@@ -105,7 +105,7 @@ jobs:
         python-version: ['3.9', '3.10', '3.11', '3.13']
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v5
@@ -184,7 +184,7 @@ jobs:
           - arch: aarch64
             runner: ubuntu-24.04-arm
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Set up Python
         uses: actions/setup-python@v5
@@ -242,12 +242,12 @@ jobs:
     needs: changes
     if: needs.changes.outputs.deploy_website == 'true'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
-          node-version: '20'
+          node-version: '24'
           cache: 'npm'
           cache-dependency-path: './web/package-lock.json'
 
@@ -259,15 +259,15 @@ jobs:
         run: |
           VERSION=$(grep -oP '__version__\s*=\s*"\K[^"]+' src/vocalinux/version.py)
           echo "Syncing version: $VERSION"
-          # Update softwareVersion where JSON-LD currently lives
-          if grep -q '"softwareVersion": "' web/src/app/page.tsx; then
-            sed -i 's/"softwareVersion": "[^"]*"/"softwareVersion": "'"$VERSION"'"/' web/src/app/page.tsx
+          # JSON-LD uses unquoted JS keys: softwareVersion: "x.y.z"
+          if grep -qE 'softwareVersion:\s*"' web/src/app/page.tsx; then
+            sed -i 's/softwareVersion: "[^"]*"/softwareVersion: "'"$VERSION"'"/' web/src/app/page.tsx
             echo "Updated page.tsx version:"
-            grep -oP '"softwareVersion":\s*"\K[^"]+' web/src/app/page.tsx
-          elif grep -q '"softwareVersion": "' web/src/app/layout.tsx; then
-            sed -i 's/"softwareVersion": "[^"]*"/"softwareVersion": "'"$VERSION"'"/' web/src/app/layout.tsx
+            grep -oP 'softwareVersion:\s*"\K[^"]+' web/src/app/page.tsx
+          elif grep -qE 'softwareVersion:\s*"' web/src/app/layout.tsx; then
+            sed -i 's/softwareVersion: "[^"]*"/softwareVersion: "'"$VERSION"'"/' web/src/app/layout.tsx
             echo "Updated layout.tsx version:"
-            grep -oP '"softwareVersion":\s*"\K[^"]+' web/src/app/layout.tsx
+            grep -oP 'softwareVersion:\s*"\K[^"]+' web/src/app/layout.tsx
           else
             echo "::warning::No softwareVersion field found in page.tsx or layout.tsx; skipping sync"
           fi
@@ -299,13 +299,11 @@ jobs:
       github.ref == 'refs/heads/main' &&
       needs.changes.outputs.deploy_website == 'true' &&
       needs.web-build.result == 'success'
-    env:
-      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: '24'
           cache: 'npm'

--- a/web/next.config.js
+++ b/web/next.config.js
@@ -6,30 +6,9 @@ const config = {
 	// Configuration for custom domain deployment
 	distDir: 'out',
 
-	// Configure cache headers for static assets
-	// This generates a _headers file for platforms like Netlify/Vercel
-	async headers() {
-		return [
-			{
-				source: '/_next/static/:path*',
-				headers: [
-					{
-						key: 'Cache-Control',
-						value: 'public, max-age=31536000, immutable',
-					},
-				],
-			},
-			{
-				source: '/:all*(svg|jpg|jpeg|png|webp|avif|ico|woff|woff2)',
-				headers: [
-					{
-						key: 'Cache-Control',
-						value: 'public, max-age=31536000, immutable',
-					},
-				],
-			},
-		];
-	},
+	// Cache/security headers live in public/_headers (copied into the static
+	// export). next.config headers() is ignored with output: 'export' and only
+	// produces build warnings.
 	images: {
 		unoptimized: true,
 		formats: ['image/avif', 'image/webp'],

--- a/web/postcss.config.js
+++ b/web/postcss.config.js
@@ -1,5 +1,7 @@
-export default {
+const config = {
   plugins: {
     tailwindcss: {},
   },
 };
+
+export default config;

--- a/web/prettier.config.js
+++ b/web/prettier.config.js
@@ -1,4 +1,6 @@
 /** @type {import('prettier').Config & import('prettier-plugin-tailwindcss').PluginOptions} */
-export default {
+const config = {
   plugins: ["prettier-plugin-tailwindcss"],
 };
+
+export default config;

--- a/web/src/components/seo-subpage-shell.tsx
+++ b/web/src/components/seo-subpage-shell.tsx
@@ -296,12 +296,12 @@ export function SeoSubpageShell({ children }: SeoSubpageShellProps) {
 
           <div className="flex items-center gap-2">
             <ThemeToggle />
-            <a
+            <Link
               href="/#install"
               className="hidden h-9 items-center rounded-full bg-primary px-4 text-sm font-medium text-primary-foreground sm:inline-flex"
             >
               Install
-            </a>
+            </Link>
             <button
               type="button"
               onClick={(e) => {
@@ -347,13 +347,13 @@ export function SeoSubpageShell({ children }: SeoSubpageShellProps) {
                   </div>
                 </div>
               ))}
-              <a
+              <Link
                 href="/#install"
                 onClick={() => setMobileMenuOpen(false)}
                 className="mt-2 flex items-center justify-center rounded-full bg-primary px-4 py-2.5 text-sm font-semibold text-primary-foreground"
               >
                 Install Vocalinux
-              </a>
+              </Link>
             </nav>
           </div>
         ) : null}
@@ -384,12 +384,12 @@ export function SeoSubpageShell({ children }: SeoSubpageShellProps) {
                 Home
                 <ChevronRight className="h-4 w-4" />
               </Link>
-              <a
+              <Link
                 href="/#install"
                 className="inline-flex items-center gap-1.5 rounded-full border border-zinc-700 px-4 py-2 text-sm font-medium text-zinc-100 transition-colors hover:border-zinc-500"
               >
                 Install
-              </a>
+              </Link>
               <a
                 href="https://github.com/jatinkrmalik/vocalinux"
                 target="_blank"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Follow-up to the deploy job noise in [CI run 30332548115](https://github.com/jatinkrmalik/vocalinux/actions/runs/30332548115/job/90190850565) (Build + Deploy Website).

## What was failing / warning
| Signal | Cause |
|---|---|
| 3 ESLint errors | `<a href="/#install">` in `seo-subpage-shell.tsx` tripped `@next/next/no-html-link-for-pages` |
| 2 ESLint warnings | anonymous `export default` in `prettier.config.js` / `postcss.config.js` |
| Next.js build warning | `headers()` in `next.config.js` is ignored with `output: 'export'` (headers already live in `public/_headers`) |
| `::warning::No softwareVersion...` | sync grepped JSON-quoted `"softwareVersion":` but the source uses JS `softwareVersion:` |
| Node 20 deprecation | `actions/checkout@v4` / `setup-node@v4` (and labeler@v5) still target Node 20 |

## Fix
- Swap install hash links to `next/link`
- Name prettier/postcss default exports
- Drop ineffective `headers()` from Next config
- Fix version sync in `unified-pipeline.yml` + `release.yml`
- Bump Actions to Node-24 runtimes (`checkout`/`setup-node` `@v5`, `labeler` `@v6`); align website build to Node 24; remove `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24`

## Verified locally
- `npm run lint` → clean
- `npm run build` → no headers/export warnings
- Jest: `next.config` / `headers` / `seo` suites pass

## Left alone (noise we can't usefully fix here)
- npm transitive deprecation/`audit` notices (eslint 8 / glob etc.) — larger dependency upgrade
- `peaceiris/actions-gh-pages` `git remote rm origin` error under `force_orphan` (benign action internals)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d5eb8057-a55d-495e-b622-e39c9b070aa6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d5eb8057-a55d-495e-b622-e39c9b070aa6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

