### PR TITLE
fix(ibus): restore XKB layout after scoped injection on X11 (#664)

### DIFF
--- a/src/vocalinux/text_injection/ibus_engine.py
+++ b/src/vocalinux/text_injection/ibus_engine.py
@@ -1409,6 +1409,10 @@ class IBusTextInjector:
         logger.info(f"Starting IBus text injection: '{text[:20]}...' (length: {len(text)})")
 
         restore_engine: Optional[str] = None
+        # Capture before any engine switch. Switching to Vocalinux can override
+        # the system XKB map to us; scoped injection must restore it after
+        # switching back (#292, #664). Empty on Wayland (no-op restore).
+        captured_xkb = get_current_xkb_layout()
         if not is_engine_active():
             current_engine = get_current_engine()
             if not current_engine:
@@ -1538,6 +1542,13 @@ class IBusTextInjector:
                     "Skipping engine restoration after injection — "
                     "no valid engine was captured (see #497)"
                 )
+
+            # Engine switch can leave XKB on us even after restoring the IBus
+            # engine (setxkbmap vs IBus). Re-apply the pre-switch map on X11;
+            # Wayland capture is empty so this is a no-op (#474, #664).
+            layout, variant, option = captured_xkb
+            if layout:
+                restore_xkb_layout(layout, variant, option)
 
         return False
 

--- a/tests/test_ibus_engine.py
+++ b/tests/test_ibus_engine.py
@@ -965,6 +965,97 @@ class TestIBusTextInjector(unittest.TestCase):
             [ENGINE_NAME, "libpinyin"],
         )
 
+    @patch("vocalinux.text_injection.ibus_engine.restore_xkb_layout")
+    @patch(
+        "vocalinux.text_injection.ibus_engine.get_current_xkb_layout",
+        return_value=("br", "", ""),
+    )
+    @patch("vocalinux.text_injection.ibus_engine.get_current_engine", return_value="xkb:br::por")
+    @patch("vocalinux.text_injection.ibus_engine.is_engine_active", return_value=False)
+    @patch("vocalinux.text_injection.ibus_engine.switch_engine", return_value=True)
+    @patch("socket.socket")
+    @patch("vocalinux.text_injection.ibus_engine.SOCKET_PATH")
+    @patch("vocalinux.text_injection.ibus_engine.IBUS_AVAILABLE", True)
+    @patch("vocalinux.text_injection.ibus_engine.ensure_ibus_dir")
+    def test_inject_text_restores_xkb_layout_after_scoped_activation(
+        self,
+        mock_ensure_dir,
+        mock_socket_path,
+        mock_socket_cls,
+        mock_switch,
+        mock_is_active,
+        mock_get_current,
+        mock_get_xkb,
+        mock_restore_xkb,
+    ):
+        """Scoped injection must restore XKB after the Vocalinux engine switch (#664)."""
+        from vocalinux.text_injection.ibus_engine import ENGINE_NAME, IBusTextInjector
+
+        mock_socket_path.exists.return_value = True
+        mock_sock = MagicMock()
+        mock_sock.__enter__.return_value = mock_sock
+        mock_sock.__exit__.return_value = None
+        mock_sock.recv.return_value = b"OK"
+        mock_socket_cls.return_value = mock_sock
+
+        parent = MagicMock()
+        parent.attach_mock(mock_get_xkb, "get_xkb")
+        parent.attach_mock(mock_switch, "switch")
+        parent.attach_mock(mock_restore_xkb, "restore_xkb")
+
+        injector = IBusTextInjector(auto_activate=False)
+        result = injector.inject_text("olá")
+
+        self.assertTrue(result)
+        mock_get_xkb.assert_called_once()
+        mock_restore_xkb.assert_called_once_with("br", "", "")
+        self.assertEqual(
+            [call.args[0] for call in mock_switch.call_args_list],
+            [ENGINE_NAME, "xkb:br::por"],
+        )
+        # Capture before switch; restore after engine restore.
+        self.assertEqual(
+            [c[0] for c in parent.mock_calls],
+            ["get_xkb", "switch", "switch", "restore_xkb"],
+        )
+
+    @patch("vocalinux.text_injection.ibus_engine.restore_xkb_layout")
+    @patch(
+        "vocalinux.text_injection.ibus_engine.get_current_xkb_layout",
+        return_value=("", "", ""),
+    )
+    @patch("vocalinux.text_injection.ibus_engine.get_current_engine", return_value="libpinyin")
+    @patch("vocalinux.text_injection.ibus_engine.is_engine_active", return_value=False)
+    @patch("vocalinux.text_injection.ibus_engine.switch_engine", return_value=True)
+    @patch("socket.socket")
+    @patch("vocalinux.text_injection.ibus_engine.SOCKET_PATH")
+    @patch("vocalinux.text_injection.ibus_engine.IBUS_AVAILABLE", True)
+    @patch("vocalinux.text_injection.ibus_engine.ensure_ibus_dir")
+    def test_inject_text_skips_xkb_restore_when_layout_empty(
+        self,
+        mock_ensure_dir,
+        mock_socket_path,
+        mock_socket_cls,
+        mock_switch,
+        mock_is_active,
+        mock_get_current,
+        mock_get_xkb,
+        mock_restore_xkb,
+    ):
+        """Wayland/empty capture must not call setxkbmap restore (#474)."""
+        from vocalinux.text_injection.ibus_engine import IBusTextInjector
+
+        mock_socket_path.exists.return_value = True
+        mock_sock = MagicMock()
+        mock_sock.__enter__.return_value = mock_sock
+        mock_sock.__exit__.return_value = None
+        mock_sock.recv.return_value = b"OK"
+        mock_socket_cls.return_value = mock_sock
+
+        injector = IBusTextInjector(auto_activate=False)
+        self.assertTrue(injector.inject_text("hello"))
+        mock_restore_xkb.assert_not_called()
+
     @patch("vocalinux.text_injection.ibus_engine.get_current_engine", return_value="xkb:de::deu")
     @patch("vocalinux.text_injection.ibus_engine.is_engine_active", return_value=False)
     @patch("vocalinux.text_injection.ibus_engine.switch_engine", return_value=True)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

**Not fixed in main before this PR.** Issue #664 (Brazilian ABNT2 → US after dictation on X11) is a regression from scoped IBus injection (#457).

The v0.13.0 changelog line about “not running setxkbmap” only covers Wayland (#474). On X11, `inject_text()` still temporarily switches to the Vocalinux IBus engine (which can override the system XKB map to `us`) and restores the previous IBus engine, but it never re-applied the captured XKB layout. The older eager-activation path (`_setup_engine`) still did capture/restore; the production warmup path (`auto_activate=False` + scoped inject) did not.

## Fix

- Capture XKB via `get_current_xkb_layout()` before the scoped engine switch
- Re-apply it in the `inject_text()` `finally` block after engine restore
- Wayland stays a no-op (empty capture + `#474` skip in `restore_xkb_layout`)

## Local verification (X11)

Installed this branch locally, set `setxkbmap br`, then ran scoped IBus `inject_text`. Layout stayed `br` and the injector logged `Restored XKB layout: br`.

**Before inject** (`layout: br`):

![Before inject - layout br](https://cursor.com/artifacts/c/art-93cbc01c-cc8e-46b6-94ce-5cc77eb6d237)

**After fixed inject** (still `layout: br`, text injected into Mousepad):

![After fixed inject - layout still br](https://cursor.com/artifacts/c/art-6c8f5b05-a50b-4da9-880c-b94aef1a46ae)

**Bug without XKB restore** (IBus engine switch alone flips to `us`):

![Bug repro without restore - layout us](https://cursor.com/artifacts/c/art-7ab5ba74-3683-4c81-bce9-443c0914d5a5)

**Manual restore back to `br`:**

![Restored layout br](https://cursor.com/artifacts/c/art-6eb40d38-0cdd-4eac-8f96-ae3a20d008ee)

## Test plan

- [x] `pytest tests/test_ibus_engine.py::TestIBusTextInjector tests/test_xkb_layout.py tests/test_ibus_xkb_wayland.py`
- [x] On X11 with a non-US layout (`setxkbmap br`): dictate once, confirm `setxkbmap -query` still shows `br` after injection and after quit

Fixes #664
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f951707e-9014-4137-a7a0-b065055e1b37?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f951707e-9014-4137-a7a0-b065055e1b37&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

