### PR TITLE
fix(ibus): keep engine teardown correct when parent destroy fails

### DIFF
--- a/src/vocalinux/text_injection/ibus_engine.py
+++ b/src/vocalinux/text_injection/ibus_engine.py
@@ -601,7 +601,13 @@ def _handle_engine_destroy(
         next_active_instance = None
 
     if ibus_available and super_destroy is not None:
-        super_destroy()
+        # The caller assigns our return value to _active_instance and clears the
+        # focus event, so a failing parent destroy must not skip that teardown:
+        # otherwise a destroyed engine stays registered as active with focus set.
+        try:
+            super_destroy()
+        except Exception:
+            logger.exception("Parent engine destroy failed; continuing teardown")
 
     return next_active_instance
 
@@ -866,7 +872,20 @@ class VocalinuxEngine(IBus.Engine if IBUS_AVAILABLE else object):
         logger.debug("VocalinuxEngine instance destroyed")
         super_destroy: Optional[Callable[[], None]] = None
         if IBUS_AVAILABLE:
-            super_destroy = super().do_destroy
+            parent_destroy = super().do_destroy
+
+            def destroy_via_parent() -> None:
+                # PyGObject binds this vfunc to the GType rather than to the
+                # instance, so calling it with no arguments raises
+                # "IBus.Object.destroy() takes exactly 1 argument (0 given)".
+                # Retry with the instance explicitly. The try/except keeps this
+                # working if a future PyGObject binds the vfunc correctly.
+                try:
+                    parent_destroy()
+                except TypeError:
+                    IBus.Object.destroy(self)
+
+            super_destroy = destroy_via_parent
         was_active = VocalinuxEngine._active_instance is self
         VocalinuxEngine._active_instance = _handle_engine_destroy(
             VocalinuxEngine._active_instance,

--- a/src/vocalinux/text_injection/ibus_engine.py
+++ b/src/vocalinux/text_injection/ibus_engine.py
@@ -14,6 +14,7 @@ This is the preferred method for Wayland environments as it works universally
 without requiring compositor-specific protocols.
 """
 
+import functools
 import logging
 import os
 import signal
@@ -589,6 +590,23 @@ def restore_xkb_layout(layout: str, variant: str = "", option: str = "") -> bool
     return False
 
 
+def _invoke_parent_destroy(parent_destroy: Callable[[], None], instance: object) -> None:
+    """Call the parent engine destroy, working around PyGObject's GType binding.
+
+    PyGObject binds the ``do_destroy`` vfunc to the GType rather than to the
+    instance, so ``super().do_destroy()`` raises
+    ``TypeError: IBus.Object.destroy() takes exactly 1 argument (0 given)``.
+    Retry with the instance explicitly.
+
+    The TypeError path rather than an unconditional ``IBus.Object.destroy``
+    keeps this working if a future PyGObject binds the vfunc correctly.
+    """
+    try:
+        parent_destroy()
+    except TypeError:
+        IBus.Object.destroy(instance)
+
+
 def _handle_engine_destroy(
     active_instance: Optional["VocalinuxEngine"],
     current_instance: object,
@@ -872,20 +890,7 @@ class VocalinuxEngine(IBus.Engine if IBUS_AVAILABLE else object):
         logger.debug("VocalinuxEngine instance destroyed")
         super_destroy: Optional[Callable[[], None]] = None
         if IBUS_AVAILABLE:
-            parent_destroy = super().do_destroy
-
-            def destroy_via_parent() -> None:
-                # PyGObject binds this vfunc to the GType rather than to the
-                # instance, so calling it with no arguments raises
-                # "IBus.Object.destroy() takes exactly 1 argument (0 given)".
-                # Retry with the instance explicitly. The try/except keeps this
-                # working if a future PyGObject binds the vfunc correctly.
-                try:
-                    parent_destroy()
-                except TypeError:
-                    IBus.Object.destroy(self)
-
-            super_destroy = destroy_via_parent
+            super_destroy = functools.partial(_invoke_parent_destroy, super().do_destroy, self)
         was_active = VocalinuxEngine._active_instance is self
         VocalinuxEngine._active_instance = _handle_engine_destroy(
             VocalinuxEngine._active_instance,

--- a/tests/test_ibus_engine.py
+++ b/tests/test_ibus_engine.py
@@ -2015,6 +2015,47 @@ class TestVocalinuxEngineDestroy(unittest.TestCase):
 
         mock_super_destroy.assert_not_called()
 
+    def test_invoke_parent_destroy_passes_through_when_binding_is_correct(self):
+        """A parent destroy that accepts no arguments is called as-is (#606)."""
+        from vocalinux.text_injection.ibus_engine import _invoke_parent_destroy
+
+        parent_destroy = MagicMock()
+
+        _invoke_parent_destroy(parent_destroy, object())
+
+        parent_destroy.assert_called_once_with()
+
+    def test_invoke_parent_destroy_retries_with_instance_on_type_error(self):
+        """PyGObject binds the vfunc to the GType, so retry with the instance (#606).
+
+        ``super().do_destroy`` resolves to a method bound to the GType rather
+        than the engine, so the no-argument call raises TypeError and the real
+        destroy never happens.
+        """
+        import vocalinux.text_injection.ibus_engine as mod
+        from vocalinux.text_injection.ibus_engine import _invoke_parent_destroy
+
+        parent_destroy = MagicMock(
+            side_effect=TypeError("IBus.Object.destroy() takes exactly 1 argument (0 given)")
+        )
+        instance = object()
+        fake_ibus = MagicMock()
+
+        with patch.object(mod, "IBus", fake_ibus):
+            _invoke_parent_destroy(parent_destroy, instance)
+
+        parent_destroy.assert_called_once_with()
+        fake_ibus.Object.destroy.assert_called_once_with(instance)
+
+    def test_invoke_parent_destroy_propagates_other_errors(self):
+        """Only the GType-binding TypeError is worked around; nothing else is masked."""
+        from vocalinux.text_injection.ibus_engine import _invoke_parent_destroy
+
+        parent_destroy = MagicMock(side_effect=RuntimeError("boom"))
+
+        with self.assertRaises(RuntimeError):
+            _invoke_parent_destroy(parent_destroy, object())
+
     def test_do_destroy_clears_active_instance_when_super_raises(self):
         """A failing parent destroy must not skip teardown (#606).
 

--- a/tests/test_ibus_engine.py
+++ b/tests/test_ibus_engine.py
@@ -2015,6 +2015,47 @@ class TestVocalinuxEngineDestroy(unittest.TestCase):
 
         mock_super_destroy.assert_not_called()
 
+    def test_do_destroy_clears_active_instance_when_super_raises(self):
+        """A failing parent destroy must not skip teardown (#606).
+
+        PyGObject binds the destroy vfunc to the GType rather than the instance,
+        so ``super().do_destroy()`` raised TypeError on every teardown. That
+        exception escaped before the return value was assigned, leaving a
+        destroyed engine registered as active with the focus event still set.
+        """
+        from vocalinux.text_injection.ibus_engine import _handle_engine_destroy
+
+        engine = object()
+        failing_super_destroy = MagicMock(
+            side_effect=TypeError("IBus.Object.destroy() takes exactly 1 argument (0 given)")
+        )
+
+        next_active = _handle_engine_destroy(
+            active_instance=engine,
+            current_instance=engine,
+            ibus_available=True,
+            super_destroy=failing_super_destroy,
+        )
+
+        failing_super_destroy.assert_called_once()
+        self.assertIsNone(next_active)
+
+    def test_do_destroy_keeps_other_instance_when_super_raises(self):
+        """A failing parent destroy still returns the unrelated active engine (#606)."""
+        from vocalinux.text_injection.ibus_engine import _handle_engine_destroy
+
+        active_engine = object()
+        failing_super_destroy = MagicMock(side_effect=RuntimeError("boom"))
+
+        next_active = _handle_engine_destroy(
+            active_instance=active_engine,
+            current_instance=object(),
+            ibus_available=True,
+            super_destroy=failing_super_destroy,
+        )
+
+        self.assertIs(next_active, active_engine)
+
     def test_do_destroy_handles_missing_super_callback(self):
         """Test destroy handler works when no parent destroy callback is provided."""
         from vocalinux.text_injection.ibus_engine import _handle_engine_destroy


### PR DESCRIPTION
Fixes #606.

## What

`do_destroy` passed `super().do_destroy` into `_handle_engine_destroy`. PyGObject binds that vfunc to the **GType** rather than to the instance, so calling it with no arguments raises:

```
TypeError: IBus.Object.destroy() takes exactly 1 argument (0 given)
```

This fired on every engine teardown, i.e. after every dictation.

## Why it matters beyond the noise

The exception escaped `_handle_engine_destroy` before its `return`, so neither statement in the caller ran:

```python
VocalinuxEngine._active_instance = _handle_engine_destroy(...)   # skipped
if was_active:
    VocalinuxEngine._focus_event.clear()                         # skipped
```

That left a destroyed engine registered as active with the focus event still set — the two values `_ibus_ping_status` (#523) reads to decide whether it is safe to commit. `do_focus_in` reassigns `_active_instance` on the next activation, which is likely why this went unnoticed; the stale window is between dictations. I could not attribute a specific dropped commit to it, so I am reporting the state corruption as fact and the commit risk as inference.

## Changes

1. **Bind the parent destroy to the instance.** Falls back to `IBus.Object.destroy(self)` only when the no-arg call raises `TypeError`, so this keeps working if a future PyGObject binds the vfunc correctly.
2. **Guard the parent destroy call**, so no failure there can skip teardown. The caller depends on the return value, so nothing inside should be able to bypass it.

## Reproduction

Independent of Vocalinux — raw IBus + PyGObject:

```python
import gi
gi.require_version("IBus", "1.0")
from gi.repository import IBus

class E(IBus.Engine):
    __gtype_name__ = "ProbeEngine"
    def probe(self):
        print(super().do_destroy)   # <bound method destroy of <GType ProbeEngine>>
        super().do_destroy()        # TypeError
E().probe()
```

Note the binding target is the GType, not the instance.

## Tests

Two added, covering teardown with a raising parent destroy (both the "is active" and "is a different instance" paths). Verified no new flake8 findings and no test failures unique to this branch against `main`.

## Environment

Vocalinux 0.14.2 · IBus 1.5.34 · PyGObject 3.56.3 · Python 3.14.6 · Hyprland 0.56.1. The reproduction depends only on IBus + PyGObject, so the compositor is incidental.
