### PR TITLE
fix(ui): flatten settings info notices

### DIFF
--- a/src/vocalinux/ui/settings_dialog.py
+++ b/src/vocalinux/ui/settings_dialog.py
@@ -503,17 +503,21 @@ spinbutton {
     margin-bottom: 6px;
 }
 
-/* Info box styling */
+/* Flat helper notices — muted surface, no accent strip */
 .info-box {
-    background-color: alpha(@theme_selected_bg_color, 0.1);
+    background-color: alpha(@theme_fg_color, 0.04);
+    border: 1px solid alpha(@borders, 0.45);
     border-radius: 8px;
-    padding: 12px;
-    border-left: 4px solid @theme_selected_bg_color;
+    padding: 10px 12px;
+}
+
+.info-box image {
+    opacity: 0.55;
 }
 
 .info-box-warning {
-    background-color: alpha(#e5a50a, 0.1);
-    border-left-color: #e5a50a;
+    background-color: alpha(#e5a50a, 0.08);
+    border-color: alpha(#e5a50a, 0.4);
 }
 
 /* Recognition status */

--- a/tests/test_settings_dialog.py
+++ b/tests/test_settings_dialog.py
@@ -253,6 +253,15 @@ class TestSettingsDialogCSS(unittest.TestCase):
         self.assertIn(".status-warning", SETTINGS_CSS)
         self.assertIn(".status-error", SETTINGS_CSS)
 
+    def test_settings_css_info_box_is_flat(self):
+        """Info notices use a flat border, not a left accent strip."""
+        from vocalinux.ui.settings_dialog import SETTINGS_CSS
+
+        self.assertIn(".info-box", SETTINGS_CSS)
+        self.assertIn("border: 1px solid", SETTINGS_CSS)
+        self.assertNotIn("border-left:", SETTINGS_CSS)
+        self.assertNotIn("border-left-color:", SETTINGS_CSS)
+
 
 class TestSettingsDialogClasses(unittest.TestCase):
     """Test cases for SettingsDialog helper classes."""


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Settings helper notices used a thick left accent bar and a selected-color tint, which read more like callout banners than the rest of the dialog.

This flattens `.info-box` to a muted surface with a thin full border (same language as the preference cards), and softens the info icon. Warning notices keep a quiet amber tint without the accent strip.

### Before / after

**Before**
![Before: info notice with left accent bar](https://cursor.com/artifacts/c/art-b874f319-b8a3-4c05-ab36-57cc74ed0fbc)

**After**
![After: flat muted info notice](https://cursor.com/artifacts/c/art-60f4fd5c-7a9f-49ab-b6f7-465a494663f9)

Close-up:
![Before and after notice crop](https://cursor.com/artifacts/c/art-621d52d6-427b-4de6-a988-86c1f7397297)

### Test plan
- [x] `pytest tests/test_settings_dialog.py::TestSettingsDialogCSS`
- [x] Open Settings → Dictation and confirm the toggle-mode notice has no left accent bar
- [x] Open Settings → Advanced (unlocked) and confirm the whisper.cpp notice matches
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-141fc03b-6336-4749-93e7-12f9110d6ac0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-141fc03b-6336-4749-93e7-12f9110d6ac0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

