### PR TITLE
fix(clipboard): text-only reads and safe overlapping restore

### DIFF
--- a/src/vocalinux/text_injection/text_injector.py
+++ b/src/vocalinux/text_injection/text_injector.py
@@ -112,9 +112,8 @@ class TextInjector:
         self._state_lock = threading.Lock()
         self._clipboard_tool_health = {}
         self._clipboard_timeout = 0.35
-        # Clipboard restore coordination for overlapping ydotool pastes.
-        # generation increments on each paste so stale restore threads exit;
-        # target holds the pre-injection content the latest restore should write back.
+        # Overlapping ydotool pastes: bump generation to cancel stale restores;
+        # target keeps the original pre-injection clipboard across the window.
         self._clipboard_restore_generation = 0
         self._clipboard_restore_target: Optional[str] = None
 
@@ -1263,12 +1262,11 @@ class TextInjector:
 
     def _read_clipboard(self) -> Optional[str]:
         """
-        Read the current clipboard *text* content.
+        Read clipboard text only.
 
-        Always requests a text MIME type so image/file clipboards are not
-        decoded as corrupted strings. Returns the clipboard text, "" if a
-        tool reports the clipboard is verifiably empty, or None if it could
-        not be read as text (non-text data, no tool, or tool error).
+        Requests text MIME types so image/file data is not treated as text.
+        Returns the text, "" if a tool reports a verifiably empty clipboard,
+        or None if unreadable as text (non-text data, no tool, or error).
         """
         host_is_wayland = (
             self._session_environment == DesktopEnvironment.WAYLAND
@@ -1276,15 +1274,13 @@ class TextInjector:
             or bool(os.environ.get("WAYLAND_DISPLAY"))
         )
 
-        # Force text MIME types. Bare `xclip -o` / `wl-paste` can return raw
-        # image bytes (rc=0); restoring that as text destroys the clipboard.
+        # Bare `xclip -o` / `wl-paste` can return raw image bytes with rc=0.
         candidates: list[list[str]] = []
         if host_is_wayland and shutil.which("wl-paste"):
             candidates.append(["wl-paste", "--no-newline", "--type", "text"])
         if shutil.which("xclip"):
             candidates.append(["xclip", "-selection", "clipboard", "-o", "-t", "UTF8_STRING"])
         if shutil.which("xsel"):
-            # xsel is text-oriented and has no MIME flag.
             candidates.append(["xsel", "--clipboard", "--output"])
         if not host_is_wayland and shutil.which("wl-paste"):
             candidates.append(["wl-paste", "--no-newline", "--type", "text"])
@@ -1303,14 +1299,10 @@ class TextInjector:
                 )
                 if result.returncode == 0:
                     return result.stdout
-                # wl-paste signals a truly empty clipboard this way. Do not
-                # treat xclip's "target … not available" as empty — that also
-                # means "clipboard has image/file, no text". Keep scanning so
-                # a later backend (e.g. xclip on XWayland) can still return text.
-                stderr_lower = (result.stderr or "").lower()
-                if "nothing is copied" in stderr_lower:
+                # Only wl-paste's empty signal — xclip "target not available"
+                # also means image/file. Keep scanning other backends.
+                if "nothing is copied" in (result.stderr or "").lower():
                     saw_empty = True
-                    continue
             except (subprocess.TimeoutExpired, OSError, UnicodeDecodeError):
                 continue
 
@@ -1320,15 +1312,10 @@ class TextInjector:
         """
         Inject text by copying to clipboard and simulating Ctrl+V with ydotool.
 
-        This is the workaround for ydotool's inability to type non-ASCII/Unicode
-        characters (accented letters, CJK, etc.) because ydotool simulates evdev
-        key events which only cover US ASCII keycodes. See issue #362.
-
-        The previous clipboard content is saved before injection and restored
-        in a background thread after Ctrl+V completes, so the user's clipboard
-        is not permanently overwritten. Overlapping pastes share one restore
-        target (the pre-first-injection content) and a generation counter so
-        stale restore threads do not clobber a newer paste.
+        Workaround for ydotool's US-ASCII-only key events (see issue #362).
+        Saves the previous clipboard and restores it after a short delay.
+        Overlapping pastes share one restore target (pre-first-injection content)
+        and a generation counter so stale restore threads exit.
 
         Returns:
             True if successful, False otherwise
@@ -1338,22 +1325,22 @@ class TextInjector:
             "(saving clipboard to restore after paste)"
         )
 
-        # Bump generation so any in-flight restore from a prior paste exits.
-        # If a restore is already pending, keep restoring to that original
-        # content rather than the intermediate dictated text still on the clipboard.
+        # Inherit a pending restore target so a second paste in the delay window
+        # still restores the original clipboard, not intermediate dictated text.
         with self._state_lock:
-            self._clipboard_restore_generation += 1
-            generation = self._clipboard_restore_generation
             pending_target = self._clipboard_restore_target
-
-        if pending_target is not None:
-            previous_clipboard: Optional[str] = pending_target
-        else:
-            previous_clipboard = self._read_clipboard()
+        previous_clipboard = (
+            pending_target if pending_target is not None else self._read_clipboard()
+        )
 
         if not self._copy_to_clipboard(text):
             logger.warning("Could not copy text to clipboard for paste injection")
             return False
+
+        # Clipboard is overwritten — cancel any in-flight restore and take ownership.
+        with self._state_lock:
+            self._clipboard_restore_generation += 1
+            generation = self._clipboard_restore_generation
 
         # Simulate Ctrl+V via ydotool. Syntax differs by major version:
         # - 0.1.x (distro packages): named sequences, e.g. ctrl+v
@@ -1372,20 +1359,18 @@ class TextInjector:
             logger.info(f"Text injected via clipboard paste: '{text[:20]}...' ({len(text)} chars)")
         except (subprocess.CalledProcessError, subprocess.TimeoutExpired) as e:
             logger.warning(f"Paste simulation failed: {e}")
+            with self._state_lock:
+                if generation == self._clipboard_restore_generation:
+                    self._clipboard_restore_target = None
             if previous_clipboard is not None and not self._should_copy_to_clipboard():
-                with self._state_lock:
-                    if generation == self._clipboard_restore_generation:
-                        self._clipboard_restore_target = None
                 if previous_clipboard == "":
                     self._clear_clipboard()
                 else:
                     self._copy_to_clipboard(previous_clipboard)
             return False
 
-        # Restore the previous clipboard content after a short delay so the
-        # Ctrl+V paste has time to land before the clipboard changes.
-        # Skip restore when the user has opted in to keeping dictated text in
-        # the clipboard (copy_to_clipboard setting) — restoring would undo that.
+        # Delayed restore so Ctrl+V can land first. Skip when the user wants
+        # dictated text left on the clipboard (copy_to_clipboard setting).
         if previous_clipboard is not None and not self._should_copy_to_clipboard():
             with self._state_lock:
                 self._clipboard_restore_target = previous_clipboard
@@ -1394,21 +1379,16 @@ class TextInjector:
                 time.sleep(0.3)
                 with self._state_lock:
                     if generation != self._clipboard_restore_generation:
-                        # A newer paste owns the restore; leave its target alone.
                         return
-                    target = self._clipboard_restore_target
                     self._clipboard_restore_target = None
-                if target is None:
-                    return
-                # If the user copied something else during the delay, don't
-                # overwrite their new clipboard content with stale data.
+                # User copied something else during the delay — leave it alone.
                 if self._read_clipboard() != text:
                     logger.debug("Clipboard changed during restore delay; skipping restore")
                     return
-                if target == "":
+                if previous_clipboard == "":
                     success = self._clear_clipboard()
                 else:
-                    success = self._copy_to_clipboard(target)
+                    success = self._copy_to_clipboard(previous_clipboard)
                 if success:
                     logger.debug("Clipboard restored to previous content")
                 else:
@@ -1416,8 +1396,6 @@ class TextInjector:
 
             threading.Thread(target=_restore, daemon=True).start()
         else:
-            # No delayed restore for this paste — drop any inherited pending
-            # target so a cancelled prior restore cannot linger.
             with self._state_lock:
                 if generation == self._clipboard_restore_generation:
                     self._clipboard_restore_target = None

--- a/src/vocalinux/text_injection/text_injector.py
+++ b/src/vocalinux/text_injection/text_injector.py
@@ -112,6 +112,11 @@ class TextInjector:
         self._state_lock = threading.Lock()
         self._clipboard_tool_health = {}
         self._clipboard_timeout = 0.35
+        # Clipboard restore coordination for overlapping ydotool pastes.
+        # generation increments on each paste so stale restore threads exit;
+        # target holds the pre-injection content the latest restore should write back.
+        self._clipboard_restore_generation = 0
+        self._clipboard_restore_target: Optional[str] = None
 
         # Force Wayland mode if requested
         if wayland_mode and self.environment == DesktopEnvironment.X11:
@@ -1258,10 +1263,12 @@ class TextInjector:
 
     def _read_clipboard(self) -> Optional[str]:
         """
-        Read the current clipboard content.
+        Read the current clipboard *text* content.
 
-        Returns the clipboard text, "" if the clipboard is verifiably empty,
-        or None if it could not be read (non-text data or no tool available).
+        Always requests a text MIME type so image/file clipboards are not
+        decoded as corrupted strings. Returns the clipboard text, "" if a
+        tool reports the clipboard is verifiably empty, or None if it could
+        not be read as text (non-text data, no tool, or tool error).
         """
         host_is_wayland = (
             self._session_environment == DesktopEnvironment.WAYLAND
@@ -1269,16 +1276,20 @@ class TextInjector:
             or bool(os.environ.get("WAYLAND_DISPLAY"))
         )
 
+        # Force text MIME types. Bare `xclip -o` / `wl-paste` can return raw
+        # image bytes (rc=0); restoring that as text destroys the clipboard.
         candidates: list[list[str]] = []
         if host_is_wayland and shutil.which("wl-paste"):
-            candidates.append(["wl-paste", "--no-newline"])
+            candidates.append(["wl-paste", "--no-newline", "--type", "text"])
         if shutil.which("xclip"):
-            candidates.append(["xclip", "-selection", "clipboard", "-o"])
+            candidates.append(["xclip", "-selection", "clipboard", "-o", "-t", "UTF8_STRING"])
         if shutil.which("xsel"):
+            # xsel is text-oriented and has no MIME flag.
             candidates.append(["xsel", "--clipboard", "--output"])
         if not host_is_wayland and shutil.which("wl-paste"):
-            candidates.append(["wl-paste", "--no-newline"])
+            candidates.append(["wl-paste", "--no-newline", "--type", "text"])
 
+        saw_empty = False
         for cmd in candidates:
             try:
                 result = subprocess.run(
@@ -1292,19 +1303,18 @@ class TextInjector:
                 )
                 if result.returncode == 0:
                     return result.stdout
-                # wl-paste and xclip signal an empty clipboard with a non-zero
-                # exit code rather than empty stdout.  Detect those messages so
-                # callers can distinguish "empty" (restore to empty) from
-                # "unreadable" (skip restore).
-                stderr_lower = result.stderr.lower()
-                if "nothing is copied" in stderr_lower or (
-                    "target" in stderr_lower and "not available" in stderr_lower
-                ):
-                    return ""
+                # wl-paste signals a truly empty clipboard this way. Do not
+                # treat xclip's "target … not available" as empty — that also
+                # means "clipboard has image/file, no text". Keep scanning so
+                # a later backend (e.g. xclip on XWayland) can still return text.
+                stderr_lower = (result.stderr or "").lower()
+                if "nothing is copied" in stderr_lower:
+                    saw_empty = True
+                    continue
             except (subprocess.TimeoutExpired, OSError, UnicodeDecodeError):
                 continue
 
-        return None
+        return "" if saw_empty else None
 
     def _inject_via_clipboard_paste(self, text: str) -> bool:
         """
@@ -1316,7 +1326,9 @@ class TextInjector:
 
         The previous clipboard content is saved before injection and restored
         in a background thread after Ctrl+V completes, so the user's clipboard
-        is not permanently overwritten.
+        is not permanently overwritten. Overlapping pastes share one restore
+        target (the pre-first-injection content) and a generation counter so
+        stale restore threads do not clobber a newer paste.
 
         Returns:
             True if successful, False otherwise
@@ -1326,7 +1338,18 @@ class TextInjector:
             "(saving clipboard to restore after paste)"
         )
 
-        previous_clipboard = self._read_clipboard()
+        # Bump generation so any in-flight restore from a prior paste exits.
+        # If a restore is already pending, keep restoring to that original
+        # content rather than the intermediate dictated text still on the clipboard.
+        with self._state_lock:
+            self._clipboard_restore_generation += 1
+            generation = self._clipboard_restore_generation
+            pending_target = self._clipboard_restore_target
+
+        if pending_target is not None:
+            previous_clipboard: Optional[str] = pending_target
+        else:
+            previous_clipboard = self._read_clipboard()
 
         if not self._copy_to_clipboard(text):
             logger.warning("Could not copy text to clipboard for paste injection")
@@ -1350,6 +1373,9 @@ class TextInjector:
         except (subprocess.CalledProcessError, subprocess.TimeoutExpired) as e:
             logger.warning(f"Paste simulation failed: {e}")
             if previous_clipboard is not None and not self._should_copy_to_clipboard():
+                with self._state_lock:
+                    if generation == self._clipboard_restore_generation:
+                        self._clipboard_restore_target = None
                 if previous_clipboard == "":
                     self._clear_clipboard()
                 else:
@@ -1361,24 +1387,40 @@ class TextInjector:
         # Skip restore when the user has opted in to keeping dictated text in
         # the clipboard (copy_to_clipboard setting) — restoring would undo that.
         if previous_clipboard is not None and not self._should_copy_to_clipboard():
+            with self._state_lock:
+                self._clipboard_restore_target = previous_clipboard
 
             def _restore() -> None:
                 time.sleep(0.3)
+                with self._state_lock:
+                    if generation != self._clipboard_restore_generation:
+                        # A newer paste owns the restore; leave its target alone.
+                        return
+                    target = self._clipboard_restore_target
+                    self._clipboard_restore_target = None
+                if target is None:
+                    return
                 # If the user copied something else during the delay, don't
                 # overwrite their new clipboard content with stale data.
                 if self._read_clipboard() != text:
                     logger.debug("Clipboard changed during restore delay; skipping restore")
                     return
-                if previous_clipboard == "":
+                if target == "":
                     success = self._clear_clipboard()
                 else:
-                    success = self._copy_to_clipboard(previous_clipboard)
+                    success = self._copy_to_clipboard(target)
                 if success:
                     logger.debug("Clipboard restored to previous content")
                 else:
                     logger.debug("Could not restore previous clipboard content")
 
             threading.Thread(target=_restore, daemon=True).start()
+        else:
+            # No delayed restore for this paste — drop any inherited pending
+            # target so a cancelled prior restore cannot linger.
+            with self._state_lock:
+                if generation == self._clipboard_restore_generation:
+                    self._clipboard_restore_target = None
 
         return True
 

--- a/tests/test_clipboard_restore.py
+++ b/tests/test_clipboard_restore.py
@@ -27,6 +27,8 @@ def _make_injector() -> Any:
     obj._state_lock = threading.Lock()
     obj._clipboard_tool_health = {}
     obj._clipboard_timeout = 0.35
+    obj._clipboard_restore_generation = 0
+    obj._clipboard_restore_target = None
     return obj
 
 
@@ -48,6 +50,25 @@ class TestReadClipboard(unittest.TestCase):
                     mock_run.return_value = MagicMock(returncode=0, stdout="copied text")
                     result = obj._read_clipboard()
         self.assertEqual(result, "copied text")
+        mock_run.assert_called_once()
+        self.assertEqual(
+            mock_run.call_args.args[0],
+            ["wl-paste", "--no-newline", "--type", "text"],
+        )
+
+    def test_xclip_requests_utf8_string_target(self):
+        """xclip must request UTF8_STRING so image clipboards are not read as text."""
+        obj = _make_injector()
+        with patch("vocalinux.text_injection.text_injector.shutil.which") as mock_which:
+            mock_which.side_effect = lambda cmd: ("/usr/bin/xclip" if cmd == "xclip" else None)
+            with patch("vocalinux.text_injection.text_injector.subprocess.run") as mock_run:
+                mock_run.return_value = MagicMock(returncode=0, stdout="xclip text")
+                result = obj._read_clipboard()
+        self.assertEqual(result, "xclip text")
+        self.assertEqual(
+            mock_run.call_args.args[0],
+            ["xclip", "-selection", "clipboard", "-o", "-t", "UTF8_STRING"],
+        )
 
     def test_xclip_fallback_when_wl_paste_unavailable(self):
         """Falls back to xclip when wl-paste is not installed."""
@@ -686,8 +707,12 @@ class TestReadClipboardEmptyDetection(unittest.TestCase):
                 result = obj._read_clipboard()
         self.assertEqual(result, "")
 
-    def test_xclip_target_not_available_returns_empty_string(self):
-        """Returns '' when xclip stderr says target STRING not available."""
+    def test_xclip_target_not_available_returns_none(self):
+        """xclip 'target not available' means no text — not an empty clipboard.
+
+        Image/file clipboards produce this message for UTF8_STRING. Returning
+        '' would cause a clear that destroys non-text data; skip restore instead.
+        """
         obj = _make_injector()
         obj._session_environment = None  # non-Wayland so xclip is tried
         with patch(
@@ -696,12 +721,28 @@ class TestReadClipboardEmptyDetection(unittest.TestCase):
             with patch(
                 "vocalinux.text_injection.text_injector.subprocess.run",
                 return_value=MagicMock(
-                    returncode=1, stdout="", stderr="Error: target STRING not available"
+                    returncode=1, stdout="", stderr="Error: target UTF8_STRING not available"
                 ),
             ):
                 with patch.dict("os.environ", {"XDG_SESSION_TYPE": "x11", "WAYLAND_DISPLAY": ""}):
                     result = obj._read_clipboard()
-        self.assertEqual(result, "")
+        self.assertIsNone(result)
+
+    def test_wl_paste_empty_falls_through_to_xclip_text(self):
+        """Empty Wayland clipboard must not skip an X11 backend that still has text."""
+        obj = _make_injector()
+        with patch.dict(os.environ, {"WAYLAND_DISPLAY": "wayland-0"}):
+            with patch("vocalinux.text_injection.text_injector.shutil.which") as mock_which:
+                mock_which.side_effect = lambda cmd: (
+                    "/usr/bin/" + cmd if cmd in ("wl-paste", "xclip") else None
+                )
+                with patch("vocalinux.text_injection.text_injector.subprocess.run") as mock_run:
+                    mock_run.side_effect = [
+                        MagicMock(returncode=1, stdout="", stderr="Nothing is copied"),
+                        MagicMock(returncode=0, stdout="x11 text"),
+                    ]
+                    result = obj._read_clipboard()
+        self.assertEqual(result, "x11 text")
 
     def test_non_empty_clipboard_error_still_returns_none(self):
         """A non-zero exit code with unknown stderr does not trigger empty detection."""
@@ -709,6 +750,74 @@ class TestReadClipboardEmptyDetection(unittest.TestCase):
         with patch("shutil.which", return_value=None):
             result = obj._read_clipboard()
         self.assertIsNone(result)
+
+
+class TestOverlappingClipboardRestore(unittest.TestCase):
+    """Overlapping pastes must restore the original pre-first-injection content."""
+
+    def test_overlapping_pastes_restore_original_clipboard(self):
+        """Second paste within the restore window must not restore intermediate text."""
+        obj = _make_injector()
+        obj.wayland_tool = "ydotool"
+        copy_calls: list[str] = []
+        # First paste saves "URL". Second paste would naively save "hello" (still on
+        # clipboard); pending-target must keep restoring to "URL".
+        read_values = iter(["URL", "world"])
+
+        with patch.object(obj, "_read_clipboard", side_effect=lambda: next(read_values)):
+            with patch.object(
+                obj, "_copy_to_clipboard", side_effect=lambda t: copy_calls.append(t) or True
+            ):
+                with patch.object(
+                    obj,
+                    "_ydotool_ctrl_v_command",
+                    return_value=["ydotool", "key", "ctrl+v"],
+                ):
+                    with patch.object(obj, "_should_copy_to_clipboard", return_value=False):
+                        with patch(
+                            "vocalinux.text_injection.text_injector.subprocess.run",
+                            return_value=MagicMock(returncode=0),
+                        ):
+                            self.assertTrue(obj._inject_via_clipboard_paste("hello"))
+                            self.assertTrue(obj._inject_via_clipboard_paste("world"))
+                            time.sleep(0.5)
+
+        self.assertEqual(copy_calls[0], "hello")
+        self.assertEqual(copy_calls[1], "world")
+        self.assertEqual(copy_calls[-1], "URL")
+        self.assertNotIn("hello", copy_calls[2:])
+        self.assertIsNone(obj._clipboard_restore_target)
+
+    def test_stale_restore_thread_is_cancelled_by_newer_paste(self):
+        """A superseded restore must not clear the pending restore target."""
+        obj = _make_injector()
+        obj.wayland_tool = "ydotool"
+        copy_calls: list[str] = []
+
+        with patch.object(obj, "_read_clipboard", side_effect=["orig", "second"]):
+            with patch.object(
+                obj, "_copy_to_clipboard", side_effect=lambda t: copy_calls.append(t) or True
+            ):
+                with patch.object(
+                    obj,
+                    "_ydotool_ctrl_v_command",
+                    return_value=["ydotool", "key", "ctrl+v"],
+                ):
+                    with patch.object(obj, "_should_copy_to_clipboard", return_value=False):
+                        with patch(
+                            "vocalinux.text_injection.text_injector.subprocess.run",
+                            return_value=MagicMock(returncode=0),
+                        ):
+                            # First paste schedules restore gen=1 for "orig".
+                            obj._inject_via_clipboard_paste("first")
+                            # Bump generation as a newer paste would, without scheduling
+                            # another restore (simulates copy_to_clipboard / unreadable).
+                            with obj._state_lock:
+                                obj._clipboard_restore_generation += 1
+                            time.sleep(0.5)
+
+        # Only the injection copy — stale restore must not write "orig" back.
+        self.assertEqual(copy_calls, ["first"])
 
 
 if __name__ == "__main__":

--- a/tests/test_clipboard_restore.py
+++ b/tests/test_clipboard_restore.py
@@ -788,37 +788,6 @@ class TestOverlappingClipboardRestore(unittest.TestCase):
         self.assertNotIn("hello", copy_calls[2:])
         self.assertIsNone(obj._clipboard_restore_target)
 
-    def test_stale_restore_thread_is_cancelled_by_newer_paste(self):
-        """A superseded restore must not clear the pending restore target."""
-        obj = _make_injector()
-        obj.wayland_tool = "ydotool"
-        copy_calls: list[str] = []
-
-        with patch.object(obj, "_read_clipboard", side_effect=["orig", "second"]):
-            with patch.object(
-                obj, "_copy_to_clipboard", side_effect=lambda t: copy_calls.append(t) or True
-            ):
-                with patch.object(
-                    obj,
-                    "_ydotool_ctrl_v_command",
-                    return_value=["ydotool", "key", "ctrl+v"],
-                ):
-                    with patch.object(obj, "_should_copy_to_clipboard", return_value=False):
-                        with patch(
-                            "vocalinux.text_injection.text_injector.subprocess.run",
-                            return_value=MagicMock(returncode=0),
-                        ):
-                            # First paste schedules restore gen=1 for "orig".
-                            obj._inject_via_clipboard_paste("first")
-                            # Bump generation as a newer paste would, without scheduling
-                            # another restore (simulates copy_to_clipboard / unreadable).
-                            with obj._state_lock:
-                                obj._clipboard_restore_generation += 1
-                            time.sleep(0.5)
-
-        # Only the injection copy — stale restore must not write "orig" back.
-        self.assertEqual(copy_calls, ["first"])
-
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description

Follow-up to #588. Fixes two issues in the clipboard save/restore path used by ydotool paste injection:

1. **Non-text clipboard corruption** — `_read_clipboard()` forces text MIME types (`wl-paste --type text`, `xclip -t UTF8_STRING`) so image/file clipboards are not decoded and later “restored” as corrupted text.
2. **Overlapping paste race** — a generation counter cancels stale restore threads, and a pending restore target keeps the original pre-first-injection content across pastes within the 300 ms window.

Also stops treating xclip’s `target … not available` as an empty clipboard (that often means image-only), and no longer short-circuits other backends when wl-paste reports empty (XWayland hybrid).

Ponytail pass: bump generation only after a successful clipboard overwrite (so a failed copy cannot cancel an in-flight restore), clear pending target on paste failure unconditionally, restore from the closure instead of re-reading shared state, trim comments, drop a redundant unit test.

## Related Issue

Follow-up to #588

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 📖 Documentation update
- [x] 🧹 Code refactoring
- [x] ✅ Test update

## Checklist

- [x] My code follows the code style of this project (black, isort)
- [ ] I have updated the documentation accordingly
- [x] I have added tests to cover my changes
- [x] All new and existing tests pass locally
- [ ] Pre-commit hooks pass

## Additional Notes

**Test plan**
- [x] `pytest tests/test_clipboard_restore.py` (36 passed)
- [ ] Manual: screenshot on clipboard → dictate → clipboard remains image (restore skipped)
- [ ] Manual: copy URL → two quick dictations → clipboard returns to URL
- [ ] Manual: empty clipboard (wl-paste) → dictate → clipboard cleared after restore
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4800dbbf-089c-4ab0-96d5-ddec87db8a7f?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4800dbbf-089c-4ab0-96d5-ddec87db8a7f&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

