### PR TITLE
docs(user-guide): note CUDA device 0 limit for dual NVIDIA

### DIFF
--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -158,6 +158,10 @@ English-only whisper.cpp specializations limit the language selector to English.
 
 On multi-GPU machines, Vocalinux prefers a **discrete** Vulkan device when one is present. You can override the device under **Advanced** settings (`whispercpp_gpu_device`).
 
+Pip wheels of pywhispercpp are often CUDA builds. In that case Vocalinux always uses CUDA device 0 (the first NVIDIA GPU), because Vulkan GPU indices do not match CUDA ordinals. On a hybrid laptop the NVIDIA GPU is usually Vulkan GPU 1; feeding that index into CUDA would land on the CPU fallback instead.
+
+If you need a second NVIDIA GPU, either set `CUDA_VISIBLE_DEVICES` before starting Vocalinux or install a Vulkan-built pywhispercpp so the Advanced GPU picker applies.
+
 To check which backend is being used, look for these log messages when starting Vocalinux:
 ```
 [INFO] whisper.cpp using Vulkan GPU backend: AMD Radeon RX 6800


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Follow-up to #636. Documents the intentional CUDA device-0 behavior in the user guide GPU section:

- CUDA-backed pywhispercpp always uses device 0 (Vulkan indices do not map to CUDA ordinals)
- Hybrid laptop rationale (Vulkan GPU 1 → CUDA CPU fallback)
- Workarounds for a non-default NVIDIA GPU: `CUDA_VISIBLE_DEVICES`, or a Vulkan-built pywhispercpp so the Advanced GPU picker applies

## Test plan

- [x] Skim `docs/USER_GUIDE.md` GPU Acceleration section for clarity

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7c0ff2ab-c061-4737-a70d-53b4d950ed8a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7c0ff2ab-c061-4737-a70d-53b4d950ed8a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

